### PR TITLE
Change default choice on publishing rights question to be none of the ch...

### DIFF
--- a/portality/formcontext/xwalk.py
+++ b/portality/formcontext/xwalk.py
@@ -532,7 +532,7 @@ class SuggestionFormXWalk(JournalGenericXWalk):
 
         forminfo['publishing_rights'], forminfo['publishing_rights_other'] = \
             reverse_interpret_other(
-                reverse_interpret_special(bibjson.author_publishing_rights.get('publishing_rights')),
+                reverse_interpret_special(bibjson.author_publishing_rights.get('publishing_rights', '')),
                 Choices.ternary_list()
             )
         forminfo['publishing_rights_url'] = bibjson.author_publishing_rights.get('url')


### PR DESCRIPTION
...oices rather than "Other -> None" when no data is present

This can be caught reliably and the behaviour defined by a suite of BDD tests. There's many more bits of the form where the behaviour when data is not present needs a closer look. But this specific instance has been clarified in #410 so for now let's fix just this.
