### PR TITLE
bugfix for crosswalk not maintaining licence aspects for non-cc licences

### DIFF
--- a/portality/journal.py
+++ b/portality/journal.py
@@ -336,10 +336,10 @@ class JournalFormXWalk(object):
                 sa = licenses[license_type]['SA']
                 license_title = licenses[license_type]['title']
             elif form.license_checkbox.data:
-                by = True if 'by' in form.license_checkbox.data else False
-                nc = True if 'nc' in form.license_checkbox.data else False
-                nd = True if 'nd' in form.license_checkbox.data else False
-                sa = True if 'sa' in form.license_checkbox.data else False
+                by = True if 'BY' in form.license_checkbox.data else False
+                nc = True if 'NC' in form.license_checkbox.data else False
+                nd = True if 'ND' in form.license_checkbox.data else False
+                sa = True if 'SA' in form.license_checkbox.data else False
                 license_title = license_type
             else:
                 by = None; nc = None; nd = None; sa = None;
@@ -534,10 +534,10 @@ class JournalFormXWalk(object):
 
         if forminfo['license_other']:
             forminfo['license_checkbox'] = []
-            if license.get('BY'): forminfo['license_checkbox'].append('by')
-            if license.get('SA'): forminfo['license_checkbox'].append('sa')
-            if license.get('NC'): forminfo['license_checkbox'].append('nc')
-            if license.get('ND'): forminfo['license_checkbox'].append('nd')
+            if license.get('BY'): forminfo['license_checkbox'].append('BY')
+            if license.get('SA'): forminfo['license_checkbox'].append('SA')
+            if license.get('NC'): forminfo['license_checkbox'].append('NC')
+            if license.get('ND'): forminfo['license_checkbox'].append('ND')
 
         forminfo['license_url'] = license.get('url')
         forminfo['open_access'] = forms.reverse_interpret_special(license.get('open_access'))

--- a/portality/suggestion.py
+++ b/portality/suggestion.py
@@ -398,10 +398,10 @@ class SuggestionFormXWalk(object):
                 sa = licenses[license_type]['SA']
                 license_title = licenses[license_type]['title']
             elif form.license_checkbox.data:
-                by = True if 'by' in form.license_checkbox.data else False
-                nc = True if 'nc' in form.license_checkbox.data else False
-                nd = True if 'nd' in form.license_checkbox.data else False
-                sa = True if 'sa' in form.license_checkbox.data else False
+                by = True if 'BY' in form.license_checkbox.data else False
+                nc = True if 'NC' in form.license_checkbox.data else False
+                nd = True if 'ND' in form.license_checkbox.data else False
+                sa = True if 'SA' in form.license_checkbox.data else False
                 license_title = license_type
             else:
                 by = None; nc = None; nd = None; sa = None;
@@ -605,10 +605,10 @@ class SuggestionFormXWalk(object):
 
         if forminfo['license_other']:
             forminfo['license_checkbox'] = []
-            if license.get('BY'): forminfo['license_checkbox'].append('by')
-            if license.get('SA'): forminfo['license_checkbox'].append('sa')
-            if license.get('NC'): forminfo['license_checkbox'].append('nc')
-            if license.get('ND'): forminfo['license_checkbox'].append('nd')
+            if license.get('BY'): forminfo['license_checkbox'].append('BY')
+            if license.get('SA'): forminfo['license_checkbox'].append('SA')
+            if license.get('NC'): forminfo['license_checkbox'].append('NC')
+            if license.get('ND'): forminfo['license_checkbox'].append('ND')
 
         forminfo['license_url'] = license.get('url')
         forminfo['open_access'] = forms.reverse_interpret_special(license.get('open_access'))


### PR DESCRIPTION
@emanuil-tolev - fixes bug with the crosswalk which does not keep the BY/NA/SA/ND aspects of non cc licences on form save.

This is my first proper gitflow hotfix, and I created it from the develop branch, which I realise was probably wrong.  Nonetheless, it should apply comfortably to the master branch, and as you can see only affects a few lines.  
