### PR TITLE
when a suggestion overwrites an existing journal, preserve the create date

### DIFF
--- a/doajtest/unit/test_reapplication.py
+++ b/doajtest/unit/test_reapplication.py
@@ -692,8 +692,15 @@ class TestReApplication(DoajTestCase):
         assert sheetqs == qs
 
     def test_14_make_journal_from_reapp(self):
+        j = models.Journal()
+        j.set_id("1234567")
+        j.set_created("2001-01-01T00:00:00Z")
+        j.save()
+
         s = models.Suggestion(**ApplicationFixtureFactory.make_application_source())
         s.set_current_journal("1234567")
+
+        time.sleep(1)
         j = s.make_journal()
 
         assert j.id == "1234567"
@@ -702,6 +709,7 @@ class TestReApplication(DoajTestCase):
         assert j.data.get("bibjson", {}).get("active")
         assert j.current_application is None
         assert j.data.get("admin", {}).get("current_journal") is None
+        assert j.created_date == "2001-01-01T00:00:00Z"
 
     def test_15_error_report_cell_refs_rows(self):
         sheet = reapplication.open_csv("invalid.csv")

--- a/portality/models/suggestion.py
+++ b/portality/models/suggestion.py
@@ -34,8 +34,10 @@ class Suggestion(Journal):
 
         # now deal with the fact that this could be a replacement of an existing journal
         if self.current_journal is not None:
+            cj = Journal.pull(self.current_journal)
             new_j.set_id(self.current_journal)
             new_j.set_last_reapplication()
+            new_j.set_created(cj.created_date)
             del new_j.data["admin"]["current_journal"]
 
         return new_j


### PR DESCRIPTION
works by loading the journal being overwritten and nabbing its create date, before overwriting it.

Also with test.