### PR TITLE
add CRUD API foundation together with journal route notes

### DIFF
--- a/doajtest/unit/test_api_account.py
+++ b/doajtest/unit/test_api_account.py
@@ -5,9 +5,23 @@ from doajtest.helpers import DoajTestCase
 from portality import models
 from portality.core import app
 from portality.app import load_account_for_login_manager
-from portality.decorators import api_key_required
+from portality.decorators import api_key_required, api_key_optional
 
 class TestClient(DoajTestCase):
+    @classmethod
+    def setUpClass(cls):
+        @app.route('/hello')
+        @api_key_required
+        def hello_world():
+            return Response("hello, world!")
+
+        @app.route('/helloopt')
+        @api_key_optional
+        def hello_world_opt():
+            return Response("hello, world!")
+
+        app.testing = True
+        app.login_manager.user_loader(load_account_for_login_manager)
 
     def setUp(self):
         super(TestClient, self).setUp()
@@ -44,7 +58,7 @@ class TestClient(DoajTestCase):
         a1.remove_role('api')
         assert a1.api_key is None
 
-    def test_02_api_decorator(self):
+    def test_02_api_required_decorator(self):
         """test the api_key_required decorator"""
         a1 = models.Account.make_account(username="a1_user", name="a1_name", email="a1@example.com", roles=["user"], associated_journal_ids=[])
         a1_key = a1.api_key
@@ -57,16 +71,6 @@ class TestClient(DoajTestCase):
 
         time.sleep(1)
 
-        app.testing = True
-        # for some reason this wasn't being registered, so do so here
-        app.login_manager.user_loader(load_account_for_login_manager)
-
-        # Create a view to test the wrapper with
-        @app.route('/hello')
-        @api_key_required
-        def hello_world():
-            return Response("hello, world!")
-
         with app.test_client() as t_client:
             # Check the authorised user can access our function, but the unauthorised one can't.
             response_authorised = t_client.get('/hello?api_key=' + a1_key)
@@ -76,4 +80,35 @@ class TestClient(DoajTestCase):
             response_denied = t_client.get('/hello?api_key=' + a2_key)
             assert response_denied.status_code == 401
 
+    def test_03_api_optional_decorator(self):
+        """test the api_key_optional decorator"""
+        a1 = models.Account.make_account(username="a1_user", name="a1_name", email="a1@example.com", roles=["user"], associated_journal_ids=[])
+        a1_key = a1.api_key
+        a1.save()               # a1 has api access
 
+        a2 = models.Account.make_account(username="a2_user", name="a2_name", email="a2@example.com", roles=["user"], associated_journal_ids=[])
+        a2_key = a2.api_key     # user gets the key before access is removed
+        a2.remove_role('api')
+        a2.save()               # a2 does not have api access.
+
+        # There is no a3 - the last test case is just a public call with no API key
+
+        time.sleep(1)
+
+        with app.test_client() as t_client:
+            # Check the authorised user can access our function, but the unauthorised one can't.
+            response_authorised = t_client.get('/helloopt?api_key=' + a1_key)
+            assert response_authorised.data == "hello, world!"
+            assert response_authorised.status_code == 200
+
+            response_denied = t_client.get('/helloopt?api_key=' + a2_key)
+            assert response_denied.status_code == 401
+
+            # also check it's ok to not have a key at all
+            response_authorised2 = t_client.get('/helloopt')
+            assert response_authorised2.data == "hello, world!"
+            assert response_authorised2.status_code == 200
+
+            # but if you do specify a key it needs to exist
+            response_denied2 = t_client.get('/helloopt?api_key=nonexistent_key')
+            assert response_denied2.status_code == 401

--- a/portality/api/v1/__init__.py
+++ b/portality/api/v1/__init__.py
@@ -1,3 +1,5 @@
 from portality.api.v1.common import jsonify_models, bad_request, forbidden, not_found
 
 from portality.api.v1.discovery import DiscoveryApi, DiscoveryException
+
+from portality.api.v1.crud import CrudApi

--- a/portality/api/v1/crud/__init__.py
+++ b/portality/api/v1/crud/__init__.py
@@ -1,0 +1,1 @@
+from portality.api.v1.crud.common import CrudApi

--- a/portality/api/v1/crud/applications.py
+++ b/portality/api/v1/crud/applications.py
@@ -1,0 +1,5 @@
+from portality.api.v1.common import Api
+
+
+class ApplicationsCrudApi(Api):
+    pass

--- a/portality/api/v1/crud/articles.py
+++ b/portality/api/v1/crud/articles.py
@@ -1,0 +1,5 @@
+from portality.api.v1.common import Api
+
+
+class ArticlesCrudApi(Api):
+    pass

--- a/portality/api/v1/crud/common.py
+++ b/portality/api/v1/crud/common.py
@@ -1,0 +1,5 @@
+from portality.api.v1.crud.journals import JournalsCrudApi
+
+
+class CrudApi(JournalsCrudApi):
+    pass

