### PR TITLE
fix for issue #349

### DIFF
--- a/portality/static/doaj/js/available_facetviews/journals_and_articles.js
+++ b/portality/static/doaj/js/available_facetviews/journals_and_articles.js
@@ -56,7 +56,7 @@ jQuery(document).ready(function($) {
         {'display':'Publisher','field':'index.publisher'},
 
         {'display':'Article: Abstract','field':'bibjson.abstract'},
-        {'display':'Article: Author','field':'bibjson.author'},
+        {'display':'Article: Author','field':'bibjson.author.name'},
         {'display':'Article: Year','field':'bibjson.year'},
         {'display':'Article: Journal Title','field':'bibjson.journal.title'},
 


### PR DESCRIPTION
#349 indicates that limiting the author field directs searches to bibjson.author, but it should be bibjson.author.name.  This fixes that!
