### PR TITLE
ToC SEO

### DIFF
--- a/portality/formcontext/formcontext.py
+++ b/portality/formcontext/formcontext.py
@@ -541,7 +541,7 @@ class ManEdApplicationReview(ApplicationContext):
             j.save()
 
             # record the url the journal is available at in the admin are and alert the user
-            jurl = url_for("doaj.toc", identifier=j.id)
+            jurl = url_for("doaj.toc", identifier=j.toc_id)
             if self.source.current_journal is not None:
                 self.add_alert('<a href="{url}" target="_blank">Existing journal updated</a>.'.format(url=jurl))
                 #self.source.remove_current_journal()

--- a/portality/models/journal.py
+++ b/portality/models/journal.py
@@ -2,7 +2,6 @@ from portality.dao import DomainObject
 from copy import deepcopy
 from datetime import datetime
 from portality.core import app
-from portality import xwalk
 from portality.models import GenericBibJSON
 
 import string
@@ -257,6 +256,16 @@ class Journal(DomainObject):
             del histories[i]
         if len(histories) == 0:
             del self.data["history"]
+
+    @property
+    def toc_id(self):
+        bibjson = self.bibjson()
+        id_ = bibjson.get_one_identifier(bibjson.E_ISSN)
+        if not id_:
+            id_ = bibjson.get_one_identifier(bibjson.P_ISSN)
+        if not id_:
+            id_ = self.id
+        return id_
 
     def issns_for_title(self, title):
         """locate the issns associated with the supplied title"""

--- a/portality/models/openurl.py
+++ b/portality/models/openurl.py
@@ -117,7 +117,7 @@ class OpenURLRequest(object):
                         if len(issns) > 0:
                             ident = issns[0]
                     if ident is None:
-                        ident = journal.id
+                        ident = journal.toc_id
 
                 # If there request has a volume parameter, query for presence of an article with that volume
                 if self.volume:

--- a/portality/scripts/sitemap.py
+++ b/portality/scripts/sitemap.py
@@ -47,7 +47,7 @@ for path, change in statics:
 for j in models.Journal.all_in_doaj(page_size=10000, minified=True):
     
     # first create an entry purely for the journal
-    toc_loc = base_url + "toc/" + j["id"]
+    toc_loc = base_url + "toc/" + j.toc_id
     lastmod = j.get("last_updated")
     
     url = etree.SubElement(urlset, NS + "url")
@@ -63,7 +63,7 @@ for j in models.Journal.all_in_doaj(page_size=10000, minified=True):
     # now create an entry for each volume in the journal
     volumes = models.JournalVolumeToC.list_volumes(j["id"])
     for v in volumes:
-        vol_loc = base_url + "toc/" + j["id"] + "/" + v
+        vol_loc = base_url + "toc/" + j.toc_id + "/" + v
         vurl = etree.SubElement(urlset, NS + "url")
         vloc = etree.SubElement(vurl, NS + "loc")
         vloc.text = vol_loc