--- a/portality/api/v1/crud/common.py
+++ b/portality/api/v1/crud/common.py
@@ -1,5 +1,7 @@
 from portality.api.v1.crud.journals import JournalsCrudApi
+from portality.api.v1.crud.articles import ArticlesCrudApi
+from portality.api.v1.crud.applications import ApplicationsCrudApi
 
 
-class CrudApi(JournalsCrudApi):
+class CrudApi(JournalsCrudApi, ArticlesCrudApi, ApplicationsCrudApi):
     pass

--- a/portality/api/v1/crud/journals.py
+++ b/portality/api/v1/crud/journals.py
@@ -2,7 +2,8 @@ from portality.api.v1.common import Api
 
 
 class JournalsCrudApi(Api):
-    def __retrieve_journal(self, jid):
+    @classmethod
+    def __retrieve_journal(cls, jid):
         pass
         # fetch the journal from Elasticsearch, make a copy of journal.data
         # remove keys that are never to be returned through the API, regardless
@@ -12,12 +13,14 @@ class JournalsCrudApi(Api):
         # remove these keys: bibjson.active
         # remove everything except bibjson, id, created_date, last_updated
 
-    def retrieve_public_journal(self, jid):
-        j = self.__retrieve_journal(jid)
+    @classmethod
+    def retrieve_public_journal(cls, jid):
+        j = cls.__retrieve_journal(jid)
         # return j
 
-    def retrieve_auth_journal(self, jid, owner):
-        j = self.__retrieve_journal(jid)
+    @classmethod
+    def retrieve_auth_journal(cls, jid, owner):
+        j = cls.__retrieve_journal(jid)
         # check if owner arg above is the same as the journal's owner (see portality.models.Journal for owner property)
         # authenticated owners of a journal are allowed to see journals where .is_in_doaj() == False
         # if yes

--- a/portality/api/v1/crud/journals.py
+++ b/portality/api/v1/crud/journals.py
@@ -1,0 +1,25 @@
+from portality.api.v1.common import Api
+
+
+class JournalsCrudApi(Api):
+    def __retrieve_journal(self, jid):
+        pass
+        # fetch the journal from Elasticsearch, make a copy of journal.data
+        # remove keys that are never to be returned through the API, regardless
+        # if the requester is authenticated or not
+        # return the resulting new dict
+
+        # remove these keys: bibjson.active
+        # remove everything except bibjson, id, created_date, last_updated
+
+    def retrieve_public_journal(self, jid):
+        j = self.__retrieve_journal(jid)
+        # return j
+
+    def retrieve_auth_journal(self, jid, owner):
+        j = self.__retrieve_journal(jid)
+        # check if owner arg above is the same as the journal's owner (see portality.models.Journal for owner property)
+        # authenticated owners of a journal are allowed to see journals where .is_in_doaj() == False
+        # if yes
+        # return j
+        # if not return something to cause 404 Not Found in the view

--- a/portality/decorators.py
+++ b/portality/decorators.py
@@ -23,6 +23,25 @@ def api_key_required(fn):
     return decorated_view
 
 
+def api_key_optional(fn):
+    """ Decorator for API functions, requiring a valid key to find a user """
+    @wraps(fn)
+    def decorated_view(*args, **kwargs):
+        api_key = request.values.get("api_key", None)
+        if api_key:
+            user = Account.pull_by_api_key(api_key)
+            if user is not None:
+                if login_user(user, remember=False):
+                    return fn(*args, **kwargs)
+            # else
+            abort(401)
+
+        # no api key, which is ok
+        return fn(*args, **kwargs)
+
+    return decorated_view
+
+
 def ssl_required(fn):
     """ Decorator for when a view f() should be served only over SSL """
     @wraps(fn)

--- a/portality/decorators.py
+++ b/portality/decorators.py
@@ -24,7 +24,7 @@ def api_key_required(fn):
 
 
 def api_key_optional(fn):
-    """ Decorator for API functions, requiring a valid key to find a user """
+    """ Decorator for API functions, requiring a valid key to find a user if a key is provided. OK if none provided. """
     @wraps(fn)
     def decorated_view(*args, **kwargs):
         api_key = request.values.get("api_key", None)


### PR DESCRIPTION
This contains the CRUD API foundation ref #754 

Some notes have been added as well for @Nimphal and @bg280 to start on.

The overall structure is one of composition: we have a package for the whole CRUD API, and inside that package we have an ApplicationsCrudApi, an ArticleCrudApi and a JournalCrudApi. The ```CrudApi``` which is eventually used by the view and exposed at the top-level (portality.api.v1) simply inherits from those 3 APIs, gaining all their methods in the process.

The whole thing enables:

1. adding new types to CRUD very easily
2. keeping code separate for applications, articles and journals - if we had one CrudApi class it'd be hard to edit and git would also complain a lot when multiple people worked on the one file. And it'd be like 1500 lines long by the end.
3. encapsulation - CrudApi is one object at the end of the day, the view routes are none the wiser to its implementation details. So long as you keep the classmethod names you can write the underlying code in assembly if you want.

@richard-jones @Steven-Eardley FYI and for comments of course!