### PR TITLE
OAI new doaj article format

### DIFF
--- a/doajtest/unit/test_oaipmh.py
+++ b/doajtest/unit/test_oaipmh.py
@@ -5,4 +5,4 @@ from portality.models import OAIPMHJournal, OAIPMHArticle
 from doajtest.bootstrap import prepare_for_test
 prepare_for_test()
 
-oaipmh.list_records(OAIPMHJournal(), "http://localhost:5004/oai")
+oaipmh.list_records(OAIPMHJournal(), "http://localhost:5004/oai", None)

--- a/portality/datasets.py
+++ b/portality/datasets.py
@@ -530,6 +530,7 @@ languages_iso639_2 = [
 
 # ok, but we don't care about the Aramaic Empire ... we only want the ISO639-1 subset of those (the ones with 2-char codes)
 languages = {}
+languages_fullname_to_3char_code = {}
 for l in languages_iso639_2:
     if l[2]:
         twochar_code = l[2].upper()
@@ -540,6 +541,9 @@ for l in languages_iso639_2:
             "name": l[3].decode('utf-8')
         }
         languages[twochar_code] = lobj
+
+    if l[3] and l[0]:  # if a name and a 3-char code exist for this lang
+        languages_fullname_to_3char_code[l[3]] = l[0]
 
 languages_dict = OrderedDict(sorted(languages.items(), key=lambda x: x[1]['name']))
 languages = languages_dict.items()

--- a/portality/models/article.py
+++ b/portality/models/article.py
@@ -426,7 +426,14 @@ class ArticleBibJSON(GenericBibJSON):
         if self.year is not None:
             # fix 2 digit years
             if len(self.year) == 2:
-                if int(self.year) <=13:
+                try:
+                    intyear = int(self.year)
+                except ValueError:
+                    # if it's 2 chars long and the 2 chars don't make an integer,
+                    # forget it
+                    return date
+
+                if intyear <= 13:
                     self.year = "20" + self.year
                 else:
                     self.year = "19" + self.year

--- a/portality/models/bibjson.py
+++ b/portality/models/bibjson.py
@@ -146,18 +146,21 @@ class GenericBibJSON(object):
             urlobj["content_type"] = content_type
         self.bibjson["link"].append(urlobj)
 
-    def get_urls(self, urltype=None):
+    def get_urls(self, urltype=None, unpack_urlobj=True):
         if urltype is None:
             return self.bibjson.get("link", [])
 
         urls = []
         for link in self.bibjson.get("link", []):
             if link.get("type") == urltype:
-                urls.append(link.get("url"))
+                if unpack_urlobj:
+                    urls.append(link.get("url"))
+                else:
+                    urls.append(link)
         return urls
 
-    def get_single_url(self, urltype):
-        urls = self.get_urls(urltype=urltype)
+    def get_single_url(self, urltype, unpack_urlobj=True):
+        urls = self.get_urls(urltype=urltype, unpack_urlobj=unpack_urlobj)
         if urls:
             return urls[0]
         return None

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -248,18 +248,24 @@ FEED_LOGO = "http://www.doaj.org/static/doaj/images/favicon.ico"
 # ============================
 # OAI-PMH SETTINGS
 
