### PR TITLE
prepare final version of discovery API docs sans applications

### DIFF
--- a/portality/app.py
+++ b/portality/app.py
@@ -214,9 +214,9 @@ if 'api' in app.config['FEATURES']:
             {
                 'api_versions': [
                     {
-                        'version': '0.0.1',
-                        'base_url': url_for('api_v1.list_operations', _external=True),
-                        'note': 'First version of the DOAJ API (IN DEVELOPMENT DO NOT USE!)',
+                        'version': '1.0.0',
+                        'base_url': url_for('api_v1.api_spec', _external=True),
+                        'note': 'First version of the DOAJ API',
                         'docs_url': url_for('api_v1.docs', _external=True)
                     }
                 ]

--- a/portality/static/doaj/css/doaj_api.css
+++ b/portality/static/doaj/css/doaj_api.css
@@ -1,3 +1,7 @@
+em {
+    font-style: italic;
+}
+
 body.swagger-section {
     padding-top: 1em;
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
@@ -21,6 +25,23 @@ footer {
     font-weight: normal;
 }
 
-.swagger-section .swagger-ui-wrap .markdown ol {
+
+.swagger-section .swagger-ui-wrap ol {
     list-style-type: decimal;
+}
+
+#extra-docs > ul {
+    list-style: disc inside;
+}
+
+#extra-docs > ul > li {
+    margin-bottom: 0.3em;
+}
+
+ul.options {
+    font-size: 125%;
+}
+
+#api_info {
+    line-height: 150%;
 }

--- a/portality/static/doaj/css/doaj_api.css
+++ b/portality/static/doaj/css/doaj_api.css
@@ -12,3 +12,15 @@ footer {
     margin-top: 2em;
     margin-bottom: 1em;
 }
+
+#swagger-ui-container #resources_container > .footer > h4 {
+    display: none;
+}
+
+.search-query-docs {
+    font-weight: normal;
+}
+
+.swagger-section .swagger-ui-wrap .markdown ol {
+    list-style-type: decimal;
+}

--- a/portality/templates/doaj/api_docs.html
+++ b/portality/templates/doaj/api_docs.html
@@ -37,10 +37,12 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = current_scheme + '//' + current_domain + "/api/v1/spec";
+        url = current_scheme + '//' + current_domain + "/api/v1";
       }
       window.swaggerUi = new SwaggerUi({
         url: url,
+        validatorUrl: null,
+        docExpansion: 'list',
         dom_id: "swagger-ui-container",
         supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
         onComplete: function(swaggerApi, swaggerUi){
@@ -56,12 +58,11 @@
             hljs.highlightBlock(e)
           });
 
-          addApiKeyAuthorization();
+          //addApiKeyAuthorization();
         },
         onFailure: function(data) {
           log("Unable to Load SwaggerUI");
         },
-        docExpansion: "none",
         apisSorter: "alpha",
         showRequestHeaders: false
       });

--- a/portality/templates/doaj/api_docs.html
+++ b/portality/templates/doaj/api_docs.html
@@ -14,6 +14,95 @@
 {% block content %}
 <body class="swagger-section">
 <div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+<div id="extra-docs" class="swagger-ui-wrap">
