### PR TITLE
modify CRUD api internals to now expose 3 CRUD API-s with a common parent

### DIFF
--- a/portality/api/v1/__init__.py
+++ b/portality/api/v1/__init__.py
@@ -2,4 +2,4 @@ from portality.api.v1.common import jsonify_models, bad_request, forbidden, not_
 
 from portality.api.v1.discovery import DiscoveryApi, DiscoveryException
 
-from portality.api.v1.crud import CrudApi
+from portality.api.v1.crud import ApplicationsCrudApi, ArticlesCrudApi, JournalsCrudApi

--- a/portality/api/v1/crud/__init__.py
+++ b/portality/api/v1/crud/__init__.py
@@ -1,1 +1,3 @@
-from portality.api.v1.crud.common import CrudApi
+from portality.api.v1.crud.applications import ApplicationsCrudApi
+from portality.api.v1.crud.articles import ArticlesCrudApi
+from portality.api.v1.crud.journals import JournalsCrudApi

--- a/portality/api/v1/crud/applications.py
+++ b/portality/api/v1/crud/applications.py
@@ -1,5 +1,5 @@
-from portality.api.v1.common import Api
+from portality.api.v1.crud.common import CrudApi
 
 
-class ApplicationsCrudApi(Api):
+class ApplicationsCrudApi(CrudApi):
     pass

--- a/portality/api/v1/crud/articles.py
+++ b/portality/api/v1/crud/articles.py
@@ -1,5 +1,5 @@
-from portality.api.v1.common import Api
+from portality.api.v1.crud.common import CrudApi
 
 
-class ArticlesCrudApi(Api):
+class ArticlesCrudApi(CrudApi):
     pass

--- a/portality/api/v1/crud/common.py
+++ b/portality/api/v1/crud/common.py
@@ -1,7 +1,5 @@
-from portality.api.v1.crud.journals import JournalsCrudApi
-from portality.api.v1.crud.articles import ArticlesCrudApi
-from portality.api.v1.crud.applications import ApplicationsCrudApi
+from portality.api.v1.common import Api
 
 
-class CrudApi(JournalsCrudApi, ArticlesCrudApi, ApplicationsCrudApi):
+class CrudApi(Api):
     pass

--- a/portality/api/v1/crud/journals.py
+++ b/portality/api/v1/crud/journals.py
@@ -1,28 +1,25 @@
-from portality.api.v1.common import Api
+from portality.api.v1.crud.common import CrudApi
 
 
-class JournalsCrudApi(Api):
+class JournalsCrudApi(CrudApi):
     @classmethod
-    def __retrieve_journal(cls, jid):
+    def __retrieve(cls, jid):
         pass
-        # fetch the journal from Elasticsearch, make a copy of journal.data
-        # remove keys that are never to be returned through the API, regardless
-        # if the requester is authenticated or not
-        # return the resulting new dict
+        # TODO define task anew based on new API data objects
 
-        # remove these keys: bibjson.active
-        # remove everything except bibjson, id, created_date, last_updated
+        # exclude from response: bibjson.active
+        # include in response: bibjson, id, created_date, last_updated
 
     @classmethod
-    def retrieve_public_journal(cls, jid):
-        j = cls.__retrieve_journal(jid)
+    def retrieve_public(cls, jid):
+        j = cls.__retrieve(jid)
         # return j
 
     @classmethod
-    def retrieve_auth_journal(cls, jid, owner):
-        j = cls.__retrieve_journal(jid)
+    def retrieve_auth(cls, jid, owner):
+        j = cls.__retrieve(jid)
         # check if owner arg above is the same as the journal's owner (see portality.models.Journal for owner property)
         # authenticated owners of a journal are allowed to see journals where .is_in_doaj() == False
         # if yes
         # return j
-        # if not return something to cause 404 Not Found in the view
+        # if not return something or define and raise a custom exception to cause 404 Not Found in the view

--- a/portality/view/api_v1.py
+++ b/portality/view/api_v1.py
@@ -3,7 +3,9 @@ from flask.ext.login import current_user
 
 from flask_swagger import swagger
 
-from portality.api.v1 import DiscoveryApi, DiscoveryException, CrudApi, jsonify_models, bad_request
+from portality.api.v1 import DiscoveryApi, DiscoveryException
+from portality.api.v1 import ApplicationsCrudApi, ArticlesCrudApi, JournalsCrudApi
+from portality.api.v1 import jsonify_models, bad_request
 from portality.core import app
 from portality.decorators import api_key_required, api_key_optional
 
@@ -878,9 +880,9 @@ def search_articles(search_query):
 @blueprint.route('/journals/<jid>')
 def retrieve_journal(jid):
     # depending on current_user being there or not, call one of these
-    j = CrudApi.retrieve_public_journal(jid)
+    j = JournalsCrudApi.retrieve_public(jid)
     # OR
-    j = CrudApi.retrieve_auth_journal(jid, current_user)
+    j = JournalsCrudApi.retrieve_auth(jid, current_user)
 
     return jsonify_models(j)
 


### PR DESCRIPTION
No tests to write/change yet. This changes the CRUD tech design so it fits with what we discussed in the meeting - now you can import an ApplicationsCrudApi, etc. from portality.api.v1 .