### PR TITLE
add first draft of subject browser

### DIFF
--- a/portality/templates/_js_includes.html
+++ b/portality/templates/_js_includes.html
@@ -16,15 +16,18 @@
 <!-- get select2 -->
 <script type="text/javascript" src="/static/portality/vendor/select2-release-3.2/select2.min.js"></script>
 
-{% if search_page %}
+{% if search_page or subject_page %}
 <!-- get facetview -->
 <!-- <script type="text/javascript" src="/static/portality/vendor/facetview/jquery.facetview.js"></script> -->
 
 <!-- fv2 and the doaj theme - replaces the above -->
 <script type="text/javascript" src="/static/portality/vendor/facetview2/es.js"></script>
+
+    {% if not subject_page %}
 <script type="text/javascript" src="/static/portality/vendor/facetview2/bootstrap2.facetview.theme.js"></script>
 <script type="text/javascript" src="/static/doaj/js/doaj.facetview.theme.js"></script>
 <script type="text/javascript" src="/static/portality/vendor/facetview2/jquery.facetview2.js"></script>
+    {% endif %}
 
 {% endif %}
 
@@ -57,12 +60,14 @@ displayed. #}
 <script type="text/javascript">var current_scheme = window.location.protocol;</script>
 <script type="text/javascript">var readonly_journal_url = "{{ url_for('doaj.journal_readonly', journal_id="") }}";</script>
 
-{% if search_page %}
+{% if search_page or subject_page %}
   <script type="text/javascript">var es_domain = current_domain;</script>
   <script type="text/javascript">var es_scheme = current_scheme;</script>
+  {% if facetviews %}
   {% for facetview in facetviews %}
     <script type="text/javascript" src="/static/doaj/js/available_facetviews/{{facetview}}.js"></script>
   {% endfor %}
+  {% endif %}
 {% endif %}
 
 <!-- get the app's js -->
@@ -74,9 +79,13 @@ displayed. #}
 
 {% endif %} 
 
-{% if edit_suggestion_page or edit_journal_page %}
+{% if edit_suggestion_page or edit_journal_page or subject_page %}
 
 <script type="text/javascript">{% if lcc_jstree %}var lcc_jstree = {{lcc_jstree | safe}};{% else %} var lcc_jstree = undefined;{% endif %}</script>
 <script type="text/javascript" src="//cdn.jsdelivr.net/jquery.jstree/3.0.0-beta10/jstree.min.js"></script>
+
+    {% if not subject_page %}
 <script type="text/javascript" src="/static/doaj/js/suggestions_and_journals.js"></script>
+    {% endif %}
+
 {% endif %}