+
+    <h2 id="search_api">Search API</h2>
+
+    <h3 id="specific_field_search">Searching inside a specific field</h3>
+
+    <p>When you are querying on a specific field you can use the json dot notation used by Elasticsearch, so for example to access the journal title of an article, you could use
+        <pre>bibjson.journal.title:"Journal of Science"</pre>
+    </p>
+
+    <p>Note that all fields are analysed, which means that the above search does not look for the exact string "Journal of Science". To do that, add ".exact" to any string field (not date or number fields) to match the exact contents:</p>
+                <pre>bibjson.journal.title.exact:"Journal of Science"</pre>
+    </p>
+
+
+
+    <h3 id="special_characters">Special characters</h3>
+    <p></p>All forward slash <code>/</code> characters will be automatically escaped for you unless you escape them yourself. This means any forward slashes <code>/</code> will become <code>\/</code> which ends up encoded as <code>%5C/</code> in a URL since a "naked" backslash <code>\</code> is not allowed in a URL. So you can search for a DOI by giving the articles endpoint either of the following queries (they will give you the same results):
+
+<pre>
+doi:10.3389/fpsyg.2013.00479
+doi:10.3389%5C/fpsyg.2013.00479
+</pre>
+    </p>
+
+
+
+    <h3 id="short_field_names">Short field names</h3>
+    <p>For convenience we also offer shorter field names for you to use when querying. Note that <em>you cannot use the ".exact" notation mentioned above on these substitutions</em>.</p>
+
+    <p>The substitutions for journals are as follows:<br>
+        <ul>
+            <li>title - search within the journal's title</li>
+            <li>issn - the journal's issn</li>
+            <li>publisher - the journal's publisher (not exact match)</li>
+            <li>license - the exact licence</li>
+        </ul>
+    </p>
+
+    <p>The substitutions for articles are as follows:<br>
+        <ul>
+            <li>title - search within the article title</li>
+            <li>doi - the article's doi</li>
+            <li>issn - the article's journal's issn</li>
+            <li>publisher - the article's journal's publisher (not exact match)</li>
+            <li>abstract - search within the article abstract</li>
+        </ul>
+    </p>
+
+
+
+    <h3 id="sorting">Sorting of results</h3>
+
+    <p>Each request can take a "sort" url parameter, which can be of the form of one of:</p>
+
+<pre>
+sort=field
+sort=field:direction
+</pre>
+
+    <p>The field again uses the dot notation.</p>
+
+    <p>If specifying the direction, it must be one of "asc" or "desc". If no direction is supplied then "asc" is used.</p>
+
+    <p>So for example</p>
+
+<pre>
+sort=bibjson.title
+sort=bibjson.title:desc
+</pre>
+
+    <p>Note that for fields which may contain multiple values (i.e. arrays), the sort will use the "smallest" value in that field to sort by (depending on the definition of "smallest" for that field type)</p>
+
+
+
+    <h3 id="query_string_advanced_usage">The query string - advanced usage</h3>
+
+    <p>The format of the query part of the URL is that of a Lucene query string, as documented here: <a href="https://lucene.apache.org/core/2_9_4/queryparsersyntax.html">https://lucene.apache.org/core/2_9_4/queryparsersyntax.html</a></p>
+
+    <p>Some of the Lucene query syntax <strong>has been disabled</strong> in order to prevent queries which may damage performance.  The disabled features are:</p>
+
+    <ol>
+        <li><p>Wildcard searches.  You may not put a * into a query string: <a href="http://lucene.apache.org/core/5_2_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Wildcard_Searches">http://lucene.apache.org/core/5_2_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Wildcard_Searches</a></p></li>
+        <li><p>Regular expression searches.  You may not put an expression between two forward slashes <code>/regex/</code> into a query string: <a href="http://lucene.apache.org/core/5_2_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Regexp_Searches">http://lucene.apache.org/core/5_2_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Regexp_Searches</a>. This is done both for performance reasons and because of the escaping of forward slashes <code>/</code> <a href="#special_characters">described above.</a></p></li>
+        <li><p>Fuzzy Searches.  You may not use the ~ notation: <a href="http://lucene.apache.org/core/5_2_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Fuzzy_Searches">http://lucene.apache.org/core/5_2_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Fuzzy_Searches</a></p></li>
+        <li><p>Proximity Searches. <a href="http://lucene.apache.org/core/5_2_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Proximity_Searches">http://lucene.apache.org/core/5_2_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Proximity_Searches</a></p></li>
+    </ol>
+
+</div>
 </body>
 {% endblock %}
 

--- a/portality/view/api_v1.py
+++ b/portality/view/api_v1.py
@@ -11,24 +11,70 @@ import json
 
 blueprint = Blueprint('api_v1', __name__)
 
-@blueprint.route('/spec')
+API_VERSION_NUMBER = '1.0.0'
+
+@blueprint.route('/')
 def api_spec():
     swag = swagger(app)
     swag['info']['title'] = "DOAJ API documentation"
