### PR TITLE
Feature/735 discovery api

### DIFF
--- a/doajtest/unit/test_api_discovery.py
+++ b/doajtest/unit/test_api_discovery.py
@@ -1,0 +1,155 @@
+from doajtest.helpers import DoajTestCase
+from portality import models
+from portality.api.v1 import DiscoveryApi, DiscoveryException
+import time
+
+class TestArticleMatch(DoajTestCase):
+
+    def setUp(self):
+        super(TestArticleMatch, self).setUp()
+
+    def tearDown(self):
+        super(TestArticleMatch, self).tearDown()
+
+    def test_01_journals(self):
+        # populate the index with some journals
+        for i in range(5):
+            j = models.Journal()
+            j.set_in_doaj(True)
+            bj = j.bibjson()
+            bj.title = "Test Journal {x}".format(x=i)
+            bj.add_identifier(bj.P_ISSN, "{x}000-0000".format(x=i))
+            bj.publisher = "Test Publisher {x}".format(x=i)
+            bj.add_url("http://homepage.com/{x}".format(x=i), "homepage")
+            j.save()
+
+            # make sure the last updated dates are suitably different
+            time.sleep(1)
+
+        # add one that's not in DOAJ, which shouldn't turn up in our results
+        j = models.Journal()
+        j.set_in_doaj(False)
+        bj = j.bibjson()
+        bj.title = "Test Journal {x}".format(x=6)
+        bj.add_identifier(bj.P_ISSN, "{x}000-0000".format(x=6))
+        bj.publisher = "Test Publisher {x}".format(x=6)
+        bj.add_url("http://homepage.com/{x}".format(x=6), "homepage")
+        j.save()
+
+        time.sleep(1)
+
+        # now run some queries
+
+        # 1. a general query that should hit everything (except number 6)
+        res = DiscoveryApi.search_journals("Test", 1, 2)
+        assert res.data.get("total") == 5
+        assert len(res.data.get("results")) == 2
+        assert res.data.get("page") == 1
+        assert res.data.get("pageSize") == 2
+        assert res.data.get("query") == "Test"
+
+        # 2. a specific field query that should hit just one
+        res = DiscoveryApi.search_journals("title:\"Test Journal 2\"", 1, 5)
+        assert res.data.get("total") == 1
+        assert len(res.data.get("results")) == 1
+        assert res.data.get("page") == 1
+        assert res.data.get("pageSize") == 5
+        assert res.data.get("query") == "title:\"Test Journal 2\""
+
+        # 3.paging out of range of results
+        res = DiscoveryApi.search_journals("Test", 2, 10)
+        assert res.data.get("total") == 5
+        assert len(res.data.get("results")) == 0
+        assert res.data.get("page") == 2
+        assert res.data.get("pageSize") == 10
+        assert res.data.get("query") == "Test"
+
+        # 4. paging outside the allowed bounds (lower)
+        res = DiscoveryApi.search_journals("Test", 0, 0)
+        assert res.data.get("total") == 5
+        assert len(res.data.get("results")) == 5
+        assert res.data.get("page") == 1
+        assert res.data.get("pageSize") == 10
+        assert res.data.get("query") == "Test"
+
+        # 5. page size above upper limit
+        res = DiscoveryApi.search_journals("Test", 1, 100000)
+        assert res.data.get("total") == 5
+        assert len(res.data.get("results")) == 5
+        assert res.data.get("page") == 1
+        assert res.data.get("pageSize") == 100
+        assert res.data.get("query") == "Test"
+
+        # 6. Failed attempt at wildcard search
+        with self.assertRaises(DiscoveryException):
+            res = DiscoveryApi.search_journals("Te*t", 1, 10)
+
+        # 7. Failed attempt at fuzzy search
+        with self.assertRaises(DiscoveryException):
+            res = DiscoveryApi.search_journals("title:Test~0.8", 1, 10)
+
+    def test_02_articles(self):
+        # populate the index with some articles
+        for i in range(5):
+            a = models.Article()
+            a.set_in_doaj(True)
+            bj = a.bibjson()
+            bj.title = "Test Article {x}".format(x=i)
+            bj.add_identifier(bj.P_ISSN, "{x}000-0000".format(x=i))
+            bj.publisher = "Test Publisher {x}".format(x=i)
+            a.save()
+
+            # make sure the last updated dates are suitably different
+            time.sleep(1)
+
+        time.sleep(1)
+
+        # now run some queries
+
+        # 1. a general query that should hit everything
+        res = DiscoveryApi.search_articles("Test", 1, 2)
+        assert res.data.get("total") == 5
+        assert len(res.data.get("results")) == 2
+        assert res.data.get("page") == 1
+        assert res.data.get("pageSize") == 2
+        assert res.data.get("query") == "Test"
+
+        # 2. a specific field query that should hit just one
+        res = DiscoveryApi.search_articles("title:\"Test Article 2\"", 1, 5)
+        assert res.data.get("total") == 1
+        assert len(res.data.get("results")) == 1
+        assert res.data.get("page") == 1
+        assert res.data.get("pageSize") == 5
+        assert res.data.get("query") == "title:\"Test Article 2\""
+
+        # 3.paging out of range of results
+        res = DiscoveryApi.search_articles("Test", 2, 10)
+        assert res.data.get("total") == 5
+        assert len(res.data.get("results")) == 0
+        assert res.data.get("page") == 2
+        assert res.data.get("pageSize") == 10
+        assert res.data.get("query") == "Test"
+
+        # 4. paging outside the allowed bounds (lower)
+        res = DiscoveryApi.search_articles("Test", 0, 0)
+        assert res.data.get("total") == 5
+        assert len(res.data.get("results")) == 5
+        assert res.data.get("page") == 1
+        assert res.data.get("pageSize") == 10
+        assert res.data.get("query") == "Test"
+
+        # 5. page size above upper limit
+        res = DiscoveryApi.search_articles("Test", 1, 100000)
+        assert res.data.get("total") == 5
+        assert len(res.data.get("results")) == 5
+        assert res.data.get("page") == 1
+        assert res.data.get("pageSize") == 100
+        assert res.data.get("query") == "Test"
+
+        # 6. Failed attempt at wildcard search
+        with self.assertRaises(DiscoveryException):
+            res = DiscoveryApi.search_articles("Te*t", 1, 10)
+
+        # 7. Failed attempt at fuzzy search
+        with self.assertRaises(DiscoveryException):
+            res = DiscoveryApi.search_articles("title:Test~0.8", 1, 10)