-OAIPMH_METADATA_FORMATS = [
-    {
-        "metadataPrefix": "oai_dc",
-        "schema": "http://www.openarchives.org/OAI/2.0/oai_dc.xsd",
-        "metadataNamespace": "http://www.openarchives.org/OAI/2.0/oai_dc/"
-    },
-    {
-        "metadataPrefix": "oai_doaj",
-        "schema": "https://doaj.org/static/doaj/doajArticles.xsd",
-        "metadataNamespace": "http://doaj.org/features/oai_doaj/1.0/"
-    }
-]
+OAI_DC_METADATA_FORMAT = {
+    "metadataPrefix": "oai_dc",
+    "schema": "http://www.openarchives.org/OAI/2.0/oai_dc.xsd",
+    "metadataNamespace": "http://www.openarchives.org/OAI/2.0/oai_dc/"
+}
+
+OAI_DOAJ_METADATA_FORMAT = {
+    "metadataPrefix": "oai_doaj",
+    "schema": "https://doaj.org/static/doaj/doajArticles.xsd",
+    "metadataNamespace": "http://doaj.org/features/oai_doaj/1.0/"
+}
+
+OAIPMH_METADATA_FORMATS = {
+    # "specific endpoint": [list, of, formats, supported]
+
+    None: [OAI_DC_METADATA_FORMAT],  # no specific endpoint, the request is to the root /oai path
+    "article": [OAI_DC_METADATA_FORMAT, OAI_DOAJ_METADATA_FORMAT]
+}
 
 OAIPMH_IDENTIFIER_NAMESPACE = "doaj.org"
 

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -250,9 +250,14 @@ FEED_LOGO = "http://www.doaj.org/static/doaj/images/favicon.ico"
 
 OAIPMH_METADATA_FORMATS = [
     {
-        "metadataPrefix" : "oai_dc",
-        "schema" : "http://www.openarchives.org/OAI/2.0/oai_dc.xsd",
-        "metadataNamespace" : "http://www.openarchives.org/OAI/2.0/oai_dc/"
+        "metadataPrefix": "oai_dc",
+        "schema": "http://www.openarchives.org/OAI/2.0/oai_dc.xsd",
+        "metadataNamespace": "http://www.openarchives.org/OAI/2.0/oai_dc/"
+    },
+    {
+        "metadataPrefix": "oai_doaj_article",
+        "schema": "https://doaj.org/static/doaj/doajArticles.xsd",
+        "metadataNamespace": "http://doaj.org/features/oai_doaj/1.0"
     }
 ]
 

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -255,7 +255,7 @@ OAIPMH_METADATA_FORMATS = [
         "metadataNamespace": "http://www.openarchives.org/OAI/2.0/oai_dc/"
     },
     {
-        "metadataPrefix": "oai_doaj_article",
+        "metadataPrefix": "oai_doaj",
         "schema": "https://doaj.org/static/doaj/doajArticles.xsd",
         "metadataNamespace": "http://doaj.org/features/oai_doaj/1.0/"
     }

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -257,7 +257,7 @@ OAIPMH_METADATA_FORMATS = [
     {
         "metadataPrefix": "oai_doaj_article",
         "schema": "https://doaj.org/static/doaj/doajArticles.xsd",
-        "metadataNamespace": "http://doaj.org/features/oai_doaj/1.0"
+        "metadataNamespace": "http://doaj.org/features/oai_doaj/1.0/"
     }
 ]
 

--- a/portality/templates/doaj/doajArticles_oai_namespace.html
+++ b/portality/templates/doaj/doajArticles_oai_namespace.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<h3>Version 1.0 of the doajArticles schema</h3>
+
+<a href="/static/doaj/doajArticles.xsd">This is the schema.</a>
+<br><br>
+<a href="/features#doajArticles_OAI_schema">This is an explanation of various parts of the schema with concrete XML examples.</a>
+
+{% endblock %}
+

--- a/portality/templates/doaj/features.html
+++ b/portality/templates/doaj/features.html
@@ -393,6 +393,7 @@ The example file below contains only one record.<br>
 <table cellspacing=0 cellpadding=0 width=100% border=0>
 <tr>
 <td colspan=2 class="text">
+<a name="doajArticles_OAI_schema" id="doajArticles_OAI_schema"></a>
 <h3>The <a href=/static/doaj/doajArticles.xsd>doajArticles.xsd</a> schema file</h3>
 This file specifies what may or may not be uploaded to the database. 
 <br> 

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -225,6 +225,11 @@ def faq():
 def features():
     return render_template("doaj/features.html")
 
+@blueprint.route("/features/oai_doaj/1.0/")
+def doajArticles_oai_namespace_page():
+    return render_template("doaj/doajArticles_oai_namespace.html")
+
+
 @blueprint.route("/oainfo")
 def oainfo():
     return render_template("doaj/oainfo.html")

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -925,9 +925,16 @@ class OAI_DC(OAI_Crosswalk):
     NSMAP = deepcopy(OAI_Crosswalk.NSMAP)
     NSMAP.update({"oai_dc": OAIDC_NAMESPACE, "dc": DC_NAMESPACE})
 
-    def _generate_subjects(self, subjects, parent_element):
+    def _generate_subjects(self, parent_element, subjects, keywords):
+        if keywords is None:
+            keywords = []
         if subjects is None:
             subjects = []