-    swag['info']['description'] = "This page documents the first version of the DOAJ API."
+    # TODO use a Jinja template for the description below, HTML works. Emails use jinja templates already.
+    swag['info']['description'] = """
+<p>This page documents the first version of the DOAJ API, v.{api_version}</p>
+<p>Base URL: <a href="{base_url}" target="_blank">{base_url}</a></p>
+<a name="api_desc_search_api" id="api_desc_search_api"></a>
+
+<h2>Search API</h2>
+
+<h3>Friendly field names</h3>
+
+<p>When you are querying on a specific field you can use the json dot notation used by Elasticsearch, so for example to access the journal title of an article, you could use
+            <pre>bibjson.journal.title:"Journal of Science"</pre>
+
+<p>Note that all fields are analysed, which means that the above search does not look for the exact string "Journal of Science". To do that, add ".exact" to any string field (not date or number fields) to match the exact contents:</p>
+            <pre>bibjson.journal.title.exact:"Journal of Science"</pre>
+</p>
+
+<h3>The query string - advanced usage</h3>
+
+<p>The format of the query part of the URL is that of a Lucene query string, as documented here: <a href="https://lucene.apache.org/core/2_9_4/queryparsersyntax.html">https://lucene.apache.org/core/2_9_4/queryparsersyntax.html</a></p>
+
+<p>Some of the lucene query syntax has been disabled in order to prevent queries which may damage performance.  The disabled features are:</p>
+
+<ol>
+<li><p>Wildcard searches.  You may not put a * into a query string: <a href="https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Wildcard Searches">https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Wildcard Searches</a></p></li>
+<li><p>Fuzzy Searches.  You may not use the ~ notation: <a href="https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Fuzzy Searches">https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Fuzzy Searches</a></p></li>
+<li><p>Proximity Searches. <a href="https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Proximity Searches">https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Proximity Searches</a></p></li>
+</ol>
+
+<h3>Sorting of results</h3>
+
+<p>Each request can take a "sort" url parameter, which can be of the form of one of:</p>
+
+<pre>
+sort=field
+sort=field:direction
+</pre>
+
+<p>The field again uses the dot notation.</p>
+
+<p>If specifying the direction, it must be one of "asc" or "desc". If no direction is supplied then "asc" is used.</p>
+
+<p>So for example</p>
+
+<pre>
+sort=bibjson.title
+sort=bibjson.title:desc
+</pre>
+
+<p>Note that for fields which may contain multiple values (i.e. arrays), the sort will use the "smallest" value in that field to sort by (depending on the definition of "smallest" for that field type)</p>
+
+""".format(
+        api_version=API_VERSION_NUMBER,
+        base_url=url_for('.api_spec', _external=True)
+    )
+    swag['info']['version'] = API_VERSION_NUMBER
 
     return make_response((jsonify(swag), 200, {'Access-Control-Allow-Origin': '*'}))
-
-@blueprint.route('/')
-def list_operations():
-    # todo use reflection or something
-    return jsonify({'available_operations': [
-        {
-            'description': "Search for journals and articles",
-            'base_url': request.base_url + 'search',
-            'docs_url': url_for('.docs', _anchor='search', _external=True)
-        }
-    ]})
 
 @blueprint.route('/docs')
 def docs():
