### PR TITLE
fix nonetype bug in history read

### DIFF
--- a/portality/models/journal.py
+++ b/portality/models/journal.py
@@ -78,6 +78,8 @@ class Journal(DomainObject):
 
     def history(self):
         histories = self.data.get("history", [])
+        if histories is None:
+            histories = []
         return [(h.get("date"), h.get("replaces"), h.get("isreplacedby"), JournalBibJSON(h.get("bibjson"))) for h in histories]
 
     def get_history_raw(self):

--- a/portality/models/suggestion.py
+++ b/portality/models/suggestion.py
@@ -44,7 +44,9 @@ class Suggestion(Journal):
             new_j.set_last_reapplication()
 
             # carry any continuations
-            new_j.set_history(cj.get_history_raw())
+            hist = cj.get_history_raw()
+            if hist is not None and len(hist) > 0:
+                new_j.set_history(cj.get_history_raw())
 
             # remove the reference to the current_journal
             del new_j.data["admin"]["current_journal"]


### PR DESCRIPTION
I was /always/ copying over the history from journal to replacement, even if it was None, resulting an an erroneous None in the history field, which was then in turn causing a NoneType error further down the chain.

Both the write of the history and a None check on read have now been implemented, which prevents this at both ends of the problem.