+
+        for keyword in keywords:
+            subj = etree.SubElement(parent_element, self.DC + "subject")
+            set_text(subj, keyword)
+
         for subs in subjects:
             scheme = subs.get("scheme")
             code = subs.get("code")
@@ -1001,14 +1008,10 @@ class OAI_DC_Article(OAI_DC):
             pubel = etree.SubElement(oai_dc, self.DC + "publisher")
             set_text(pubel, bibjson.publisher)
         
-        for keyword in bibjson.keywords:
-            subj = etree.SubElement(oai_dc, self.DC + "subject")
-            set_text(subj, keyword)
-        
         objecttype = etree.SubElement(oai_dc, self.DC + "type")
         set_text(objecttype, "article")
         
-        self._generate_subjects(oai_dc, bibjson.subjects())
+        self._generate_subjects(parent_element=oai_dc, subjects=bibjson.subjects(), keywords=bibjson.keywords)
 
         jlangs = bibjson.journal_language
         if jlangs is not None:
@@ -1107,10 +1110,6 @@ class OAI_DC_Journal(OAI_DC):
         idel = etree.SubElement(oai_dc, self.DC + "identifier")
         set_text(idel, url)
         
-        for keyword in bibjson.keywords:
-            subj = etree.SubElement(oai_dc, self.DC + "subject")
-            set_text(subj, keyword)
-        
         if bibjson.language is not None and len(bibjson.language) > 0:
             for language in bibjson.language:
                 lang = etree.SubElement(oai_dc, self.DC + "language")
@@ -1143,7 +1142,7 @@ class OAI_DC_Journal(OAI_DC):
         objecttype = etree.SubElement(oai_dc, self.DC + "type")
         set_text(objecttype, "journal")
 
-        self._generate_subjects(oai_dc, bibjson.subjects())
+        self._generate_subjects(parent_element=oai_dc, subjects=bibjson.subjects(), keywords=bibjson.keywords)
             
         return metadata
     

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -898,6 +898,22 @@ class OAI_Crosswalk(object):
     def header(self, record):
         raise NotImplementedError()
 
+    def _generate_header_subjects(self, parent_element, subjects):
+        if subjects is None:
+            subjects = []
+        
+        for subs in subjects:
+            scheme = subs.get("scheme", '')
+            term = subs.get("term", '')
+            
+            if term:
+                prefix = ''
+                if scheme:
+                    prefix = scheme + ':'
+
+                subel = etree.SubElement(parent_element, self.PMH + "setSpec")
+                set_text(subel, make_set_spec(prefix + term))
+
 
 class OAI_DC(OAI_Crosswalk):
     OAIDC_NAMESPACE = "http://www.openarchives.org/OAI/2.0/oai_dc/"
@@ -1021,13 +1037,7 @@ class OAI_DC_Article(OAI_DC):
         datestamp = etree.SubElement(head, self.PMH + "datestamp")
         set_text(datestamp, normalise_date(record.last_updated))
         
-        for subs in bibjson.subjects():
-            scheme = subs.get("scheme")
-            term = subs.get("term")
-            
-            subel = etree.SubElement(head, self.PMH + "setSpec")
-            set_text(subel, make_set_spec(scheme + ":" + term))
-        
+        self._generate_header_subjects(parent_element=head, subjects=bibjson.subjects())
         return head
 
     def _make_citation(self, bibjson):
@@ -1147,13 +1157,7 @@ class OAI_DC_Journal(OAI_DC):
         datestamp = etree.SubElement(head, self.PMH + "datestamp")
         set_text(datestamp, normalise_date(record.last_updated))
         
-        for subs in bibjson.subjects():
-            scheme = subs.get("scheme")
-            term = subs.get("term")
-            
-            subel = etree.SubElement(head, self.PMH + "setSpec")
-            set_text(subel, make_set_spec(scheme + ":" + term))
-        
+        self._generate_header_subjects(parent_element=head, subjects=bibjson.subjects())
         return head
 
 
@@ -1289,13 +1293,7 @@ class OAI_DOAJ_Article(OAI_Crosswalk):
         datestamp = etree.SubElement(head, self.PMH + "datestamp")
         set_text(datestamp, normalise_date(record.last_updated))
 