@@ -38,7 +84,7 @@ def docs():
 @api_key_required
 def search_applications(search_query):
     """
-    Search your applications
+    Search your applications [Authenticated, not public]
     ---
     tags:
       - search
@@ -51,22 +97,22 @@ def search_applications(search_query):
         type: "string"
       -
         name: "page"
-        in: "body":
+        in: "query"
         required: false
-        type: "int"
+        type: "integer"
       -
         name: "pageSize"
-        in: "body"
-        required: false,
-        type: "int"
+        in: "query"
+        required: false
+        type: "integer"
       -
         name: "sort"
-        in: "body"
+        in: "query"
         required: false
         type: "string"
       -
         name: "api_key"
-        in: "body"
+        in: "query"
         required: true
         type: "string"
     responses:
@@ -110,22 +156,53 @@ def search_journals(search_query):
     parameters:
       -
         name: search_query
-        description: What you are searching for, e.g. computers
+        description:
+            <div class="search-query-docs">
+            What you are searching for, e.g. computers
+            <br>
+            <br>
+            For convenience we also offer shorter field names for you to use when querying. Note that you cannot use the ".exact" notation mentioned above on these substitutions. The substitutions for articles are as follows:<br>
+            <ul>
+            <li>title - search within the journal's title</li>
+            <li>issn - the journal's issn</li>
+            <li>publisher - the journal's publisher (not exact match)</li>
+            <li>license - the exact licence</li>
+            </ul>
+            E.g. you can search for
+            <pre>issn:1874-9496</pre>
+            <pre>license:CC-BY</pre>
+            </div>
         in: path
         required: true
         type: string
       -
         name: page
         description: Which page of the results you wish to see.
-        in: path
+        in: query
         required: false
         type: integer
       -
         name: pageSize
-        description: How many results per page you wish to see, the default is 100.
-        in: path
+        description: How many results per page you wish to see, the default is 10.
+        in: query
         required: false
         type: integer
+      -
+        name: "sort"
+        in: "query"
+        description:
+            <div>
+            Substitutions are also available here for convenience
+            <ul>
+            <li>title - order by the normalised, unpunctuated version of the title</li>
+            <li>issn - sort by issn</li>
+            </ul>
+            For example
+            <pre>title:asc</pre>
+            <pre>issn:desc</pre>
+            </div>
+        required: false
+        type: "string"
     responses:
       200:
         schema:
@@ -219,7 +296,7 @@ def search_journals(search_query):
                           properties:
                             code:
                               type: string
-                            terms:
+                            term:
                               type: string
                             scheme:
                               type: string
@@ -252,7 +329,6 @@ def search_journals(search_query):
     except:
         return bad_request("Page size was not an integer")
 
-    results = None
     try:
         results = DiscoveryApi.search_journals(search_query, page, psize, sort)
     except DiscoveryException as e:
@@ -271,26 +347,52 @@ def search_articles(search_query):
     parameters:
       -
         name: search_query
-        description: What you are searching for, e.g. computers
+        description:
+            <div class="search-query-docs">
+            What you are searching for, e.g. computers
+            <br>
+            <br>
+            For convenience we also offer shorter field names for you to use when querying. Note that you cannot use the ".exact" notation mentioned above on these substitutions. The substitutions for articles are as follows:<br>
+            <ul>
+            <li>title - search within the article title</li>
+            <li>doi - the article's doi</li>
+            <li>issn - the article's journal's issn</li>
+            <li>publisher - the article's journal's publisher (not exact match)</li>
+            <li>abstract - search within the article abstract</li>
+            </ul>
+            E.g. you can search for
+            <pre>doi:10.3389/fpsyg.2013.00479</pre>
+            <pre>title:hydrostatic pressure</pre>
+            </div>
         in: path
         required: true
         type: string
       -
         name: page
         description: Which page of the results you wish to see.
-        in: path
+        in: query
         required: false
         type: integer
       -
-        name: "pageSize"
-        in: "body"
-        required: false,
-        type: "int"
+        name: pageSize
+        description: How many results per page you wish to see, the default is 10.
+        in: query
+        required: false
+        type: integer
       -
-        name: "sort"
-        in: "body"
-        required: false,
-        type: "string"
+        name: sort
+        description:
+            <div>
+            Substitutions are also available here for convenience
+            <ul>
+            <li>title - order by the normalised, unpunctuated version of the title</li>
+            </ul>
+            For example
+            <pre>title:asc</pre>
+            </div>
+        in: query
+        required: false
+        type: string
     responses:
       200:
         schema:
@@ -400,7 +502,7 @@ def search_articles(search_query):
                           properties:
                             code:
                               type: string
-                            terms:
+                            term:
                               type: string
                             scheme:
                               type: string

--- a/portality/view/api_v1.py
+++ b/portality/view/api_v1.py
@@ -21,56 +21,15 @@ def api_spec():
     swag['info']['description'] = """
 <p>This page documents the first version of the DOAJ API, v.{api_version}</p>
 <p>Base URL: <a href="{base_url}" target="_blank">{base_url}</a></p>
-<a name="api_desc_search_api" id="api_desc_search_api"></a>
+<h2 id="intro">Using this live documentation page</h2>
+This page contains a list of all routes available via the DOAJ API. It also serves as a live demo page. You can fill in the parameters needed by the API and it will construct and send a request to the live API for you, letting you see all the details you might need for your integration. Further information on advanced usage of the routes is available at the bottom below the route list.
 
