### PR TITLE
[hotfix] make continuations work with ToC pages

### DIFF
--- a/portality/models/journal.py
+++ b/portality/models/journal.py
@@ -1085,6 +1085,14 @@ class JournalBibJSON(GenericBibJSON):
     @publication_time.setter
     def publication_time(self, weeks): self.bibjson["publication_time"] = weeks
 
+    # to help with ToC - we prefer to refer to a journal by E-ISSN, or
+    # if not, then P-ISSN
+    def get_preferred_issn(self):
+        issn = self.get_one_identifier(self.E_ISSN)
+        if not issn:
+            issn = self.get_one_identifier(self.P_ISSN)
+        return issn
+
 class JournalQuery(object):
     """
     wrapper around the kinds of queries we want to do against the journal type

--- a/portality/templates/doaj/toc.html
+++ b/portality/templates/doaj/toc.html
@@ -366,7 +366,7 @@
 <div class="row-fluid">
   <div class="span12" style="margin-bottom:10px;padding-bottom:5px;">
     {% for v in volumes %}
-        <a class="bjsr volume btn{% if current_volume == v %} btn-info{% else %} btn-doaj{% endif %}" id="vol_{{v}}" href="{{url_for('doaj.toc', identifier=journal.toc_id, volume=v)}}">{{v}}</a>
+        <a class="bjsr volume btn{% if current_volume == v %} btn-info{% else %} btn-doaj{% endif %}" id="vol_{{v}}" href="{{url_for('doaj.toc', identifier=bibjson.get_preferred_issn(), volume=v)}}">{{v}}</a>
     {% endfor %}
   </div>
 </div>
@@ -376,7 +376,7 @@
 <div class="row-fluid">
   <div class="span12" style="margin-bottom:10px;padding-bottom:5px;" id="issuelist">
     {% for i in issues %}
-        <a class="bjsr issue btn{% if current_issue == i %} btn-info{% else %} btn-doaj{% endif %}" id="issue_{{i}}" href="{{url_for('doaj.toc', identifier=journal.toc_id, volume=current_volume)}}/{{i}}">{{i}}</a>
+        <a class="bjsr issue btn{% if current_issue == i %} btn-info{% else %} btn-doaj{% endif %}" id="issue_{{i}}" href="{{url_for('doaj.toc', identifier=bibjson.get_preferred_issn(), volume=current_volume)}}/{{i}}">{{i}}</a>
     {% endfor %}
   </div>
 </div>
@@ -420,7 +420,7 @@ $(document).ready(function() {
     
     var tidymonth = function(mth) {
         var mths = {
-            "1" : "January", "2" : "February", "3" : "March", "4" : "April", "5" : "May", "6" : "June", "7" : "July", "8" : "August", "9" : "September", "10" : "October", "11" : "November", "12" : "December","01" : "January", "02" : "February", "03" : "March", "04" : "April", "05" : "May", "06" : "June", "07" : "July", "08" : "August", "09" : "September",
+            "1" : "January", "2" : "February", "3" : "March", "4" : "April", "5" : "May", "6" : "June", "7" : "July", "8" : "August", "9" : "September", "10" : "October", "11" : "November", "12" : "December","01" : "January", "02" : "February", "03" : "March", "04" : "April", "05" : "May", "06" : "June", "07" : "July", "08" : "August", "09" : "September"
         }
         return mths[mth];
     }
@@ -430,36 +430,13 @@ $(document).ready(function() {
         if (issuelist !== undefined ) {
             var isscontent = '';
             for ( var i in issuelist ) {
-                isscontent += '<a class="bjsr issue btn btn-doaj" id="issue_' + issuelist[i] + '" href="/toc/{{bibjson.issns()[0]}}/' + $('#volumeid').html() + '/' + issuelist[i] + '">' + issuelist[i] + '</a> ';
+                isscontent += '<a class="bjsr issue btn btn-doaj" id="issue_' + issuelist[i] + '" href="/toc/{{bibjson.get_preferred_issn()}}/' + $('#volumeid').html() + '/' + issuelist[i] + '">' + issuelist[i] + '</a> ';
             }
             $('#issuelist').html(isscontent);
             $('.bjsr.issue').first().removeClass('btn-doaj').addClass('btn-info');
             $('.bjsr.issue').bind('click',bjsr);
         }
-        /*var als = [];
-        var sa = {};
-        keys = [];
-        var nsa = [];
-        // sort the article list by start_page if present
-        for ( var c in data.articles ) {
-            if ( "bibjson.start_page" in data.articles[c] ) {
-                if ( data.articles[c]["bibjson.start_page"].length > 0 ) {
-                    sa[data.articles[c]["bibjson.start_page"]] = data.articles[c];
-                    keys.push(data.articles[c]["bibjson.start_page"]);
-                } else {
-                    nsa.push(data.articles[c]);
-                }
-            } else {
-                nsa.push(data.articles[c]);
-            }
-        }
-        function sortNumber(a,b) { return a - b; }
-        keys.sort(sortNumber);
-        for ( var i = 0; i < keys.length; i++ ) {
-            k = keys[i];
-            als.push(sa[k]);
-        }
-        var articlelist = als.concat(nsa)*/
+
         // put the articles on the page
         for (var a in data.articles) {
             var artcl = data.articles[a];

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -159,8 +159,6 @@ def toc(identifier=None, volume=None, issue=None):
         issn_ref = True     # just a flag so we can check if we were requested via issn
     else:
         journal = models.Journal.pull(identifier)
-        if journal is None:
-            abort(404)
 
     if journal is None:
         abort(404)
@@ -188,11 +186,11 @@ def toc(identifier=None, volume=None, issue=None):
         if issn_ref:  # the journal is referred to by an ISSN
 
             # if there is an E-ISSN (and it's not the one in the request), redirect to it
-            # if not, but there is a P-ISSN (and it's not the one in the request), redirect to the P-ISSN
             eissn = bibjson.get_one_identifier(bibjson.E_ISSN)
             if eissn and identifier != eissn:
                     return redirect(url_for('doaj.toc', identifier=eissn, volume=volume, issue=issue), 301)
-            
+
+            # if there's no E-ISSN, but there is a P-ISSN (and it's not the one in the request), redirect to the P-ISSN
             if not eissn:
                 pissn = bibjson.get_one_identifier(bibjson.P_ISSN)
                 if pissn and identifier != pissn:
@@ -243,7 +241,7 @@ def toc(identifier=None, volume=None, issue=None):
     if bjsr:
         res = {"articles": articles}
         if bjsri: res["issues"] = all_issues
-        resp = make_response( json.dumps(res) )
+        resp = make_response(json.dumps(res))
         resp.mimetype = "application/json"
         return resp
     else:


### PR DESCRIPTION
# HOTFIX, do not merge here!

Fix #696 . Do not rely on information in the journal, rely on the bibjson. Continuations code currently replaces the bibjson when it finds a continuation, not the journal object (bad conceptually - that's what led to this long-standing bug - but the only thing that can be done if continuations are not "proper" journal objects, which will happen later this year).