--- a/portality/api/v1/__init__.py
+++ b/portality/api/v1/__init__.py
@@ -1,3 +1,3 @@
 from portality.api.v1.common import jsonify_models
 
-from portality.api.v1.discovery import DiscoveryApi
+from portality.api.v1.discovery import DiscoveryApi, DiscoveryException

--- a/portality/api/v1/discovery.py
+++ b/portality/api/v1/discovery.py
@@ -1,14 +1,166 @@
 from portality.api.v1.common import Api
-
 from portality import models
+from portality.core import app
+from datetime import datetime
+import esprit
+import re, json
+
+class DiscoveryException(Exception):
+    pass
+
+class SearchResult(object):
+    def __init__(self, raw=None):
+        self.data = raw if raw is not None else {}
+
+def substitute(query, substitutions):
+    if len(substitutions.keys()) == 0:
+        return query
+
+    # apply the regex escapes to the substitutions, so we know they
+    # are ready to be matched
+    escsubs = {}
+    for k, v in substitutions.iteritems():
+        escsubs[k.replace(":", "\\:")] = v
+
+    # define a function which takes the match group and returns the
+    # substitution if there is one
+    def rep(match):
+        for k, v in escsubs.iteritems():
+            if k == match.group(1):
+                return v
+        return match.group(1)
+
+    # define the regular expressions for splitting and then extracting
+    # the field to be substituted
+    split_rx = "([^\\\\]:)"
+    field_rx = "([^\s\+\-\(\)\"]+?):$"
+
+    # split the query around any unescaped colons
+    bits = re.split(split_rx, query)
+
+    # stitch back together the split sections and the separators
+    segs = [bits[i] + bits[i+1] for i in range(0, len(bits), 2) if i+1 < len(bits)] + [bits[len(bits) - 1]] if len(bits) % 2 == 1 else []
+
+    # substitute the fields as required
+    subs = []
+    for seg in segs:
+        if seg.endswith(":"):
+            subs.append(re.sub(field_rx, rep, seg))
+        else:
+            subs.append(seg)
+
+    return ":".join(subs)
+
+def allowed(query, wildcards=False, fuzzy=False):
+    if not wildcards:
+        rx = "(.+[^\\\\][\?\*]+.*)"
+        if re.search(rx, query):
+            return False
+
+    if not fuzzy:
+        # this covers both fuzzy searching and proximity searching
+        rx = "(.+[^\\\\]~[0-9]{0,1}[\.]{0,1}[0-9]{0,1})"
+        if re.search(rx, query):
+            return False
+
+    return True
 
 
 class DiscoveryApi(Api):
 
     @classmethod
