### PR TITLE
modify article upload logic to allow match on only one issn provided …

### DIFF
--- a/doajtest/fixtures/article.py
+++ b/doajtest/fixtures/article.py
@@ -1,0 +1,33 @@
+import os
+from lxml import etree
+from StringIO import StringIO
+
+RESOURCES = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "unit", "resources")
+ARTICLES = os.path.join(RESOURCES, "article_uploads.xml")
+
+class ArticleFixtureFactory(object):
+
+    @classmethod
+    def _response_from_xpath(cls, xpath):
+        with open(ARTICLES) as f:
+            doc = etree.parse(f)
+        records = doc.getroot()
+        articles = records.xpath(xpath)
+        nr = etree.Element("records")
+        for a in articles:
+            nr.append(a)
+        out = etree.tostring(nr, encoding="UTF-8", xml_declaration=True)
+        return StringIO(out)
+
+    @classmethod
+    def upload_2_issns_correct(cls):
+        return cls._response_from_xpath("//record[journalTitle='2 ISSNs Correct']")
+
+    @classmethod
+    def upload_2_issns_ambiguous(cls):
+        return cls._response_from_xpath("//record[journalTitle='2 ISSNs Ambiguous']")
+
+    @classmethod
+    def upload_1_issn_correct(cls):
+        return cls._response_from_xpath("//record[journalTitle='PISSN Correct']")
+

--- a/doajtest/unit/resources/article_uploads.xml
+++ b/doajtest/unit/resources/article_uploads.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<records>
+
+    <!-- a record with two correct issns -->
+    <record>
+        <language>fre</language>
+        <publisher>Codicille éditeur et CRILCQ</publisher>
+
+        <journalTitle>2 ISSNs Correct</journalTitle>
+        <issn>1234-5678</issn>
+        <eissn>9876-5432</eissn>
+
+        <publicationDate>2013</publicationDate>
+        <volume/>
+        <issue>7</issue>
+        <startPage/>
+        <endPage/>
+        <documentType>article</documentType>
+        <title language="fre">Imaginaires autochtones contemporains. Introduction</title>
+        <authors>
+            <author>
+                <name>Papillon, Joëlle</name>
+                <email/>
+                <affiliationId>1</affiliationId>
+            </author>
+        </authors>
+        <affiliationsList>
+            <affiliationName affiliationId="1"/>
+        </affiliationsList>
+        <fullTextUrl/>
+        <keywords>
+            <keyword>Introduction</keyword>
+            <keyword>Littérature amérindienne</keyword>
+            <keyword>Histoire</keyword>
+            <keyword>Identité</keyword>
+            <keyword>Amerindian Literature</keyword>
+            <keyword>History</keyword>
+            <keyword>Identity</keyword>
+            <keyword>Littérature contemporaine</keyword>
+            <keyword>Imaginaire</keyword>
+            <keyword>Contemporary Literature</keyword>
+            <keyword>Imaginary</keyword>
+        </keywords>
+    </record>
+
+    <!-- a record with one correct issn and one unknown one -->
+    <record>
+        <language>fre</language>
+        <publisher>Codicille éditeur et CRILCQ</publisher>
+
+        <journalTitle>2 ISSNs Ambiguous</journalTitle>
+        <issn>1234-5678</issn>
+        <eissn>2345-6789</eissn>
+
+        <publicationDate>2013</publicationDate>
+        <volume/>
+        <issue>7</issue>
+        <startPage/>
+        <endPage/>
+        <documentType>article</documentType>
+        <title language="fre">Imaginaires autochtones contemporains. Introduction</title>
+        <authors>
+            <author>
+                <name>Papillon, Joëlle</name>
+                <email/>
+                <affiliationId>1</affiliationId>
+            </author>
+        </authors>
+        <affiliationsList>
+            <affiliationName affiliationId="1"/>
+        </affiliationsList>
+        <fullTextUrl/>
+        <keywords>
+            <keyword>Introduction</keyword>
+            <keyword>Littérature amérindienne</keyword>
+            <keyword>Histoire</keyword>
+            <keyword>Identité</keyword>
+            <keyword>Amerindian Literature</keyword>
+            <keyword>History</keyword>
+            <keyword>Identity</keyword>
+            <keyword>Littérature contemporaine</keyword>
+            <keyword>Imaginaire</keyword>
+            <keyword>Contemporary Literature</keyword>
+            <keyword>Imaginary</keyword>
+        </keywords>
+    </record>
+
+    <!-- a record with one correct issns -->
+    <record>
+        <language>fre</language>
+        <publisher>Codicille éditeur et CRILCQ</publisher>
+
+        <journalTitle>PISSN Correct</journalTitle>
+        <issn>1234-5678</issn>
+        <!--  <eissn>9876-5432</eissn> -->
+
+        <publicationDate>2013</publicationDate>
+        <volume/>
+        <issue>7</issue>
+        <startPage/>
+        <endPage/>
+        <documentType>article</documentType>
+        <title language="fre">Imaginaires autochtones contemporains. Introduction</title>
+        <authors>
+            <author>
+                <name>Papillon, Joëlle</name>
+                <email/>
+                <affiliationId>1</affiliationId>
+            </author>
+        </authors>
+        <affiliationsList>
+            <affiliationName affiliationId="1"/>
+        </affiliationsList>
+        <fullTextUrl/>
+        <keywords>
+            <keyword>Introduction</keyword>
+            <keyword>Littérature amérindienne</keyword>
+            <keyword>Histoire</keyword>
+            <keyword>Identité</keyword>
+            <keyword>Amerindian Literature</keyword>
+            <keyword>History</keyword>
+            <keyword>Identity</keyword>
+            <keyword>Littérature contemporaine</keyword>
+            <keyword>Imaginaire</keyword>
+            <keyword>Contemporary Literature</keyword>
+            <keyword>Imaginary</keyword>
+        </keywords>
+    </record>
+
+</records>