--- a/portality/templates/doaj/subjects.html
+++ b/portality/templates/doaj/subjects.html
@@ -1,0 +1,138 @@
+{% extends "base.html" %}
+
+
+{% block content %}
+
+<h1>Browse Subjects</h1>
+
+<p>All Journals and Articles in the DOAJ are categorised with the Library of Congress Subject Classifications.  Use the
+subject browser below to find subjects you are interested in.</p>
+
+<div class="row-fluid">
+    <div class="span8">
+        <div id="subject_tree_container">
+            <div class="control-group" id="subject_tree_search-container">
+                <label class="control-label" for="subject_tree_search">Search through the subjects</label>
+                <div class="controls">
+                    <input class="input-large" id="subject_tree_search" type="text" placeholder="start typing...">
+                </div>
+            </div>
+            <div id="subject_tree"></div>
+        </div>
+    </div>
+    <div class="span4">
+        <div id="selection-container" class="with-borders" style="width: 200px; padding: 10px">
+            <div id="selection-header" style="display:none; margin-bottom: 20px">You have selected the subject</div>
+            <div id="selected-subject">Select a subject from the tree.</div>
+        </div>
+
+    </div>
+</div>
+
+
+{% endblock %}
+
+{% block extra_js_bottom %}
+<script type="text/javascript">
+jQuery(document).ready(function($) {
+
+    function lookupSubject(subject) {
+
+        var query = {
+            "query" : {
+                "filtered" : {
+                    "query" : {
+                        "match_all" : {}
+                    },
+                    "filter" : {
+                        "bool" : {
+                            "must" : [
+                                {"term" : {"index.classification.exact" : subject}}
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+
+        function subjectFound(rawdata, result) {
+            var count = rawdata.hits.total;
+            var url = "/search?source=" + encodeURIComponent(JSON.stringify(query));
+
+            var frag = "<div style='font-weight: bold; font-size: 150%; margin-bottom: 20px'>" + subject + "</div>";
+            frag += '<div style="margin-bottom: 10px"><span style="font-size: 130%; font-weight: bold; margin-bottom: 10px">' + count + "</span> records for this subject</div>";
+            frag += '<a class="btn btn-info" href="' + url + '">View Journals/Articles</a>';
+            $("#selected-subject").html(frag);
+            $("#selection-header").show();
+        }
+
+        var count_query = $.extend({}, query);
+        count_query["size"] = 0;
+
+        doElasticSearchQuery({
+            success: subjectFound,
+            queryobj: query,
+            search_url: es_scheme + '//' + es_domain + '/query/journal,article/_search?',
+            datatype: "jsonp"
+        });
+    }
+
+    function setup_subject_tree() {
+
+        $('#subject_tree').jstree({
+            'plugins': ["sort", "search"],
+            'core': {
+                'data': lcc_jstree
+            },
+            "checkbox": {
+                "three_state": false
+            },
+            "search": {
+                "fuzzy": false,
+                "show_only_matches": true
+            }
+        });
+
+        $('#subject_tree')
+                .on('ready.jstree', function (e, data) {
+                    var subjects = $('#subject').val() || [];
+                    for (var i = 0; i < subjects.length; i++) {
+                        $('#subject_tree').jstree('select_node', subjects[i]);
+                    }
+                });
+
+        $('#subject_tree')
+                .on('changed.jstree', function (e, data) {
+                    var subjects = $('#subject').val(data.selected);
+                });
+
+        $("#subject_tree").on("select_node.jstree", function(e, data) {
+            lookupSubject(data.node.text);
+        });
+
+        var to = false;
+        $('#subject_tree_search').keyup(function () {
+            if (to) {
+                clearTimeout(to);
+            }
+            to = setTimeout(function () {
+                var v = $('#subject_tree_search').val();
+                $('#subject_tree').jstree(true).search(v);
+            }, 750);
+        });
+
+
+    }
+
+    setup_subject_tree();
+
+    $(document).scroll(function(){
+        $('#selection-container').css('position','');
+        var top = $('#selection-container').offset().top;
+        $('#selection-container').css('position','absolute');
+        $('#selection-container').css('top',Math.max(top,$(document).scrollTop()) + 10);
+    });
+
+});
+</script>
+{% endblock extra_js_bottom %}

--- a/portality/templates/header.html
+++ b/portality/templates/header.html
@@ -21,6 +21,7 @@
           <ul class="nav" id="main-nav-first-menu">
             <li{% if request.path == '/' %} class="active"{% endif %}><a href="{{ url_for('doaj.home') }}">Home</a></li>
             <li{% if request.path == '/search' %} class="active"{% endif %}><a href="{{ url_for('doaj.search') }}" alt="Search or browse DOAJ" title="Search or browse DOAJ">Search</a></li>
+            <li{% if request.path == '/subjects' %} class="active"{% endif %}><a href="{{ url_for('doaj.subjects') }}" alt="Browse by Subject" title="Browse by Subject">Subjects</a></li>
           </ul>
           <a class="btn btn-navbar" data-target=".nav-collapse" data-toggle="collapse">
           <span class="icon-bar"></span>

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -10,6 +10,7 @@ from portality import blog
 from portality.datasets import countries_dict
 from portality import lock
 from portality.formcontext import formcontext
+from portality.lcc import lcc_jstree
 
 import json
 import os
@@ -58,6 +59,10 @@ def search_post():
 
     query = dao.Facetview2.make_query(request.form.get("q"), filters=filters)
     return redirect(url_for('.search') + '?source=' + urllib.quote(json.dumps(query)))
+
+@blueprint.route("/subjects")
+def subjects():
+    return render_template("doaj/subjects.html", subject_page=True, lcc_jstree=json.dumps(lcc_jstree))
 
 @blueprint.route("/application/new", methods=["GET", "POST"])
 def suggestion():


### PR DESCRIPTION
I've gone for a jstree based approach, since once I made a start trying to lay out the subjects it was clear that the varying depths of the tree at different points would make a static layout prohibitively difficult.

Instead the solution is more javascript oriented, and reactive to the user.  Hopefully it is the right kind of thing.