-    def search_articles(cls, q):
-        return [models.Article(id="1ef4d6", bibjson={"title": "Mock Article 1"}), models.Article(id="1ef4d7", bibjson={"title": "Mock Article 2"})]
+    def _make_query(cls, q, page, page_size, subs):
+        if not allowed(q):
+            raise DiscoveryException("Query contains disallowed Lucene features")
+
+        q = substitute(q, subs)
+        # print q
+
+        # calculate the position of the from cursor in the document set
+        fro = (page - 1) * page_size
+
+        # assemble the query
+        query = SearchQuery(q, fro, page_size)
+        # print json.dumps(query.query())
+
+        return query
 
     @classmethod
-    def search_journals(cls, q):
-        return [models.Journal(id="2ef4d6", bibjson={"title": "Mock Journal 1"}), models.Journal(id="2ef4d7", bibjson={"title": "Mock Journal 2"})]
+    def _make_response(cls, res, q, page, page_size, obs):
+        total = res.get("hits", {}).get("total", 0)
+
+        # build the response object
+        result = {
+            "total" : total,
+            "page" : page,
+            "pageSize" : page_size,
+            "timestamp" : datetime.utcnow().strftime("%Y-%m%dT%H:%M:%SZ"),
+            "query" : q,
+            "results" : obs
+        }
+
+        return SearchResult(result)
+
+    @classmethod
+    def search_articles(cls, q, page, page_size):
+        subs = app.config.get("DISCOVERY_ARTICLE_SUBS", {})
+        query = cls._make_query(q, page, page_size, subs)
+
+        # execute the query against the articles
+        res = models.Article.query(q=query.query(), consistent_order=False)
+
+        # check to see if there was a search error
+        if res.get("error") is not None:
+            app.logger.error("Error executing discovery query search: {x}".format(x=res.get("error")))
+            raise DiscoveryException("There was an error executing your query")
+
+        obs = [models.Article(**raw) for raw in esprit.raw.unpack_json_result(res)]
+        return cls._make_response(res, q, page, page_size, obs)
+
+    @classmethod
+    def search_journals(cls, q, page, page_size):
+        subs = app.config.get("DISCOVERY_JOURNAL_SUBS", {})
+        query = cls._make_query(q, page, page_size, subs)
+
+        # execute the query against the articles
+        res = models.Journal.query(q=query.query(), consistent_order=False)
+
+        # check to see if there was a search error
+        if res.get("error") is not None:
+            app.logger.error("Error executing discovery query search: {x}".format(x=res.get("error")))
+            raise DiscoveryException("There was an error executing your query")
+
+        obs = [models.Journal(**raw) for raw in esprit.raw.unpack_json_result(res)]
+        return cls._make_response(res, q, page, page_size, obs)
+
+class SearchQuery(object):
+    def __init__(self, qs, fro, psize):
+        self.qs = qs
+        self.fro = fro
+        self.psize = psize
+
+    def query(self):
+        return {
+            "query" : {
+                "filtered" : {
+                    "filter" : {
+                        "bool" : {
+                            "must" : [
+                                {"term" : {"admin.in_doaj": True}}
+                            ]
+                        }
+                    },
+                    "query" : {
+                        "query_string" : {
+                            "query" : self.qs
+                        }
+                    }
+                }
+            },
+            "_source": {
+                "include": ["last_updated", "created_date", "id", "bibjson"],
+                "exclude": [],
+            },
+            "from" : self.fro,
+            "size" : self.psize
+        }

