### PR TITLE
remove 'remove note' button from non-administrators, and change permissi...

### DIFF
--- a/portality/journal.py
+++ b/portality/journal.py
@@ -399,16 +399,17 @@ class JournalFormXWalk(object):
         formnotes = []
         for formnote in form.notes.data:
             if formnote['note']:
-                if formnote['note'] not in curnotes:
+                if formnote['note'] not in curnotes and formnote["note"] != "":
                     journal.add_note(formnote['note'])
                 # also generate another text index of notes, this time an index of the form notes
                 formnotes.append(formnote['note'])
 
-        # delete all notes not coming back from the form, means they've been deleted
-        # also if one of the saved notes is completely blank, delete it
-        for curnote in journal.notes()[:]:
-            if not curnote['note'] or curnote['note'] not in formnotes:
-                journal.remove_note(curnote)
+        if current_user.has_role("delete_note"):
+            # delete all notes not coming back from the form, means they've been deleted
+            # also if one of the saved notes is completely blank, delete it
+            for curnote in journal.notes()[:]:
+                if not curnote['note'] or curnote['note'] not in formnotes:
+                    journal.remove_note(curnote)
 
         new_subjects = []
         for code in form.subject.data:

--- a/portality/static/doaj/js/suggestions_and_journals.js
+++ b/portality/static/doaj/js/suggestions_and_journals.js
@@ -340,8 +340,14 @@ function setup_add_button_handlers() {
             });
         }
 
+        // FIXME: this is a duplicate of what the jinja template does, meaning we have 2 places
+        // where we need to update it if it changes.  Should clone a similar element instead.
+        var delclass = ""
+        if (notes_deletable) { // global variable set by template
+            delclass = " deletable "
+        }
         thefield = [
-            '<div class="control-group row-fluid deletable " id="notes-' + cur_number_of_notes + '-container">',
+            '<div class="control-group row-fluid' + delclass + '" id="notes-' + cur_number_of_notes + '-container">',
             '    <div class="span8 nested-field-container">',
             '        <label class="control-label" for="note">',
             '          Note',
@@ -364,7 +370,9 @@ function setup_add_button_handlers() {
         cur_number_of_notes += 1;  // this doesn't get decremented in the remove button because there's no point, WTForms will understand it
             // even if the ID-s go 0, 2, 7, 13 etc.
         $(this).before(thefield);
-        setup_remove_buttons();
+        if (notes_deletable) {
+            setup_remove_buttons();
+        }
     };
 
     var button_handlers = {

--- a/portality/suggestion.py
+++ b/portality/suggestion.py
@@ -468,16 +468,17 @@ class SuggestionFormXWalk(object):
             formnotes = []
             for formnote in form.notes.data:
                 if formnote['note']:
-                    if formnote['note'] not in curnotes:
+                    if formnote['note'] not in curnotes and formnote["note"] != "":
                         suggestion.add_note(formnote['note'])
                     # also generate another text index of notes, this time an index of the form notes
                     formnotes.append(formnote['note'])
 
-            # delete all notes not coming back from the form, means they've been deleted
-            # also if one of the saved notes is completely blank, delete it
-            for curnote in suggestion.notes()[:]:
-                if not curnote['note'] or curnote['note'] not in formnotes:
-                    suggestion.remove_note(curnote)
+            if current_user.has_role("delete_note"):
+                # delete all notes not coming back from the form, means they've been deleted
+                # also if one of the saved notes is completely blank, delete it
+                for curnote in suggestion.notes()[:]:
+                    if not curnote['note'] or curnote['note'] not in formnotes:
+                        suggestion.remove_note(curnote)
 
         if getattr(form, 'subject', None):
             new_subjects = []

--- a/portality/templates/_journal_form.html
+++ b/portality/templates/_journal_form.html
@@ -281,7 +281,11 @@
         {% endfor %}
 
         <div class="addable-field-container" id="notes-outer-container">
-          {{ render_field(form.notes, render_subfields_horizontal=True, container_class="deletable", **subfield_display_kwargs) }}
+            {% if current_user.has_role("delete_note") %}
+                {{ render_field(form.notes, render_subfields_horizontal=True, container_class="deletable", **subfield_display_kwargs) }}
+            {% else %}
+                {{ render_field(form.notes, render_subfields_horizontal=True, **subfield_display_kwargs) }}
+            {% endif %}
         </div>
       </div>
 

--- a/portality/templates/_suggestion_form.html
+++ b/portality/templates/_suggestion_form.html
@@ -280,7 +280,11 @@
         {% endfor %}
 
         <div class="addable-field-container" id="notes-outer-container">
-          {{ render_field(form.notes, render_subfields_horizontal=True, container_class="deletable", **subfield_display_kwargs) }}
+          {% if current_user.has_role("delete_note") %}
+                {{ render_field(form.notes, render_subfields_horizontal=True, container_class="deletable", **subfield_display_kwargs) }}
+            {% else %}
+                {{ render_field(form.notes, render_subfields_horizontal=True, **subfield_display_kwargs) }}
+            {% endif %}
         </div>
       </div>
 

--- a/portality/templates/admin/journal.html
+++ b/portality/templates/admin/journal.html
@@ -23,5 +23,11 @@
 
 {% include "_journal_form.html" %}
 
+{% block extra_js_bottom %}
+<script type="text/javascript">
+    var notes_deletable = {% if current_user.has_role("admin") %}true{% else %}false{% endif %}
+</script>
+{% endblock extra_js_bottom %}
+
 {% endblock %}
 

--- a/portality/templates/admin/suggestion.html
+++ b/portality/templates/admin/suggestion.html
@@ -23,5 +23,11 @@
 
 {% include "_suggestion_form.html" %}
 
+{% block extra_js_bottom %}
+<script type="text/javascript">
+    var notes_deletable = {% if current_user.has_role("admin") %}true{% else %}false{% endif %}
+</script>
+{% endblock extra_js_bottom %}
+
 {% endblock %}
 

--- a/portality/templates/editor/journal.html
+++ b/portality/templates/editor/journal.html
@@ -23,5 +23,13 @@
 
 {% include "_journal_form.html" %}
 
+
+{% block extra_js_bottom %}
+<script type="text/javascript">
+    var notes_deletable = {% if current_user.has_role("admin") %}true{% else %}false{% endif %}
+</script>
+{% endblock extra_js_bottom %}
+
+
 {% endblock %}
 

--- a/portality/templates/editor/suggestion.html
+++ b/portality/templates/editor/suggestion.html
@@ -23,5 +23,11 @@
 
 {% include "_suggestion_form.html" %}
 
+{% block extra_js_bottom %}
+<script type="text/javascript">
+    var notes_deletable = {% if current_user.has_role("admin") %}true{% else %}false{% endif %}
+</script>
+{% endblock extra_js_bottom %}
+
 {% endblock %}
 


### PR DESCRIPTION
...ons in the back-end so only administrators can remove notes.  This is a simplest-possible solution, without changing the data model, and therefore has some oddities, like existing notes can be edited and thus result in new notes in addition to the old note they are an edit of.