-<h2>Search API</h2>
-
-<h3>Friendly field names</h3>
-
-<p>When you are querying on a specific field you can use the json dot notation used by Elasticsearch, so for example to access the journal title of an article, you could use
-            <pre>bibjson.journal.title:"Journal of Science"</pre>
-
-<p>Note that all fields are analysed, which means that the above search does not look for the exact string "Journal of Science". To do that, add ".exact" to any string field (not date or number fields) to match the exact contents:</p>
-            <pre>bibjson.journal.title.exact:"Journal of Science"</pre>
-</p>
-
-<h3>The query string - advanced usage</h3>
-
-<p>The format of the query part of the URL is that of a Lucene query string, as documented here: <a href="https://lucene.apache.org/core/2_9_4/queryparsersyntax.html">https://lucene.apache.org/core/2_9_4/queryparsersyntax.html</a></p>
-
-<p>Some of the lucene query syntax has been disabled in order to prevent queries which may damage performance.  The disabled features are:</p>
-
-<ol>
-<li><p>Wildcard searches.  You may not put a * into a query string: <a href="https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Wildcard Searches">https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Wildcard Searches</a></p></li>
-<li><p>Fuzzy Searches.  You may not use the ~ notation: <a href="https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Fuzzy Searches">https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Fuzzy Searches</a></p></li>
-<li><p>Proximity Searches. <a href="https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Proximity Searches">https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Proximity Searches</a></p></li>
-</ol>
-
-<h3>Sorting of results</h3>
-
-<p>Each request can take a "sort" url parameter, which can be of the form of one of:</p>
-
-<pre>
-sort=field
-sort=field:direction
-</pre>
-
-<p>The field again uses the dot notation.</p>
-
-<p>If specifying the direction, it must be one of "asc" or "desc". If no direction is supplied then "asc" is used.</p>
-
-<p>So for example</p>
-
-<pre>
-sort=bibjson.title
-sort=bibjson.title:desc
-</pre>
-
-<p>Note that for fields which may contain multiple values (i.e. arrays), the sort will use the "smallest" value in that field to sort by (depending on the definition of "smallest" for that field type)</p>
-
+<h2 id="intro_auth">Authenticated routes</h2>
+<p>Note that some routes require authentication and are only available to publishers who submit data to DOAJ or other collaborators who integrate more closely with DOAJ. If you think you could benefit from integrating more closely with DOAJ by using these routes, please <a href="{contact_us_url}">contact us</a>.</p>
 """.format(
         api_version=API_VERSION_NUMBER,
-        base_url=url_for('.api_spec', _external=True)
+        base_url=url_for('.api_spec', _external=True),
+        contact_us_url=url_for('doaj.contact')
     )
     swag['info']['version'] = API_VERSION_NUMBER
 
@@ -84,7 +43,7 @@ def docs():
 @api_key_required
 def search_applications(search_query):
     """
-    Search your applications [Authenticated, not public]
+    Search your applications <span class="red">[Authenticated, not public]</span>
     ---
     tags:
       - search
@@ -161,16 +120,13 @@ def search_journals(search_query):
             What you are searching for, e.g. computers
             <br>
             <br>
-            For convenience we also offer shorter field names for you to use when querying. Note that you cannot use the ".exact" notation mentioned above on these substitutions. The substitutions for articles are as follows:<br>
-            <ul>
-            <li>title - search within the journal's title</li>
-            <li>issn - the journal's issn</li>
-            <li>publisher - the journal's publisher (not exact match)</li>
-            <li>license - the exact licence</li>
-            </ul>
-            E.g. you can search for
+            You can search inside any field you see in the results or the schema. <a href="#specific_field_search">More details</a>
+            <br>
+            For example, to search for all journals tagged with the keyword "heritage"
+            <pre>bibjson.keywords:heritage</pre>
+            <a href="#short_field_names">Short-hand names are available</a> for some fields
             <pre>issn:1874-9496</pre>
-            <pre>license:CC-BY</pre>
+            <pre>publisher:dove</pre>
             </div>
         in: path
         required: true
@@ -352,16 +308,14 @@ def search_articles(search_query):
             What you are searching for, e.g. computers
             <br>
             <br>
-            For convenience we also offer shorter field names for you to use when querying. Note that you cannot use the ".exact" notation mentioned above on these substitutions. The substitutions for articles are as follows:<br>
-            <ul>
-            <li>title - search within the article title</li>
-            <li>doi - the article's doi</li>
-            <li>issn - the article's journal's issn</li>
-            <li>publisher - the article's journal's publisher (not exact match)</li>
-            <li>abstract - search within the article abstract</li>
-            </ul>
-            E.g. you can search for
+            You can search inside any field you see in the results or the schema. <a href="#specific_field_search">More details</a>
+            <br>
+            For example, to search for all articles with abstracts containing the word "shadow"
+            <pre>bibjson.abstract:"shadow"</pre>
+            <a href="#short_field_names">Short-hand names are available</a> for some fields
             <pre>doi:10.3389/fpsyg.2013.00479</pre>