--- a/portality/api/v1/discovery.py
+++ b/portality/api/v1/discovery.py
@@ -76,6 +76,15 @@ class DiscoveryApi(Api):
         q = substitute(q, subs)
         # print q
 
+        # sanitise the page size information
+        if page < 1:
+            page = 1
+
+        if page_size > app.config.get("DISCOVERY_MAX_PAGE_SIZE", 100):
+            page_size = app.config.get("DISCOVERY_MAX_PAGE_SIZE", 100)
+        elif page_size < 1:
+            page_size = 10
+
         # calculate the position of the from cursor in the document set
         fro = (page - 1) * page_size
 
@@ -83,7 +92,7 @@ class DiscoveryApi(Api):
         query = SearchQuery(q, fro, page_size)
         # print json.dumps(query.query())
 
-        return query
+        return query, page, page_size
 
     @classmethod
     def _make_response(cls, res, q, page, page_size, obs):
@@ -104,7 +113,7 @@ class DiscoveryApi(Api):
     @classmethod
     def search_articles(cls, q, page, page_size):
         subs = app.config.get("DISCOVERY_ARTICLE_SUBS", {})
-        query = cls._make_query(q, page, page_size, subs)
+        query, page, page_size = cls._make_query(q, page, page_size, subs)
 
         # execute the query against the articles
         res = models.Article.query(q=query.query(), consistent_order=False)
@@ -120,7 +129,7 @@ class DiscoveryApi(Api):
     @classmethod
     def search_journals(cls, q, page, page_size):
         subs = app.config.get("DISCOVERY_JOURNAL_SUBS", {})
-        query = cls._make_query(q, page, page_size, subs)
+        query, page, page_size = cls._make_query(q, page, page_size, subs)
 
         # execute the query against the articles
         res = models.Journal.query(q=query.query(), consistent_order=False)

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -433,5 +433,15 @@ DISCOVERY_MAX_PAGE_SIZE = 100
 DISCOVERY_ARTICLE_SUBS = {
     "title" : "bibjson.title",
     "doi" : "bibjson.identifier.id.exact",
-    "publisher" : "bibjson.journal.publisher"
+    "issn" :  "index.issn.exact",
+    "publisher" : "bibjson.journal.publisher",
+    "journal" : "bibjson.journal.title",
+    "abstract" :  "bibjson.abstract"
+}
+
+DISCOVERY_JOURNAL_SUBS = {
+    "title" : "index.title",
+    "issn" :  "index.issn.exact",
+    "publisher" : "bibjson.publisher",
+    "license" : "index.license.exact"
 }

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -423,3 +423,15 @@ DATE_FORMATS = [
     "%B %Y",                # e.g. February 2014
     "%Y"                    # e.g. 1978
 ]
+
+
+# ========================================
+# API configuration
+
+DISCOVERY_MAX_PAGE_SIZE = 100
+
+DISCOVERY_ARTICLE_SUBS = {
+    "title" : "bibjson.title",
+    "doi" : "bibjson.identifier.id.exact",
+    "publisher" : "bibjson.journal.publisher"
+}

--- a/portality/view/api_v1.py
+++ b/portality/view/api_v1.py
@@ -75,24 +75,17 @@ def search(search_type, search_query):
     page = request.values.get("page", 1)
     psize = request.values.get("pageSize", 10)
 
-    # check the page is an integer greater than 0
+    # check the page is an integer
     try:
         page = int(page)
     except:
         return _bad_request("Page number was not an integer")