-        for subs in bibjson.subjects():
-            scheme = subs.get("scheme")
-            term = subs.get("term")
-
-            subel = etree.SubElement(head, self.PMH + "setSpec")
-            set_text(subel, make_set_spec(scheme + ":" + term))
-
+        self._generate_header_subjects(parent_element=head, subjects=bibjson.subjects())
         return head
 
 

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -1161,12 +1161,11 @@ class OAI_DC_Journal(OAI_DC):
 
 
 class OAI_DOAJ_Article(OAI_Crosswalk):
-    # OAI_DOAJ_NAMESPACE = "http://doaj.org/features/oai_doaj/1.0/"
-    # OAI_DOAJ = "{%s}" % OAI_DOAJ_NAMESPACE
-    OAI_DOAJ = OAI_Crosswalk.PMH
+    OAI_DOAJ_NAMESPACE = "http://doaj.org/features/oai_doaj/1.0/"
+    OAI_DOAJ = "{%s}" % OAI_DOAJ_NAMESPACE
 
-    # NSMAP = deepcopy(OAI_Crosswalk.NSMAP)
-    # NSMAP.update({"oai_doaj": OAI_DOAJ_NAMESPACE})
+    NSMAP = deepcopy(OAI_Crosswalk.NSMAP)
+    NSMAP.update({"oai_doaj": OAI_DOAJ_NAMESPACE})
 
     def crosswalk(self, record):
         bibjson = record.bibjson()
@@ -1174,7 +1173,7 @@ class OAI_DOAJ_Article(OAI_Crosswalk):
         metadata = etree.Element(self.PMH + "metadata", nsmap=self.NSMAP)
         oai_doaj_article = etree.SubElement(metadata, self.OAI_DOAJ + "doajArticle")
         oai_doaj_article.set(self.XSI + "schemaLocation",
-            "http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd http://doaj.org/features/oai_doaj/1.0 https://doaj.org/static/doaj/doajArticles.xsd")
+            "http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd http://doaj.org/features/oai_doaj/1.0/ https://doaj.org/static/doaj/doajArticles.xsd")
 
         jlangs = bibjson.journal_language
         if jlangs:

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -914,7 +914,7 @@ class OAI_DC_Article(OAI_DC_Crosswalk):
         if bibjson.title is not None:
             title = etree.SubElement(oai_dc, self.DC + "title")
             set_text(title, bibjson.title)
-        
+
         # all the external identifiers (ISSNs, etc)
         for identifier in bibjson.get_identifiers():
             idel = etree.SubElement(oai_dc, self.DC + "identifier")
@@ -961,14 +961,25 @@ class OAI_DC_Article(OAI_DC_Crosswalk):
         
         for subs in bibjson.subjects():
             scheme = subs.get("scheme")
+            code = subs.get("code")
             term = subs.get("term")
+
+            if scheme.lower() == 'lcc':
+                attrib = {"{{{nspace}}}type".format(nspace=self.XSI_NAMESPACE): "dcterms:LCSH"}
+                termtext = term
+                codetext = code
+            else:
+                attrib = {}
+                termtext = scheme + ':' + term if term else None
+                codetext = scheme + ':' + code if code else None
+
+            if termtext:
+                subel = etree.SubElement(oai_dc, self.DC + "subject", **attrib)
+                set_text(subel, termtext)
             
-            subel = etree.SubElement(oai_dc, self.DC + "subject")
-            set_text(subel, scheme + ":" + term)
-            
-            if "code" in subs:
-                sel2 = etree.SubElement(oai_dc, self.DC + "subject")
-                set_text(sel2, scheme + ":" + subs.get("code"))
+            if codetext:
+                sel2 = etree.SubElement(oai_dc, self.DC + "subject", **attrib)
+                set_text(sel2, codetext)
 
         jlangs = bibjson.journal_language
         if jlangs is not None:

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -919,10 +919,9 @@ class OAI_DC_Article(OAI_DC_Crosswalk):
         for identifier in bibjson.get_identifiers():
             idel = etree.SubElement(oai_dc, self.DC + "identifier")
             set_text(idel, identifier.get("id"))