+            <pre>issn:1874-9496</pre>
+            <pre>license:CC-BY</pre>
             <pre>title:hydrostatic pressure</pre>
             </div>
         in: path

--- a/portality/view/api_v1.py
+++ b/portality/view/api_v1.py
@@ -22,7 +22,7 @@ def api_spec():
 <p>This page documents the first version of the DOAJ API, v.{api_version}</p>
 <p>Base URL: <a href="{base_url}" target="_blank">{base_url}</a></p>
 <h2 id="intro">Using this live documentation page</h2>
-This page contains a list of all routes available via the DOAJ API. It also serves as a live demo page. You can fill in the parameters needed by the API and it will construct and send a request to the live API for you, letting you see all the details you might need for your integration. Further information on advanced usage of the routes is available at the bottom below the route list.
+This page contains a list of all routes available via the DOAJ API. It also serves as a live demo page. You can fill in the parameters needed by the API and it will construct and send a request to the live API for you, letting you see all the details you might need for your integration. Please note that not all fields will be available on all records. Further information on advanced usage of the routes is available at the bottom below the route list.
 
 <h2 id="intro_auth">Authenticated routes</h2>
 <p>Note that some routes require authentication and are only available to publishers who submit data to DOAJ or other collaborators who integrate more closely with DOAJ. If you think you could benefit from integrating more closely with DOAJ by using these routes, please <a href="{contact_us_url}">contact us</a>.</p>
@@ -47,36 +47,299 @@ def search_applications(search_query):
     ---
     tags:
       - search
-    description: "Search your applications to the DOAJ"
     parameters:
       -
-        name: "search_query"
-        in: "path"
+        name: api_key
+        description: <div class="search-query-docs"> Go to the top right of the page and click your username. If you have generated an API key already, it will appear under your name. If not, click the Generate API Key button. Accounts are not available to the public. <a href="#intro_auth">More details</a></div>
+        in: query
         required: true
-        type: "string"
+        type: string
       -
-        name: "page"
-        in: "query"
-        required: false
-        type: "integer"
-      -
-        name: "pageSize"
-        in: "query"
-        required: false
-        type: "integer"
-      -
-        name: "sort"
-        in: "query"
-        required: false
-        type: "string"
-      -
-        name: "api_key"
-        in: "query"
+        name: search_query
+        description:
+            <div class="search-query-docs">
+            What you are searching for, e.g. computers
+            <br>
+            <br>
+            You can search inside any field you see in the results or the schema. <a href="#specific_field_search">More details</a>
+            <br>
+            For example, to search for all journals tagged with the keyword "heritage"
+            <pre>bibjson.keywords:heritage</pre>
+            <a href="#short_field_names">Short-hand names are available</a> for some fields
+            <pre>issn:1874-9496</pre>
+            <pre>publisher:dove</pre>
+            </div>
+        in: path
         required: true
-        type: "string"
+        type: string
+      -
+        name: page
+        description: Which page of the results you wish to see.
+        in: query
+        required: false
+        type: integer
+      -
+        name: pageSize
+        description: How many results per page you wish to see, the default is 10.
+        in: query
+        required: false
+        type: integer
+      -
+        name: sort
+        in: query
+        description:
+            <div>
+            Substitutions are also available here for convenience
+            <ul>
+            <li>title - order by the normalised, unpunctuated version of the title</li>
+            <li>issn - sort by issn</li>
+            </ul>
+            For example
+            <pre>title:asc</pre>
+            <pre>issn:desc</pre>
+            </div>
+        required: false
+        type: string
     responses:
       200:
