### PR TITLE
tweaks to core to initialise correctly with es14

### DIFF
--- a/portality/core.py
+++ b/portality/core.py
@@ -70,8 +70,11 @@ def initialise_index(app):
     i = str(app.config['ELASTIC_SEARCH_HOST']).rstrip('/')
     i += '/' + app.config['ELASTIC_SEARCH_DB']
     for key, mapping in mappings.iteritems():
-        im = i + '/' + key + '/_mapping'
-        exists = requests.get(im)
+        # im = i + '/' + key + '/_mapping'  # es 0.x
+        im = i + "/_mapping/" + key         # es 1.x
+        typeurl = i + "/" + key
+        # exists = requests.get(im)         # es 0.x
+        exists = requests.head(typeurl)     # es 1.x
         if exists.status_code != 200:
             ri = requests.post(i)
             r = requests.put(im, json.dumps(mapping))


### PR DESCRIPTION
This minor change is key for the migration from es 0.x to ex 1.x - it changes the way that mappings are created at application initialisation.  Other than that DOAJ appears to operate fine under 1.4.2, and when we upgrade to fv2 we'll iron out any minor niggles.

My suggestion is that we merge this change to develop asap, and then carry on building on top of ES 1.4.  This will initially break the test server, as it is running 0.9, so there will be a period when builds and test are not operational.  I'll open some issues to cover that shortly.