-        
-        # our internal identifier (currently just links to the search results page)
-        query = urllib.urlencode([("source", '{"query":{"bool":{"must":[{"term":{"id":"' + record.id + '"}}]}}}')])
-        url = app.config['BASE_URL'] + "/search?" + query
+
+        # our internal identifier
+        url = app.config['BASE_URL'] + "/article/" + record.id
         idel = etree.SubElement(oai_dc, self.DC + "identifier")
         set_text(idel, url)
         
@@ -931,11 +930,14 @@ class OAI_DC_Article(OAI_DC_Crosswalk):
         if date != "":
             monthyear = etree.SubElement(oai_dc, self.DC + "date")
             set_text(monthyear, date)
-        
-        if len(bibjson.get_urls()) > 0:
-            for url in bibjson.get_urls():
-                urlel = etree.SubElement(oai_dc, self.DC + "relation")
-                set_text(urlel, url.get("url"))
+
+        for url in bibjson.get_urls():
+            urlel = etree.SubElement(oai_dc, self.DC + "relation")
+            set_text(urlel, url.get("url"))
+
+        for identifier in bibjson.get_identifiers(idtype=bibjson.P_ISSN) + bibjson.get_identifiers(idtype=bibjson.E_ISSN):
+            journallink = etree.SubElement(oai_dc, self.DC + "relation")
+            set_text(journallink, app.config['BASE_URL'] + "/toc/" + identifier)
         
         if bibjson.abstract is not None:
             abstract = etree.SubElement(oai_dc, self.DC + "description")
@@ -1065,10 +1067,8 @@ class OAI_DC_Journal(OAI_DC_Crosswalk):
         for identifier in bibjson.get_identifiers():
             idel = etree.SubElement(oai_dc, self.DC + "identifier")
             set_text(idel, identifier.get("id"))
-        
-        # our internal identifier (currently just links to the search results page)
-        #query = urllib.urlencode([("source", '{"query":{"bool":{"must":[{"term":{"id":"' + record.id + '"}}]}}}')])
-        #url = app.config['BASE_URL'] + "/search?" + query
+
+        # our internal identifier
         url = app.config["BASE_URL"] + "/toc/" + record.id
         idel = etree.SubElement(oai_dc, self.DC + "identifier")
         set_text(idel, url)

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -250,7 +250,7 @@ def clean_unreadable(input_string):
     try:
         return _illegal_xml_chars_RE.sub("", input_string)
     except TypeError as e:
-        print app.logger.error("Unable to strip illegal XML chars from: {x}, {y}".format(x=input_string, y=type(input_string)))
+        app.logger.error("Unable to strip illegal XML chars from: {x}, {y}".format(x=input_string, y=type(input_string)))
         return None
 
 def xml_clean(input_string):

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -99,7 +99,7 @@ class DateFormat(object):
                 datetime.strptime(datestr, f)
                 success = True
                 break
-            except:
+            except Exception:
                 pass
         return success
 

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from flask import Blueprint, request, make_response
 from portality.core import app
 from portality.models import OAIPMHJournal, OAIPMHArticle
+from portality import datasets
 from copy import deepcopy
 
 blueprint = Blueprint('oaipmh', __name__)
@@ -1175,10 +1176,20 @@ class OAI_DOAJ_Article(OAI_Crosswalk):
         oai_doaj_article.set(self.XSI + "schemaLocation",
             "http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd http://doaj.org/features/oai_doaj/1.0/ https://doaj.org/static/doaj/doajArticles.xsd")
 
+        # look up the journal's language
         jlangs = bibjson.journal_language
+        # first, if there are any languages recorded, get the 3-char code
+        # corresponding to the first language
+        if jlangs:
+            if isinstance(jlangs, list):
+                jlangs = jlangs[0]
+            jlangs = datasets.languages_fullname_to_3char_code.get(jlangs)
+
+        # if the language code lookup was successful, add it to the
+        # result
         if jlangs:
             langel = etree.SubElement(oai_doaj_article, self.OAI_DOAJ + "language")
-            set_text(langel, jlangs[0])
+            set_text(langel, jlangs)
 
         if bibjson.publisher:
             publel = etree.SubElement(oai_doaj_article, self.OAI_DOAJ + "publisher")

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -1210,7 +1210,17 @@ class OAI_DOAJ_Article(OAI_Crosswalk):
 
         # work out the date of publication
         date = bibjson.get_publication_date()