-        description: Search results
+        schema:
+          title: Journal search
+          properties:
+            pageSize:
+              type: integer
+            timestamp:
+              type: string
+              format: dateTime
+            results:
+              type: array
+              items:
+                type: object
+                title: Journal
+                properties:
+                  last_updated:
+                    type: string
+                    format: dateTime
+                  id:
+                    type: string
+                  bibjson:
+                    type: object
+                    title: bibjson
+                    properties:
+                      publisher:
+                        type: string
+                      author_pays:
+                        type: string
+                      license:
+                        type: array
+                        items:
+                          type: object
+                          title: license
+                          properties:
+                            title:
+                              type: string
+                            url:
+                              type: string
+                            NC:
+                              type: boolean
+                            ND:
+                              type: boolean
+                            embedded_example_url:
+                              type: string
+                            SA:
+                              type: boolean
+                            type:
+                              type: string
+                            BY:
+                              type: boolean
+                      title:
+                        type: string
+                      alternative_title:
+                        type: string
+                      author_pays_url:
+                        type: string
+                      country:
+                        type: string
+                      link:
+                        type: array
+                        items:
+                          type: object
+                          title: link
+                          properties:
+                            url:
+                              type: string
+                            type:
+                              type: string
+                      provider:
+                        type: string
+                      institution:
+                        type: string
+                      keywords:
+                        type: array
+                        items:
+                            type: string
+                      oa_start:
+                        type: object
+                        title: oa_start
+                        properties:
+                          year:
+                            type: string
+                          volume:
+                            type: string
+                          number:
+                            type: string
+                      oa_end:
+                        type: object
+                        title: oa_end
+                        properties:
+                          year:
+                            type: string
+                          volume:
+                            type: string
+                          number:
+                            type: string
+                      apc_url:
+                        type: string
+                      apc:
+                        type: object
+                        title: apc
+                        properties:
+                          currency:
+                            type: string
+                          average_price:
+                            type: string
+                      submission_charges_url:
+                        type: string
+                      submission_charges:
+                        type: object
+                        title: apc
+                        properties:
+                          currency:
+                            type: string
+                          average_price:
+                            type: string
+                      archiving_policy:
+                        type: object
+                        title: archiving_policy
+                        properties:
+                          policy:
+                            type: array
+                            items:
+                              type: string
+                          url:
+                            type: string
+                      editorial_review:
+                        type: object
+                        title: editorial_review
+                        properties:
+                          process:
+                            type: string
+                          url:
+                            type: string
+                      plagiarism_detection:
+                        type: object
+                        title: plagiarism_detection
+                        properties:
+                          detection:
+                            type: boolean
+                          url:
+                            type: string
+                      article_statistics:
+                        type: object
+                        title: article_statistics
+                        properties:
+                          statistics:
+                            type: boolean
+                          url:
+                            type: string
+                      deposit_policy:
+                        type: array
+                        items:
+                          type: string
+                      author_copyright:
+                        type: object
+                        title: author_copyright
+                        properties:
+                          copyright:
+                            type: string
+                          url:
+                            type: string
+                      author_publishing_rights:
+                        type: object
+                        title: author_publishing_rights
+                        properties:
+                          publishing_rights:
+                            type: string
+                          url:
+                            type: string
+                      identifier:
+                        type: array
+                        items:
+                          type: object
+                          title: identifier
+                          properties:
+                            type:
+                              type: string
+                            id:
+                              type: string
+                      allows_fulltext_indexing:
+                        type: boolean
+                      persistent_identifier_scheme:
+                        type: array
+                        items:
+                          type: string
+                      format:
+                        type: array
+                        items:
+                          type: string
+                      publication_time:
+                        type: string
+                      subject:
+                        type: array
+                        items:
+                          type: object
+                          title: subject
+                          properties:
+                            code:
+                              type: string
+                            term:
+                              type: string
+                            scheme:
+                              type: string
+                  suggestion:
+                    type: object
+                    title: suggestion
+                    properties:
+                      suggester:
+                        type: object
+                        title: suggester
+                        properties:
+                          name:
+                            type: string
+                          email:
+                            type: string
+                      suggested_on:
+                        type: string
+                        format: dateTime
+                      articles_last_year:
+                        type: object
+                        title: articles_last_year
+                        properties:
+                          count:
+                            type: string
+                          url:
+                            type: string
+                      article_metadata:
+                        type: boolean
+
+                  created_date:
+                    type: string
+                    format: dateTime
+            query:
+              type: string
+            total:
+              type: integer
+            page:
+              type: integer
       400:
         description: Bad Request
     """
@@ -144,8 +407,8 @@ def search_journals(search_query):
         required: false
         type: integer
       -
-        name: "sort"
-        in: "query"
+        name: sort
+        in: query
         description:
             <div>
             Substitutions are also available here for convenience
@@ -158,7 +421,7 @@ def search_journals(search_query):
             <pre>issn:desc</pre>
             </div>
         required: false
-        type: "string"
+        type: string
     responses:
       200:
         schema:
@@ -212,6 +475,8 @@ def search_journals(search_query):
                               type: boolean
                       title:
                         type: string
+                      alternative_title:
+                        type: string
                       author_pays_url:
                         type: string
                       country:
@@ -228,12 +493,106 @@ def search_journals(search_query):
                               type: string
                       provider:
                         type: string
+                      institution:
+                        type: string
                       keywords:
                         type: array
                         items:
                             type: string
                       oa_start:
                         type: object
+                        title: oa_start
+                        properties:
+                          year:
+                            type: string
+                          volume:
+                            type: string
+                          number:
+                            type: string
+                      oa_end:
+                        type: object
+                        title: oa_end
+                        properties:
+                          year:
+                            type: string
+                          volume:
+                            type: string
+                          number:
+                            type: string
+                      apc_url:
+                        type: string
+                      apc:
+                        type: object
+                        title: apc
+                        properties:
+                          currency:
+                            type: string
+                          average_price:
+                            type: string
+                      submission_charges_url:
+                        type: string
+                      submission_charges:
+                        type: object
+                        title: apc
+                        properties:
+                          currency:
+                            type: string
+                          average_price:
+                            type: string
+                      archiving_policy:
+                        type: object
+                        title: archiving_policy
+                        properties:
+                          policy:
+                            type: array
+                            items:
+                              type: string
+                          url:
+                            type: string
+                      editorial_review:
+                        type: object
+                        title: editorial_review
+                        properties:
+                          process:
+                            type: string
+                          url:
+                            type: string
+                      plagiarism_detection:
+                        type: object
+                        title: plagiarism_detection
+                        properties:
+                          detection:
+                            type: boolean
+                          url:
+                            type: string
+                      article_statistics:
+                        type: object
+                        title: article_statistics
+                        properties:
+                          statistics:
+                            type: boolean
+                          url:
+                            type: string
+                      deposit_policy:
+                        type: array
+                        items:
+                          type: string
+                      author_copyright:
+                        type: object
+                        title: author_copyright
+                        properties:
+                          copyright:
+                            type: string
+                          url:
+                            type: string
+                      author_publishing_rights:
+                        type: object
+                        title: author_publishing_rights
+                        properties:
+                          publishing_rights:
+                            type: string
+                          url:
+                            type: string
                       identifier:
                         type: array
                         items:
@@ -244,6 +603,18 @@ def search_journals(search_query):
                               type: string
                             id:
                               type: string
+                      allows_fulltext_indexing:
+                        type: boolean
+                      persistent_identifier_scheme:
+                        type: array
+                        items:
+                          type: string
+                      format:
+                        type: array
+                        items:
+                          type: string
+                      publication_time:
+                        type: string
                       subject:
                         type: array
                         items:
@@ -413,9 +784,9 @@ def search_articles(search_query):
                           country:
                             type: string
                           number:
-                            type: integer
+                            type: string
                           volume:
-                            type: integer
+                            type: string
                       author:
                         type: array
                         items:
@@ -429,7 +800,7 @@ def search_articles(search_query):
                             name:
                               type: string
                       month:
-                        type: integer
+                        type: string
                       link:
                         type: array
                         items:
@@ -443,7 +814,7 @@ def search_articles(search_query):
                             content_type:
                               type: string
                       year:
-                        type: integer
+                        type: string
                       keywords:
                         type: array
                         items:
@@ -463,7 +834,7 @@ def search_articles(search_query):
                       abstract:
                         type: string
                       end_page:
-                        type: integer
+                        type: string
                   created_date:
                     type: string
                     format: dateTime


### PR DESCRIPTION
Overall prep of discovery API docs for final release. Only missing thing is applications schema and sort options. Journals and articles routes should be complete and you should not need to refer to github in order to perform a search - all info should be there.

Would be great if you have the time to have a play with the 2 public endpoints @richard-jones @Steven-Eardley @Nimphal . Paging, sorting, searching, shorthand fields were my stops on the happy api bus.

Also overall how does it look / feel? There is now a screenful of text before it gets to the examples - however you can link to a specific live route demo by just opening it (the URL will change and if you share that, it'll scroll past the text). My biggest question is should the text go somehow below the live demos, or is it OK as it is.

When you check out this branch go to http://localhost:5004/api/v1/docs and make sure you have a little bit of data so you get something back (11+ journals and 11+ articles will do).