### PR TITLE
User / authentication 

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,30 +334,31 @@ It is likely that history records will only be created upon request by the admin
 
 NOTE: there's an argument for putting the issn identifiers inside the journal part of the bibjson, rather than at the root of the bibliographic record, but this creates some annoying complexities in the software implementation and its API for interacting with identifiers, so it has not yet been done.  Sould it be?  The same goes for the subject, which currently comes from the journal record, but which can effectively be applied the the article too.
 
-### Contact Data Model
-
-    {
-        "id" : "<the username of the user>",
-        "password" : "<hashed password>",
-        "name" : "<user's actual name>",
-        "email" : "<user's email address>",
-        "role" : [<list of user roles>]
-        "journal" : [<list of journal ids the user can administer>]
-    }
-
+### Account Data Model
+```python
+{
+    "id" : "<the username of the user>",
+    "password" : "<hashed password>",
+    "name" : "<user's actual name>",
+    "email" : "<user's email address>",
+    "role" : [<list of user roles>],
+    "journal" : [<list of journal ids the user can administer>],
+    "api_key" : "<32 character-long hexadecimal key to access API>"
+}
+```
 ### File Upload Data Model
-
-    {
-        "id": "<opaque id of upload>",
-        "status": "incoming|validated|failed|processed",
-        "last_updated": "<last date modified>",
-        "created_date": "<date of initial upload>",
-        "owner": "<user id of owner>",
-        "schema": "<metadata scheme used>",
-        "filename": "<filename of upload>",
-        "error" : "<any error associated with the upload>"
-    }
-
+```python
+{
+    "id": "<opaque id of upload>",
+    "status": "incoming|validated|failed|processed",
+    "last_updated": "<last date modified>",
+    "created_date": "<date of initial upload>",
+    "owner": "<user id of owner>",
+    "schema": "<metadata scheme used>",
+    "filename": "<filename of upload>",
+    "error" : "<any error associated with the upload>"
+}
+```
 ### Journal ToC Data Model
 
 The Journal ToC data model stores a cache of the Table of Contents on a per-volume basis

--- a/doajtest/unit/test_api_account.py
+++ b/doajtest/unit/test_api_account.py
@@ -1,0 +1,79 @@
+import time
+from flask import Response
+
+from doajtest.helpers import DoajTestCase
+from portality import models
+from portality.core import app
+from portality.app import load_account_for_login_manager
+from portality.decorators import api_key_required
+
+class TestClient(DoajTestCase):
+
+    def setUp(self):
+        super(TestClient, self).setUp()
+
+    def tearDown(self):
+        super(TestClient, self).tearDown()
+
+    def test_01_api_role(self):
+        """test the new roles added for the API"""
+        a1 = models.Account.make_account(username="a1_user", name="a1_name", email="a1@example.com", roles=["user"], associated_journal_ids=[])
+        a1.save()
+        time.sleep(1)
+
+        # Check an API key was generated on account creation
+        a1_key = a1.api_key
+        assert a1_key is not None
+
+        # Check we can retrieve the account by its key
+        a1_retrieved = models.Account.pull_by_api_key(a1_key)
+        assert a1 == a1_retrieved
+
+        # Check all roles gain the api role on creation
+        a2 = models.Account.make_account(username="a2_user", name="a2_name", email="a2@example.com", roles=["admin"], associated_journal_ids=[])
+        a3 = models.Account.make_account(username="a3_user", name="a3_name", email="a3@example.com", roles=["publisher"], associated_journal_ids=[])
+        a4 = models.Account.make_account(username="a4_user", name="a4_name", email="a4@example.com", roles=["editor"], associated_journal_ids=[])
+        a5 = models.Account.make_account(username="a5_user", name="a5_name", email="a5@example.com", roles=["associate_editor"], associated_journal_ids=[])
+        assert a1.has_role("api")
+        assert a2.has_role("api")
+        assert a3.has_role("api")
+        assert a4.has_role("api")
+        assert a5.has_role("api")
+
+        # Check that removing the API role means you don't get a key
+        a1.remove_role('api')
+        assert a1.api_key is None
+
+    def test_02_api_decorator(self):
+        """test the api_key_required decorator"""
+        a1 = models.Account.make_account(username="a1_user", name="a1_name", email="a1@example.com", roles=["user"], associated_journal_ids=[])
+        a1_key = a1.api_key
+        a1.save()               # a1 has api access
+
+        a2 = models.Account.make_account(username="a2_user", name="a2_name", email="a2@example.com", roles=["user"], associated_journal_ids=[])
+        a2_key = a2.api_key     # user gets the key before access is removed
+        a2.remove_role('api')
+        a2.save()               # a2 does not have api access.
+
+        time.sleep(1)
+
+        app.testing = True
+        # for some reason this wasn't being registered, so do so here
+        app.login_manager.user_loader(load_account_for_login_manager)
+
+        # Create a view to test the wrapper with
+        @app.route('/hello')
+        @api_key_required
+        def hello_world():
+            return Response("hello, world!")
+
+        with app.test_client() as t_client:
+            # Check the authorised user can access our function, but the unauthorised one can't.
+            response_authorised = t_client.get('/hello?api_key=' + a1_key)
+            assert response_authorised.data == "hello, world!"
+            assert response_authorised.status_code == 200
+
+            response_denied = t_client.get('/hello?api_key=' + a2_key)
+            assert response_denied.status_code == 401
+
+