--- a/doajtest/unit/test_article_upload.py
+++ b/doajtest/unit/test_article_upload.py
@@ -1,0 +1,301 @@
+from doajtest.helpers import DoajTestCase
+from doajtest.fixtures.article import ArticleFixtureFactory
+from portality import article, models
+import uuid, time
+
+class TestArticleUpload(DoajTestCase):
+
+    def setUp(self):
+        super(TestArticleUpload, self).setUp()
+
+    def tearDown(self):
+        super(TestArticleUpload, self).tearDown()
+
+    def test_01_journal_2_article_2_success(self):
+        # Create a journal with two issns both of which match the 2 issns in the article
+        # we expect a successful article ingest
+
+        j = models.Journal()
+        j.set_owner("testowner")
+        bj = j.bibjson()
+        bj.add_identifier(bj.P_ISSN, "1234-5678")
+        bj.add_identifier(bj.E_ISSN, "9876-5432")
+        j.save()
+
+        time.sleep(2)
+
+        handle = ArticleFixtureFactory.upload_2_issns_correct()
+        results = article.ingest_file(handle, format_name="doaj", owner="testowner", upload_id=None)
+
+        assert results["success"] == 1
+        assert results["fail"] == 0
+        assert results["update"] == 0
+        assert results["new"] == 1
+
+        time.sleep(2)
+
+        found = [a for a in models.Article.find_by_issns(["1234-5678", "9876-5432"])]
+        assert len(found) == 1
+
+    def test_02_journal_2_article_1_success(self):
+        # Create a journal with 2 issns, one of which is present in the article as the
+        # only issn
+        # We expect a successful article ingest
+
+        j = models.Journal()
+        j.set_owner("testowner")
+        bj = j.bibjson()
+        bj.add_identifier(bj.P_ISSN, "1234-5678")
+        bj.add_identifier(bj.E_ISSN, "9876-5432")
+        j.save()
+
+        time.sleep(2)
+
+        handle = ArticleFixtureFactory.upload_1_issn_correct()
+        results = article.ingest_file(handle, format_name="doaj", owner="testowner", upload_id=None)
+
+        assert results["success"] == 1
+        assert results["fail"] == 0
+        assert results["update"] == 0
+        assert results["new"] == 1
+
+        time.sleep(2)
+
+        found = [a for a in models.Article.find_by_issns(["1234-5678"])]
+        assert len(found) == 1
+
+    def test_03_journal_1_article_2_success(self):
+        # Create a journal with 1 issn, which is one of the 2 issns on the article
+        # we expect a successful article ingest
+
+        j = models.Journal()
+        j.set_owner("testowner")
+        bj = j.bibjson()
+        bj.add_identifier(bj.E_ISSN, "9876-5432")
+        j.save()
+
+        time.sleep(2)
+
+        handle = ArticleFixtureFactory.upload_2_issns_correct()
+        results = article.ingest_file(handle, format_name="doaj", owner="testowner", upload_id=None)
+
+        assert results["success"] == 1
+        assert results["fail"] == 0
+        assert results["update"] == 0
+        assert results["new"] == 1
+
+        time.sleep(2)
+
+        found = [a for a in models.Article.find_by_issns(["1234-5678", "9876-5432"])]
+        assert len(found) == 1
+
+    def test_04_journal_1_article_1_success(self):
+        # Create a journal with 1 issn, which is the same 1 issn on the article
+        # we expect a successful article ingest
+
+        j = models.Journal()
+        j.set_owner("testowner")
+        bj = j.bibjson()
+        bj.add_identifier(bj.P_ISSN, "1234-5678")
+        j.save()
+
+        time.sleep(2)
+
+        handle = ArticleFixtureFactory.upload_1_issn_correct()
+        results = article.ingest_file(handle, format_name="doaj", owner="testowner", upload_id=None)
+
+        assert results["success"] == 1
+        assert results["fail"] == 0
+        assert results["update"] == 0
+        assert results["new"] == 1
+
+        time.sleep(2)
+
+        found = [a for a in models.Article.find_by_issns(["1234-5678"])]
+        assert len(found) == 1
+
+    def test_05_journal_2_article_2_1_different_success(self):
+        # Create a journal with 2 issns, one of which is the same as an issn on the
+        # article, but the article also contains an issn which doesn't match the journal
+        # We expect a successful article ingest nonetheless
+
+        j = models.Journal()
+        j.set_owner("testowner")
+        bj = j.bibjson()
+        bj.add_identifier(bj.P_ISSN, "1234-5678")
+        bj.add_identifier(bj.E_ISSN, "9876-5432")
+        j.save()
+
+        time.sleep(2)
+
+        handle = ArticleFixtureFactory.upload_2_issns_ambiguous()
+        results = article.ingest_file(handle, format_name="doaj", owner="testowner", upload_id=None)
+
+        assert results["success"] == 1
+        assert results["fail"] == 0
+        assert results["update"] == 0
+        assert results["new"] == 1
+
+        time.sleep(2)
+
+        found = [a for a in models.Article.find_by_issns(["1234-5678", "2345-6789"])]
+        assert len(found) == 1
+
+    def test_05_2_journals_different_owners_both_issns_fail(self):
+        # Create 2 journals with the same issns but different owners, which match the issns on the article
+        # We epect an ingest failure
+
+        legit_fail = {"fail" : 0}
+        def fail_callback_closure(register):
+            def fail_callback(article):
+                register["fail"] += 1
+            return fail_callback
+
+        j1 = models.Journal()
+        j1.set_owner("testowner1")
+        bj1 = j1.bibjson()
+        bj1.add_identifier(bj1.P_ISSN, "1234-5678")
+        bj1.add_identifier(bj1.E_ISSN, "9876-5432")
+        j1.save()
+
+        j2 = models.Journal()
+        j2.set_owner("testowner2")
+        j2.set_in_doaj(False)
+        bj2 = j2.bibjson()
+        bj2.add_identifier(bj2.P_ISSN, "1234-5678")
+        bj2.add_identifier(bj2.E_ISSN, "9876-5432")
+        j2.save()
+
+        time.sleep(2)
+
+        handle = ArticleFixtureFactory.upload_2_issns_correct()
+        results = article.ingest_file(handle, format_name="doaj", owner="testowner1", upload_id=None, article_fail_callback=fail_callback_closure(legit_fail))
+
+        assert results["success"] == 0
+        assert results["fail"] == 1
+        assert results["update"] == 0
+        assert results["new"] == 0
+
+        assert legit_fail["fail"] == 1
+
+        time.sleep(2)
+
+        found = [a for a in models.Article.find_by_issns(["1234-5678", "9876-5432"])]
+        assert len(found) == 0
+
+    def test_06_2_journals_different_owners_issn_each_fail(self):
+        # Create 2 journals with different owners and one different issn each.  The two issns in the
+        # article match each of the journals respectively
+        # We expect an ingest failure
+
+        legit_fail = {"fail" : 0}
+        def fail_callback_closure(register):
+            def fail_callback(article):
+                register["fail"] += 1
+            return fail_callback
+
+        j1 = models.Journal()
+        j1.set_owner("testowner1")
+        bj1 = j1.bibjson()
+        bj1.add_identifier(bj1.P_ISSN, "1234-5678")
+        j1.save()
+
+        j2 = models.Journal()
+        j2.set_owner("testowner2")
+        j2.set_in_doaj(False)
+        bj2 = j2.bibjson()
+        bj2.add_identifier(bj2.E_ISSN, "9876-5432")
+        j2.save()
+
+        time.sleep(2)
+
+        handle = ArticleFixtureFactory.upload_2_issns_correct()
+        results = article.ingest_file(handle, format_name="doaj", owner="testowner1", upload_id=None, article_fail_callback=fail_callback_closure(legit_fail))
+
+        assert results["success"] == 0
+        assert results["fail"] == 1
+        assert results["update"] == 0
+        assert results["new"] == 0
+
+        assert legit_fail["fail"] == 1
+
+        time.sleep(2)
+
+        found = [a for a in models.Article.find_by_issns(["1234-5678", "9876-5432"])]
+        assert len(found) == 0
+
+    def test_07_2_journals_same_owner_issn_each_success(self):
+        # Create 2 journals with the same owner, each with one different issn.  The article's 2 issns
+        # match each of these issns
+        # We expect a successful article ingest
+
+        j1 = models.Journal()
+        j1.set_owner("testowner")
+        bj1 = j1.bibjson()
+        bj1.add_identifier(bj1.P_ISSN, "1234-5678")
+        j1.save()
+
+        j2 = models.Journal()
+        j2.set_owner("testowner")
+        j2.set_in_doaj(False)
+        bj2 = j2.bibjson()
+        bj2.add_identifier(bj2.E_ISSN, "9876-5432")
+        j2.save()
+
+        time.sleep(2)
+
+        handle = ArticleFixtureFactory.upload_2_issns_correct()
+        results = article.ingest_file(handle, format_name="doaj", owner="testowner", upload_id=None)
+
+        assert results["success"] == 1
+        assert results["fail"] == 0
+        assert results["update"] == 0
+        assert results["new"] == 1
+
+        time.sleep(2)
+
+        found = [a for a in models.Article.find_by_issns(["1234-5678", "9876-5432"])]
+        assert len(found) == 1
+
+    def test_08_2_journals_different_owners_different_issns_mixed_article_fail(self):
+        # Create 2 different journals with different owners and different issns (2 each).
+        # The article's issns match one issn in each journal
+        # We expect an ingest failure
+
+        legit_fail = {"fail" : 0}
+        def fail_callback_closure(register):
+            def fail_callback(article):
+                register["fail"] += 1
+            return fail_callback
+
+        j1 = models.Journal()
+        j1.set_owner("testowner1")
+        bj1 = j1.bibjson()
+        bj1.add_identifier(bj1.P_ISSN, "1234-5678")
+        bj1.add_identifier(bj1.E_ISSN, "2345-6789")
+        j1.save()
+
+        j2 = models.Journal()
+        j2.set_owner("testowner2")
+        j2.set_in_doaj(False)
+        bj2 = j2.bibjson()
+        bj2.add_identifier(bj2.P_ISSN, "8765-4321")
+        bj2.add_identifier(bj2.E_ISSN, "9876-5432")
+        j2.save()
+
+        time.sleep(2)
+
+        handle = ArticleFixtureFactory.upload_2_issns_correct()
+        results = article.ingest_file(handle, format_name="doaj", owner="testowner1", upload_id=None, article_fail_callback=fail_callback_closure(legit_fail))
+
+        assert results["success"] == 0
+        assert results["fail"] == 1
+        assert results["update"] == 0
+        assert results["new"] == 0
+
+        assert legit_fail["fail"] == 1
+
+        time.sleep(2)
+
+        found = [a for a in models.Article.find_by_issns(["1234-5678", "9876-5432"])]
+        assert len(found) == 0


### PR DESCRIPTION
…there are no inconsistencies on the matched journals.  Also adds full suite of tests for all eventualities.

@emanuil-tolev - I've done this as a PR against develop, but perhaps it would be better against production, if we can roll features like these out regularly?