--- a/portality/static/doaj/js/available_facetviews/public.journalarticle.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/public.journalarticle.facetview.js
@@ -216,7 +216,7 @@ jQuery(document).ready(function($) {
 
         // set the title
         if (resultobj.bibjson.title) {
-            result += "<span class='title'><a href='/toc/" + resultobj.id + "'>" + escapeHtml(resultobj.bibjson.title) + "</a></span><br>";
+            result += "<span class='title'><a href='/toc/" + journal_toc_id(resultobj) + "'>" + escapeHtml(resultobj.bibjson.title) + "</a></span><br>";
         }
 
         // set the alternative title

--- a/portality/static/doaj/js/doaj.js
+++ b/portality/static/doaj/js/doaj.js
@@ -17,3 +17,25 @@ function iso_datetime2date_and_time(isodate_str) {
     return isodate_str.replace('T',' ').replace('Z','')
 }
 
+function journal_toc_id(journal) {
+    // if e-issn is available, use that
+    // if not, but a p-issn is available, use that
+    // if neither ISSN is available, use the internal ID
+    var ids = journal.bibjson.identifier;
+    var pissns = [];
+    var eissns = [];
+    for (var i = 0; i < ids.length; i++) {
+        if (ids[i].type === "pissn") {
+            pissns.push(ids[i].id)
+        } else if (ids[i].type === "eissn") {
+            eissns.push(ids[i].id)
+        }
+    }
+
+    var toc_id = undefined;
+    if (eissns.length > 0) { toc_id = eissns[0]; }
+    if (!toc_id && pissns.length > 0) { toc_id = pissns[0]; }
+    if (!toc_id) { toc_id = journal.id; }
+
+    return toc_id;
+}

--- a/portality/static/doaj/js/facetview_results_render_callbacks.js
+++ b/portality/static/doaj/js/facetview_results_render_callbacks.js
@@ -162,7 +162,7 @@ fv_title_field = (function (resultobj) {
         }
         if (resultobj.bibjson.title) {
             if (isjournal) {
-                field += "&nbsp<a href='/toc/" + resultobj.id + "'>" + resultobj.bibjson.title + "</a>";
+                field += "&nbsp<a href='/toc/" + journal_toc_id(resultobj) + "'>" + resultobj.bibjson.title + "</a>";
             } else {
                 field += "&nbsp" + resultobj.bibjson.title;
             }

--- a/portality/templates/base.html
+++ b/portality/templates/base.html
@@ -2,8 +2,8 @@
 <html dir="ltr" lang="en">
 <head>
     <meta charset="utf-8">
-    <title>{{ app.config['SERVICE_NAME'] }}</title>
-    <meta name="description" content="{{ app.config['SERVICE_TAGLINE'] }}">
+    {% block page_title %}<title>{{ app.config['SERVICE_NAME'] }}</title>{% endblock %}
+    {% block page_desc %}<meta name="description" content="{{ app.config['SERVICE_TAGLINE'] }}">{% endblock %}
     <meta name="author" content="{{ app.config['ADMIN_NAME'] }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/portality/templates/doaj/article.html
+++ b/portality/templates/doaj/article.html
@@ -1,5 +1,17 @@
 {% extends "base.html" %}
 
+{% block page_title %}
+    {% set bibjson = article.bibjson() %}
+    {% set metatitle = bibjson.title %}
+    {% set metatitle = metatitle + ' | ' + app.config['SERVICE_NAME'] %}
+    <title>{{ metatitle }}</title>
+{% endblock %}
+
+{% block page_desc %}
+    {% set bibjson = article.bibjson() %}
+    <meta name="description" content="Information about the open-access article '{{ bibjson.title }}' in DOAJ. {{ app.config['SERVICE_TAGLINE'] }}">
+{% endblock %}
+
 {% block extra_meta_tags %}
 
 {% set bibjson = article.bibjson() %}

--- a/portality/templates/doaj/article.html
+++ b/portality/templates/doaj/article.html
@@ -61,7 +61,7 @@ hosted on DOAJ.org) #}
         <p>
         {# citation #}
         {% if issns|length > 0 %}
-            <a href="{{url_for('doaj.toc', identifier=issns[0])}}">{{jtitle}}</a>. {{cite}}
+            <a href="{{url_for('doaj.toc', identifier=journal.toc_id)}}">{{jtitle}}</a>. {{cite}}
         {% else %}
             {{jtitle}}. {{cite}}
         {% endif %}

--- a/portality/templates/doaj/journals.html
+++ b/portality/templates/doaj/journals.html
@@ -8,7 +8,7 @@
 
 {% for j in journals %}
 
-<a href="/toc/{{j.id}}">{{ j['bibjson.title'] }}</a><br>
+<a href="/toc/{{j.toc_id}}">{{ j['bibjson.title'] }}</a><br>
 
 {% endfor %}
 

--- a/portality/templates/doaj/toc.html
+++ b/portality/templates/doaj/toc.html
@@ -1,5 +1,15 @@
 {% extends "base.html" %}
 
+{% block page_title %}
+    {% set metatitle = bibjson.title %}
+    {% if current_volume %}{% set metatitle = metatitle + ', ' + 'Volume ' + current_volume %}{% endif %}
+    {% if current_issue %}{% set metatitle = metatitle + ', ' + 'Issue ' + current_issue %}{% endif %}
+    {% set metatitle = metatitle + ' | ' + app.config['SERVICE_NAME'] %}
+    <title>{{ metatitle }}</title>
+{% endblock %}
+
+{% block page_desc %}<meta name="description" content="Information about the open-access journal {{ bibjson.title }} in DOAJ. {{ app.config['SERVICE_TAGLINE'] }}">{% endblock %}
+
 {% block content %}
 
 {%- set CC_MAP = {

--- a/portality/templates/doaj/toc.html
+++ b/portality/templates/doaj/toc.html
@@ -346,7 +346,7 @@
 <div class="row-fluid">
   <div class="span12" style="margin-bottom:10px;padding-bottom:5px;">
     {% for v in volumes %}
-        <a class="bjsr volume btn{% if current_volume == v %} btn-info{% else %} btn-doaj{% endif %}" id="vol_{{v}}" href="{{url_for('doaj.toc', identifier=bibjson.issns()[0], volume=v)}}">{{v}}</a>
+        <a class="bjsr volume btn{% if current_volume == v %} btn-info{% else %} btn-doaj{% endif %}" id="vol_{{v}}" href="{{url_for('doaj.toc', identifier=journal.toc_id, volume=v)}}">{{v}}</a>
     {% endfor %}
   </div>
 </div>
@@ -356,7 +356,7 @@
 <div class="row-fluid">
   <div class="span12" style="margin-bottom:10px;padding-bottom:5px;" id="issuelist">
     {% for i in issues %}
-        <a class="bjsr issue btn{% if current_issue == i %} btn-info{% else %} btn-doaj{% endif %}" id="issue_{{i}}" href="{{url_for('doaj.toc', identifier=bibjson.issns()[0], volume=current_volume)}}/{{i}}">{{i}}</a>
+        <a class="bjsr issue btn{% if current_issue == i %} btn-info{% else %} btn-doaj{% endif %}" id="issue_{{i}}" href="{{url_for('doaj.toc', identifier=journal.toc_id, volume=current_volume)}}/{{i}}">{{i}}</a>
     {% endfor %}
   </div>
 </div>

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -158,14 +158,17 @@ def toc(identifier=None, volume=None, issue=None):
             abort(404)
         journal = js[0]
 
-        # if there is an E-ISSN (and it's not the one in the request), redirect to it
-        # if not, but there is a P-ISSN
         bibjson = journal.bibjson()
+        
+        # if there is an E-ISSN (and it's not the one in the request), redirect to it
+        # if not, but there is a P-ISSN (and it's not the one in the request), redirect to the P-ISSN
         eissn = bibjson.get_one_identifier(bibjson.E_ISSN)
-
-        if identifier != eissn:
+        if eissn and identifier != eissn:
             return redirect(url_for('doaj.toc', identifier=eissn, volume=volume, issue=issue), 301)
-
+        
+        pissn = bibjson.get_one_identifier(bibjson.P_ISSN)
+        if pissn and identifier != pissn:
+            return redirect(url_for('doaj.toc', identifier=pissn, volume=volume, issue=issue), 301)
 
         issn_ref = True     # just a flag so we can check if we were requested via issn
     else:

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -162,11 +162,12 @@ def toc(identifier=None, volume=None, issue=None):
         # if not, but there is a P-ISSN (and it's not the one in the request), redirect to the P-ISSN
         eissn = bibjson.get_one_identifier(bibjson.E_ISSN)
         if eissn and identifier != eissn:
-            return redirect(url_for('doaj.toc', identifier=eissn, volume=volume, issue=issue), 301)
+                return redirect(url_for('doaj.toc', identifier=eissn, volume=volume, issue=issue), 301)
         
-        pissn = bibjson.get_one_identifier(bibjson.P_ISSN)
-        if pissn and identifier != pissn:
-            return redirect(url_for('doaj.toc', identifier=pissn, volume=volume, issue=issue), 301)
+        if not eissn:
+            pissn = bibjson.get_one_identifier(bibjson.P_ISSN)
+            if pissn and identifier != pissn:
+                return redirect(url_for('doaj.toc', identifier=pissn, volume=volume, issue=issue), 301)
 
         issn_ref = True     # just a flag so we can check if we were requested via issn
     else:

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -8,8 +8,6 @@ from portality import dao
 from portality import models
 from portality.core import app, ssl_required, write_required
 from portality import blog
-from portality.datasets import countries_dict
-from portality import lock
 from portality.formcontext import formcontext
 from portality.lcc import lcc_jstree
 

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -1107,7 +1107,7 @@ class OAI_DC_Journal(OAI_DC):
             set_text(idel, identifier.get("id"))
 
         # our internal identifier
-        url = app.config["BASE_URL"] + "/toc/" + record.id
+        url = app.config["BASE_URL"] + "/toc/" + record.toc_id
         idel = etree.SubElement(oai_dc, self.DC + "identifier")
         set_text(idel, url)
         


### PR DESCRIPTION
Introduce title and description meta tags for journal *and* article pages (bonus!). Keywords tag is no longer used and in fact penalized by Bing so not adding that.

Reroute all ToC pages to use ISSNs. The canonical URL is the one with the ISSN now, but an internal ES hex id will be accepted if no ISSN can be provided. Continuations should continue to work. All search results, sitemap, etc. have adopted the new approach. Finally, E-ISSNs are preferred over P-ISSNs where available.