--- a/portality/app.py
+++ b/portality/app.py
@@ -9,7 +9,6 @@ import os
 
 from flask import request, abort, render_template, redirect, send_file, url_for, jsonify
 from flask.ext.login import login_user, current_user
-from copy import deepcopy
 
 from datetime import datetime
 import tzlocal
@@ -18,7 +17,6 @@ import pytz
 import portality.models as models
 from portality.core import app, login_manager
 from portality import settings
-from portality.util import flash_with_url
 
 from portality.view.account import blueprint as account
 from portality.view.admin import blueprint as admin

--- a/portality/authorise.py
+++ b/portality/authorise.py
@@ -30,5 +30,3 @@ class Authorise(object):
     def top_level_roles(cls):
         return app.config.get("TOP_LEVEL_ROLES", [])
 
-        
-        

--- a/portality/dao.py
+++ b/portality/dao.py
@@ -1,11 +1,11 @@
-import os, json, UserDict, requests, uuid
+import json, UserDict, requests, uuid
 from copy import deepcopy
 from datetime import datetime
 import time
 # debugging
 import traceback, sys
 
-from portality.core import app, current_user
+from portality.core import app
 
 '''
 All models in models.py should inherig this DomainObject to know how to save themselves in the index and so on.

--- a/portality/decorators.py
+++ b/portality/decorators.py
@@ -1,0 +1,59 @@
+from functools import wraps
+from flask import request, abort, redirect, flash, url_for, render_template
+from flask.ext.login import current_user
+from flask_login import login_user
+
+from portality.core import app
+from portality.models import Account
+
+
+def api_key_required(fn):
+    """ Decorator for API functions, requiring a valid key to find a user """
+    @wraps(fn)
+    def decorated_view(*args, **kwargs):
+        api_key = request.values.get("api_key", None)
+        if api_key is not None:
+            user = Account.pull_by_api_key(api_key)
+            if user is not None:
+                if login_user(user, remember=False):
+                    return fn(*args, **kwargs)
+        # else
+        abort(401)
+
+    return decorated_view
+
+
+def ssl_required(fn):
+    """ Decorator for when a view f() should be served only over SSL """
+    @wraps(fn)
+    def decorated_view(*args, **kwargs):
+        if app.config.get("SSL"):
+            if request.is_secure:
+                return fn(*args, **kwargs)
+            else:
+                return redirect(request.url.replace("http://", "https://"))
+
+        return fn(*args, **kwargs)
+
+    return decorated_view
+
+
+def restrict_to_role(role):
+    if current_user.is_anonymous():
+        flash('You are trying to access a protected area. Please log in first.', 'error')
+        return redirect(url_for('account.login', next=request.url))
+
+    if not current_user.has_role(role):
+        flash('You do not have permission to access this area of the site.', 'error')
+        return redirect(url_for('doaj.home'))
+
+
+def write_required(fn):
+    @wraps(fn)
+    def decorated_view(*args, **kwargs):
+        if app.config.get("READ_ONLY_MODE", False):
+            return render_template("doaj/readonly.html")
+
+        return fn(*args, **kwargs)
+
+    return decorated_view

--- a/portality/migrate/api_v1/README.md
+++ b/portality/migrate/api_v1/README.md
@@ -1,0 +1,4 @@
+# Upgrade code for the API_v1 project
+
+To add 'api_key' entries and 'api' role to all accounts:
+    python portality/upgrade.py -u portality/migrate/api_v1/api_auth.json

--- a/portality/migrate/api_v1/api_auth.json
+++ b/portality/migrate/api_v1/api_auth.json
@@ -1,0 +1,12 @@
+{
+  "types": [
+      {
+        "type": "account",
+        "tasks": {
+          "add_role": {"role" : "api"},
+          "generate_api_key": {}
+        },
+        "keepalive": "1m"
+      }
+  ]
+}

--- a/portality/models/account.py
+++ b/portality/models/account.py
@@ -162,7 +162,7 @@ class Account(DomainObject, UserMixin):
     @classmethod
     def pull_by_api_key(cls, key):
         """Find a user by their API key - only succeed if they currently have API access."""
-        res = cls.query(q='api_key:"' + key + '"')
+        res = cls.query(q='api_key.exact:"' + key + '"')
         if res.get('hits', {}).get('total', 0) == 1:
             usr = cls(**res['hits']['hits'][0]['_source'])
             if usr.has_role('api'):

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -105,26 +105,26 @@ TOP_LEVEL_ROLES = ["admin", "publisher", "editor", "associate_editor", "user", ]
 
 ROLE_MAP = {
     "publisher": [
-        "api"
+        #"api"                  # added on account creation, commented out here so it can be revoked per account
     ],
     "editor": [
-        "associate_editor", # note, these don't cascade, so we still need to list all the low-level roles
+        "associate_editor",     # note, these don't cascade, so we still need to list all the low-level roles
         "edit_journal",
         "edit_suggestion",
         "editor_area",
         "assign_to_associate",
         "list_group_journals",
         "list_group_suggestions",
-        "api"
+        #"api"
     ],
     "associate_editor": [
         "edit_journal",
         "edit_suggestion",
         "editor_area",
-        "api"
+        #"api"
     ],
     "user": [
-        #"api"              # added on account creation, commented out here so it can be revoked
+        #"api"
     ]
 }
 

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -101,9 +101,12 @@ TICK_THRESHOLD = '2014-03-19T00:00:00Z'
 
 SUPER_USER_ROLE = "admin"
 
-TOP_LEVEL_ROLES = ["admin", "publisher", "editor", "associate_editor"]
+TOP_LEVEL_ROLES = ["admin", "publisher", "editor", "associate_editor", "user", ]
 
 ROLE_MAP = {
+    "publisher": [
+        "api"
+    ],
     "editor": [
         "associate_editor", # note, these don't cascade, so we still need to list all the low-level roles
         "edit_journal",
@@ -111,12 +114,17 @@ ROLE_MAP = {
         "editor_area",
         "assign_to_associate",
         "list_group_journals",
-        "list_group_suggestions"
+        "list_group_suggestions",
+        "api"
     ],
-    "associate_editor" : [
+    "associate_editor": [
         "edit_journal",
         "edit_suggestion",
-        "editor_area"
+        "editor_area",
+        "api"
+    ],
+    "user": [
+        #"api"              # added on account creation, commented out here so it can be revoked
     ]
 }
 

--- a/portality/view/account.py
+++ b/portality/view/account.py
@@ -1,12 +1,13 @@
 import uuid, json
 
-from flask import Blueprint, request, url_for, flash, redirect, make_response, session
+from flask import Blueprint, request, url_for, flash, redirect, make_response
 from flask import render_template, abort
 from flask.ext.login import login_user, logout_user, current_user, login_required
-from flask.ext.wtf import StringField, TextAreaField, SelectField, HiddenField
+from flask.ext.wtf import StringField, HiddenField
 from flask.ext.wtf import Form, PasswordField, validators, ValidationError
 
-from portality.core import app, ssl_required, write_required
+from portality.core import app
+from portality.decorators import ssl_required, write_required
 from portality import models
 from portality import util, app_email
 

--- a/portality/view/admin.py
+++ b/portality/view/admin.py
@@ -4,7 +4,7 @@ from flask import Blueprint, request, flash, abort, make_response
 from flask import render_template, redirect, url_for
 from flask.ext.login import current_user, login_required
 
-from portality.core import app, ssl_required, restrict_to_role, write_required
+from portality.decorators import ssl_required, restrict_to_role, write_required
 import portality.models as models
 from portality.formcontext import formcontext
 from portality import lock

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -1,12 +1,12 @@
-from flask import Blueprint, request, abort, make_response
-from flask import render_template, abort, redirect, url_for, flash, send_file, jsonify
+from flask import Blueprint, request, make_response
+from flask import render_template, abort, redirect, url_for, send_file, jsonify
 from flask.ext.login import current_user, login_required
 import urllib
-from copy import deepcopy
 
 from portality import dao
 from portality import models
-from portality.core import app, ssl_required, write_required
+from portality.core import app
+from portality.decorators import ssl_required, write_required, api_key_required
 from portality import blog
 from portality.formcontext import formcontext
 from portality.lcc import lcc_jstree

--- a/portality/view/doajservices.py
+++ b/portality/view/doajservices.py
@@ -1,11 +1,11 @@
 import json, urllib, requests
 
-from flask import Blueprint, abort, make_response, request, abort, url_for
+from flask import Blueprint, make_response, request, abort, url_for
 from flask.ext.login import current_user, login_required
 
-from portality.core import app, ssl_required, write_required
+from portality.core import app
+from portality.decorators import ssl_required, write_required
 from portality.util import jsonp
-
 from portality import lock
 
 blueprint = Blueprint('doajservices', __name__)

--- a/portality/view/editor.py
+++ b/portality/view/editor.py
@@ -1,8 +1,9 @@
-from flask import Blueprint, request, flash, abort, make_response
+from flask import Blueprint, request, flash, abort
 from flask import render_template, redirect, url_for
 from flask.ext.login import current_user, login_required
 
-from portality.core import app, ssl_required, restrict_to_role, write_required
+from portality.core import app
+from portality.decorators import ssl_required, restrict_to_role, write_required
 from portality import models
 
 from portality import lock

--- a/portality/view/publisher.py
+++ b/portality/view/publisher.py
@@ -2,7 +2,8 @@ from flask import Blueprint, request, send_from_directory
 from flask import render_template, abort, redirect, url_for, flash
 from flask.ext.login import current_user, login_required
 
-from portality.core import app, ssl_required, restrict_to_role, write_required
+from portality.core import app
+from portality.decorators import ssl_required, restrict_to_role, write_required
 
 from portality import models, article
 from portality.view.forms import ArticleForm


### PR DESCRIPTION
for API issue #734:

* added new roles 'user' (top level) and 'api' to allow api access
* added 'api_key' to Account model
* updated account creation to give api role and set api_key by default
* added new decorator for checking requests have active api_key
* updated readme to include new fields in data model
* new tests for api account
* refactored decorators out of portality.core to avoid circular import (including ssl_required etc)
* tidied up some imports
* updated an outdated function call in core.py