### PR TITLE
ensure that owners are synchronised between journals and suggestions

### DIFF
--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -1,7 +1,8 @@
 from doajtest.helpers import DoajTestCase
 from portality import models
 from datetime import datetime
-from doajtest.fixtures import ApplicationFixtureFactory
+from doajtest.fixtures import ApplicationFixtureFactory, JournalFixtureFactory
+import time
 
 class TestClient(DoajTestCase):
 
@@ -97,3 +98,54 @@ class TestClient(DoajTestCase):
         assert j.id != s.id
         assert "suggestion" not in j.data
         assert j.data.get("bibjson", {}).get("active")
+
+    def test_07_sync_owners(self):
+        # suggestion with no current_journal
+        s = models.Suggestion(**ApplicationFixtureFactory.make_application_source())
+        s.save()
+
+        models.Suggestion.refresh()
+        s = models.Suggestion.pull(s.id)
+        assert s is not None
+
+        # journal with no current_application
+        j = models.Journal(**JournalFixtureFactory.make_journal_source())
+        j.save()
+
+        models.Journal.refresh()
+        j = models.Journal.pull(j.id)
+        assert j is not None
+
+        # suggestion with erroneous current_journal
+        s.set_current_journal("asdklfjsadjhflasdfoasf")
+        s.save()
+
+        models.Suggestion.refresh()
+        s = models.Suggestion.pull(s.id)
+        assert s is not None
+
+        # journal with erroneous current_application
+        j.set_current_application("kjwfuiwqhu220952gw")
+        j.save()
+
+        models.Journal.refresh()
+        j = models.Journal.pull(j.id)
+        assert j is not None
+
+        # suggestion with journal
+        s.set_owner("my_new_owner")
+        s.set_current_journal(j.id)
+        s.save()
+
+        models.Journal.refresh()
+        j = models.Journal.pull(j.id)
+        assert j.owner == "my_new_owner"
+
+        # journal with suggestion
+        j.set_owner("another_new_owner")
+        j.set_current_application(s.id)
+        j.save()
+
+        models.Suggestion.refresh()
+        s = models.Suggestion.pull(s.id)
+        assert s.owner == "another_new_owner"

--- a/portality/models/suggestion.py
+++ b/portality/models/suggestion.py
@@ -142,8 +142,19 @@ class Suggestion(Journal):
             return
         self._set_suggestion_property("suggester", sugg)
 
-    def save(self, **kwargs):
+    def _sync_owner_to_journal(self):
+        if self.current_journal is None:
+            return
+        from portality.models import Journal
+        cj = Journal.pull(self.current_journal)
+        if cj is not None and cj.owner != self.owner:
+            cj.set_owner(self.owner)
+            cj.save(sync_owner=False)
+
+    def save(self, sync_owner=True, **kwargs):
         self.prep()
+        if sync_owner:
+            self._sync_owner_to_journal()
         super(Suggestion, self).save(snapshot=False, **kwargs)
 
 class SuggestionQuery(object):


### PR DESCRIPTION
This is implemented at the save() level, so any operation which causes the owner to change will cause the related journal/application to be updated.  It comes that the cost of an additional query to the index, and the possibility of an additional write (if the owner needs to be synchronised).