-        if date != "":
+        # convert it to the format required by the XML schema by parsing
+        # it into a Python datetime and getting it back out as string.
+        # If it's not coming back properly from the bibjson, throw it
+        # away.
+        try:
+            date = datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
+            date = date.strftime("%Y-%m-%d")
+        except:
+            date = ""
+
+        if date:
             monthyear = etree.SubElement(oai_doaj_article, self.OAI_DOAJ + "publicationDate")
             set_text(monthyear, date)
 

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -881,28 +881,31 @@ class NoSetHierarchy(OAIPMHError):
 ## Crosswalks
 #####################################################################
 
-class OAI_DC_Crosswalk(object):
+class OAI_Crosswalk(object):
     PMH_NAMESPACE = "http://www.openarchives.org/OAI/2.0/"
     PMH = "{%s}" % PMH_NAMESPACE
-    
+
     XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
     XSI = "{%s}" % XSI_NAMESPACE
-    
+
+    def crosswalk(self, record):
+        raise NotImplementedError()
+
+    def header(self, record):
+        raise NotImplementedError()
+
+
+class OAI_DC(OAI_Crosswalk):
     OAIDC_NAMESPACE = "http://www.openarchives.org/OAI/2.0/oai_dc/"
     OAIDC = "{%s}" % OAIDC_NAMESPACE
     
     DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"
     DC = "{%s}" % DC_NAMESPACE
     
-    NSMAP = {None : PMH_NAMESPACE, "xsi" : XSI_NAMESPACE, "oai_dc" : OAIDC_NAMESPACE, "dc" : DC_NAMESPACE}
-    
-    def crosswalk(self, record):
-        raise NotImplementedError()
-    
-    def header(self, record):
-        raise NotImplementedError()
+    NSMAP = {None: OAI_Crosswalk.PMH_NAMESPACE, "xsi": OAI_Crosswalk.XSI_NAMESPACE, "oai_dc": OAIDC_NAMESPACE, "dc": DC_NAMESPACE}
 
-class OAI_DC_Article(OAI_DC_Crosswalk):
+
+class OAI_DC_Article(OAI_DC):
     def crosswalk(self, record):
         bibjson = record.bibjson()
         
@@ -1061,7 +1064,7 @@ class OAI_DC_Article(OAI_DC_Crosswalk):
 
         return citation if citation != "" else None
 
-class OAI_DC_Journal(OAI_DC_Crosswalk):
+class OAI_DC_Journal(OAI_DC):
     def crosswalk(self, record):
         bibjson = record.bibjson()
         
@@ -1152,10 +1155,22 @@ class OAI_DC_Journal(OAI_DC_Crosswalk):
         
         return head
 
+
+class OAI_DOAJ_Article(OAI_Crosswalk):
+    def crosswalk(self, record):
+        pass
+
+    def header(self, record):
+        pass
+
+
 CROSSWALKS = {
     "oai_dc" : {
         "article" : OAI_DC_Article,
         "journal" : OAI_DC_Journal
+    },
+    'oai_doaj_article': {
+        "article": OAI_DOAJ_Article
     }
 }
 

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -910,12 +910,14 @@ class OAI_DC(OAI_Crosswalk):
     NSMAP.update({"oai_dc": OAIDC_NAMESPACE, "dc": DC_NAMESPACE})
 
     def _generate_subjects(self, subjects, parent_element):
+        if subjects is None:
+            subjects = []
         for subs in subjects:
             scheme = subs.get("scheme")
             code = subs.get("code")
             term = subs.get("term")
 
-            if scheme.lower() == 'lcc':
+            if scheme and scheme.lower() == 'lcc':
                 attrib = {"{{{nspace}}}type".format(nspace=self.XSI_NAMESPACE): "dcterms:LCSH"}
                 termtext = term
                 codetext = code


### PR DESCRIPTION
Issues #180 and #542 

Adds new format. Tested locally and all the data seems to correspond to the OAI_DC format exactly, except in the places where it should differ (namespace, core element being named doajArticle rather than dc, and of course most fields in the metadata element - where the formats actually differ).

Also adds a small webpage which will eventually be served at the namespace URL http://doaj.org/features/oai_doaj/1.0/ .

Also makes list of metadata formats different for different OAI endpoints. It should be very little effort to add more endpoints and formats in the future with the new config this introduces.