-    if page < 1:
-        page = 1
 
-    # limit the page size as per the configuration
+    # check the page size is an integer
     try:
         psize = int(psize)
     except:
         return _bad_request("Page size was not an integer")
-
-    if psize > app.config.get("DISCOVERY_MAX_PAGE_SIZE", 100):
-        psize = app.config.get("DISCOVERY_MAX_PAGE_SIZE", 100)
-    elif psize < 1:
-        psize = 10
 
     results = None
     if search_type == "articles":

--- a/portality/view/api_v1.py
+++ b/portality/view/api_v1.py
@@ -1,10 +1,21 @@
-from flask import Blueprint, jsonify, url_for, request, make_response
+from flask import Blueprint, jsonify, url_for, request, make_response, abort
 from flask_swagger import swagger
 
-from portality.api.v1 import DiscoveryApi, jsonify_models
+from portality.api.v1 import DiscoveryApi, DiscoveryException, jsonify_models
 from portality.core import app
 
+import json
+
 blueprint = Blueprint('api_v1', __name__)
+
+def _bad_request(message=None, exception=None):
+    if exception is not None:
+        message = exception.message
+    app.logger.info("Sending 400 Bad Request from client: {x}".format(x=message))
+    resp = make_response(json.dumps({"status" : "error", "error" : message}))
+    resp.mimetype = "application/json"
+    resp.status_code = 400
+    return resp
 
 @blueprint.route('/spec')
 def api_spec():
@@ -25,7 +36,7 @@ def list_operations():
 def docs():
     return 'Documentation root'
 
-@blueprint.route('/search/<search_type>/<search_query>')
+@blueprint.route('/search/<search_type>/<path:search_query>')
 def search(search_type, search_query):
     """
     Search journals and articles
@@ -44,20 +55,57 @@ def search(search_type, search_query):
         in: "path"
         required: true
         type: "string"
+      -
+        name: "page"
+        in: "body":
+        required: false
+        type: "int"
+      -
+        name: "pageSize"
+        in: "body"
+        required: false,
+        type: "int"
     responses:
       200:
         description: Search results
+      400:
+        description: Bad Request
     """
-    results = {
-        'results': {
-            'search_query': search_query,
-        }
-    }
+    # get the values for the 2 other bits of search info: the page number and the page size
+    page = request.values.get("page", 1)
+    psize = request.values.get("pageSize", 10)
 
-    if search_type == 'articles' or search_type == 'all':
-        results['results'].update({'articles': DiscoveryApi.search_articles(search_query)})
+    # check the page is an integer greater than 0
+    try:
+        page = int(page)
+    except:
+        return _bad_request("Page number was not an integer")
+    if page < 1:
+        page = 1
 
-    if search_type == 'journals' or search_type == 'all':
-        results['results'].update({'journals': DiscoveryApi.search_journals(search_query)})
+    # limit the page size as per the configuration
+    try:
+        psize = int(psize)
+    except:
+        return _bad_request("Page size was not an integer")
+
+    if psize > app.config.get("DISCOVERY_MAX_PAGE_SIZE", 100):
+        psize = app.config.get("DISCOVERY_MAX_PAGE_SIZE", 100)
+    elif psize < 1:
+        psize = 10
+
+    results = None
+    if search_type == "articles":
+        try:
+            results = DiscoveryApi.search_articles(search_query, page, psize)
+        except DiscoveryException as e:
+            return _bad_request(e.message)
+    elif search_type == "journals":
+        try:
+            results = DiscoveryApi.search_journals(search_query, page, psize)
+        except DiscoveryException as e:
+            return _bad_request(e.message)
+    else:
+        abort(404)
 
     return jsonify_models(results)


### PR DESCRIPTION
This provides the actual implementation of the public discovery API, but it doesn't really do very much about the documentation.  I'm not sure how that fits in with the swagger stuff - I expect the docs will probably want to contain some examples, a bit of detail about the allowed lucene queries, and possibly references to the data that is produced, but that seems like a lot to go into a single method comment.