### PR TITLE
New data object and Application Create API

### DIFF
--- a/doajtest/fixtures/applications.py
+++ b/doajtest/fixtures/applications.py
@@ -23,6 +23,10 @@ class ApplicationFixtureFactory(object):
     def make_reapp_unicode_source():
         return deepcopy(REAPP2_UNICODE_SOURCE)
 
+    @classmethod
+    def incoming_application(cls):
+        return deepcopy(INCOMING_SOURCE)
+
 APPLICATION_SOURCE = {
     "id" : "abcdefghijk",
     "created_date" : "2000-01-01T00:00:00Z",
@@ -54,6 +58,25 @@ APPLICATION_SOURCE = {
         "editor_group" : "editorgroup",
         "editor" : "associate",
         "seal" : True,
+    }
+}
+
+INCOMING_SOURCE = {
+    "bibjson": deepcopy(JOURNAL_SOURCE['bibjson']),
+    "suggestion" : {
+        "articles_last_year" : {
+            "count" : 16,
+            "url" : "http://articles.last.year"
+        },
+        "article_metadata" : True
+    },
+    "admin" : {
+        "contact" : [
+            {
+                "email" : "contact@email.com",
+                "name" : "Contact Name"
+            }
+        ]
     }
 }
 

--- a/doajtest/fixtures/journals.py
+++ b/doajtest/fixtures/journals.py
@@ -269,9 +269,9 @@ JOURNAL_APIDO_STRUCT = {
     "structs": {
         "admin": {
             "fields": {
-                "in_doaj": {"coerce": "bool", "default": False},
-                "ticked": {"coerce": "bool", "default": False},
-                "seal": {"coerce": "bool", "default": False},
+                "in_doaj": {"coerce": "bool", "get__default": False},
+                "ticked": {"coerce": "bool", "get__default": False},
+                "seal": {"coerce": "bool", "get__default": False},
                 "owner": {"coerce": "unicode"},
             },
             "lists": {

--- a/doajtest/unit/test_api_crud_application.py
+++ b/doajtest/unit/test_api_crud_application.py
@@ -1,0 +1,121 @@
+from doajtest.helpers import DoajTestCase
+from portality.lib.dataobj import DataObj, DataStructureException
+from portality.api.v1.data_objects import IncomingApplication
+from portality.api.v1 import ApplicationsCrudApi, Api401Error, Api400Error
+from portality import models
+from datetime import datetime
+from doajtest.fixtures import ApplicationFixtureFactory
+import time
+
+class TestCrudApplication(DoajTestCase):
+
+    def setUp(self):
+        super(TestCrudApplication, self).setUp()
+
+    def tearDown(self):
+        super(TestCrudApplication, self).tearDown()
+
+    def test_01_incoming_application_do(self):
+        # make a blank one
+        ia = IncomingApplication()
+
+        # make one from an incoming application model fixture
+        data = ApplicationFixtureFactory.incoming_application()
+        ia = IncomingApplication(data)
+
+        # FIXME: this bit doesn't yet work - dataobj refactor required
+        # make another one that's broken
+        #data = ApplicationFixtureFactory.incoming_application()
+        #del data["bibjson"]["title"]
+        #with self.assertRaises(DataStructureException):
+        #    ia = IncomingApplication(data)
+
+        # now progressively remove the conditionally required/advanced validation stuff
+        #
+        # missing identifiers
+        data = ApplicationFixtureFactory.incoming_application()
+        data["bibjson"]["identifier"] = []
+        with self.assertRaises(DataStructureException):
+            ia = IncomingApplication(data)
+
+        # no issns specified
+        data["bibjson"]["identifier"] = [{"type" : "wibble", "id": "alksdjfas"}]
+        with self.assertRaises(DataStructureException):
+            ia = IncomingApplication(data)
+
+        # issns the same (but not normalised the same)
+        data["bibjson"]["identifier"] = [{"type" : "pissn", "id": "12345678"}, {"type" : "eissn", "id": "1234-5678"}]
+        with self.assertRaises(DataStructureException):
+            ia = IncomingApplication(data)
+
+        # no homepage link
+        data = ApplicationFixtureFactory.incoming_application()
+        data["bibjson"]["link"] = [{"type" : "awaypage", "url": "http://there"}]
+        with self.assertRaises(DataStructureException):
+            ia = IncomingApplication(data)
+
+        # plagiarism detection but no url
+        data = ApplicationFixtureFactory.incoming_application()
+        data["bibjson"]["plagiarism_detection"] = {"detection" : True}
+        with self.assertRaises(DataStructureException):
+            ia = IncomingApplication(data)
+
+        # embedded licence but no url
+        data = ApplicationFixtureFactory.incoming_application()
+        data["bibjson"]["license"][0]["embedded"] = True
+        del data["bibjson"]["license"][0]["embedded_example_url"]
+        with self.assertRaises(DataStructureException):
+            ia = IncomingApplication(data)
+
+        # author copyright and no link
+        data = ApplicationFixtureFactory.incoming_application()
+        data["bibjson"]["author_copyright"]["copyright"] = True
+        del data["bibjson"]["author_copyright"]["url"]
+        with self.assertRaises(DataStructureException):
+            ia = IncomingApplication(data)
+
+        # author publishing rights and no ling
+        data = ApplicationFixtureFactory.incoming_application()
+        data["bibjson"]["author_publishing_rights"]["publishing_rights"] = True
+        del data["bibjson"]["author_publishing_rights"]["url"]
+        with self.assertRaises(DataStructureException):
+            ia = IncomingApplication(data)
+
+    def test_02_create_application_success(self):
+        # set up all the bits we need
+        data = ApplicationFixtureFactory.incoming_application()
+        account = models.Account()
+        account.set_id("test")
+        account.set_name("Tester")
+        account.set_email("test@test.com")
+
+        # call create on the object (which will save it to the index)
+        a = ApplicationsCrudApi.create(data, account)
+
+        # check that it got created with the right properties
+        assert isinstance(a, models.Suggestion)
+        assert a.id is not None
+        assert a.suggester.get("name") == "Tester"
+        assert a.suggester.get("email") == "test@test.com"
+        assert a.owner == "test"
+        assert a.suggested_on is not None
+
+        time.sleep(2)
+
+        s = models.Suggestion.pull(a.id)
+        assert s is not None
+
+    def test_03_create_application_fail(self):
+        # if the account is dud
+        with self.assertRaises(Api401Error):
+            data = ApplicationFixtureFactory.incoming_application()
+            a = ApplicationsCrudApi.create(data, None)
+
+        # if the data is bust
+        with self.assertRaises(Api400Error):
+            account = models.Account()
+            account.set_id("test")
+            account.set_name("Tester")
+            account.set_email("test@test.com")
+            data = {"some" : {"junk" : "data"}}
+            a = ApplicationsCrudApi.create(data, account)

--- a/doajtest/unit/test_api_dataobj.py
+++ b/doajtest/unit/test_api_dataobj.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from doajtest.fixtures import ApplicationFixtureFactory, JournalFixtureFactory, ArticleFixtureFactory
 import time
 
-class TestClient(DoajTestCase):
+class TestAPIDataObj(DoajTestCase):
 
     # we aren't going to talk to ES so override setup and teardown of index
     def setUp(self):
@@ -17,25 +17,21 @@ class TestClient(DoajTestCase):
 
     def test_01_create_empty(self):
         """Create an empty dataobject, mostly to check it doesn't die a recursive death"""
-        do = DataObj(raw={}, _type='test')
-        assert do._type == 'test'
-        assert do._data == {}
-        assert do._struct == {}
+        do = DataObj()
+        assert do.data == {}
+        assert do._struct is None
         with self.assertRaises(AttributeError):
             do.nonexistent_attribute
 
     def test_02_create_from_dict(self):
         expected_struct = JournalFixtureFactory.make_journal_apido_struct()
-        do = DataObj(raw=self.jm.data, _struct=expected_struct, _type='journal', _silent_drop_extra_fields=True)
-        assert do._type == 'journal'
+        do = DataObj(raw=self.jm.data, struct=expected_struct, construct_silent_prune=True, expose_data=True)
         assert do._struct == expected_struct
         self.check_do(do, expected_struct)
 
     def test_03_create_from_model(self):
         expected_struct = JournalFixtureFactory.make_journal_apido_struct()
         do = JournalDO.from_model(self.jm)
-        assert do._type == 'journal'
-        #assert do._data == {}
         assert do._struct == expected_struct
         self.check_do(do, expected_struct)
 
@@ -90,3 +86,4 @@ class TestClient(DoajTestCase):
         assert isinstance(do.bibjson.archiving_policy.policy, list)
         # TODO the below line passes but journal struct needs enhancing here
         # assert do.bibjson.archiving_policy.policy == [u"['LOCKSS', 'CLOCKSS', ['A national library', 'Trinity'], ['Other', 'A safe place']]", u"['LOCKSS', 'CLOCKSS', ['A national library', 'Trinity'], ['Other', 'A safe place']]", u"['LOCKSS', 'CLOCKSS', ['A national library', 'Trinity'], ['Other', 'A safe place']]", u"['LOCKSS', 'CLOCKSS', ['A national library', 'Trinity'], ['Other', 'A safe place']]"], do.bibjson.archiving_policy.policy
+

--- a/portality/api/v1/__init__.py
+++ b/portality/api/v1/__init__.py
@@ -1,4 +1,4 @@
-from portality.api.v1.common import jsonify_models, jsonify_data_object, Api400Error, Api401Error, Api404Error
+from portality.api.v1.common import jsonify_models, jsonify_data_object, Api400Error, Api401Error, Api404Error, created
 
 from portality.api.v1.discovery import DiscoveryApi, DiscoveryException
 

--- a/portality/api/v1/common.py
+++ b/portality/api/v1/common.py
@@ -1,6 +1,6 @@
 import json, uuid
 from portality.core import app
-from flask import request
+from flask import request, url_for
 
 
 class Api(object):
@@ -25,6 +25,13 @@ class DataObjectJsonEncoder(json.JSONEncoder):
 class ModelJsonEncoder(json.JSONEncoder):
     def default(self, o):
         return o.data
+
+def created(obj, location):
+    app.logger.info("Sending 201 Created: {x}".format(x=location))
+    resp = respond(json.dumps({"status" : "created", "id" : obj.id, "location" : location }))
+    resp.headers["Location"] = location
+    resp.status_code = 201
+    return resp
 
 def jsonify_data_object(do):
     data = json.dumps(do, cls=DataObjectJsonEncoder)

--- a/portality/api/v1/crud/README.md
+++ b/portality/api/v1/crud/README.md
@@ -1,0 +1,84 @@
+# CRUD API
+
+## Applications
+
+### Create an Application
+
+Send:
+
+    POST /applications?api_key=<api_key>
+    Content-Type: application/json
+    
+    [Incoming Application]
+
+On Error:
+
+    HTTP 1.1  400 Bad Request
+    Content-Type: application/json
+    
+    {
+        "error" : "<human readable error message>"
+    }
+
+On Success:
+
+    HTTP 1.1  201 Created
+    Content-Type: application/json
+    Location: <url for api endpoint for created application>
+    
+    {
+        "status" : "created",
+        "id" : "<unique identifier for the application>",
+        "location" : "<url for api endpoint for newly created application>"
+    }
+
+### Retrieve an Application
+
+Send:
+
+    GET /application/<application_id>?api_key=<api_key>
+
+On Success:
+
+    HTTP 1.1  200 OK
+    Content-Type: application/json
+    
+    [Outgoing Application]
+
+
+### Update an Application
+
+Send:
+
+    PUT /application/<application_id>?api_key=<api_key>
+    Content-Type: application/json
+    
+    [Incoming Application]
+
+On Error:
+
+    HTTP 1.1  400 Bad Request
+    Content-Type: application/json
+    
+    {
+        "error" : "<human readable error message>"
+    }
+
+On Success:
+
+    HTTP 1.1  204 No Content
+
+### Delete an Application
+
+Send:
+
+    DELETE /application/<application_id>?api_key=<api_key>
+
+On Success:
+
+    HTTP 1.1  204 No Content
+
+### Incoming Application Model
+
+
+### Outgoing Application Model

--- a/portality/api/v1/crud/applications.py
+++ b/portality/api/v1/crud/applications.py
@@ -1,5 +1,41 @@
 from portality.api.v1.crud.common import CrudApi
-
+from portality.api.v1 import Api401Error, Api400Error
+from portality.api.v1.data_objects import IncomingApplication
+from portality.lib import dataobj
+from datetime import datetime
 
 class ApplicationsCrudApi(CrudApi):
-    pass
+
+    @classmethod
+    def create(cls, data, account):
+        # as long as authentication (in the layer above) has been successful, and the account exists, then
+        # we are good to proceed
+        if account is None:
+            raise Api401Error()
+
+        # first thing to do is a structural validation, but instantiating the data object
+        try:
+            ia = IncomingApplication(data)
+        except dataobj.DataStructureException as e:
+            raise Api400Error(e.message)
+
+        # if that works, convert it to a Suggestion object
+        ap = ia.to_application_model()
+
+        # now augment the suggestion object with all the additional information it requires
+        #
+        # suggester name and email from the user account
+        ap.set_suggester(account.name, account.email)
+
+        # suggested_on right now
+        ap.suggested_on = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # initial application status for workflow
+        ap.set_application_status('pending')
+
+        # set the owner to the current account
+        ap.set_owner(account.id)
+
+        # finally save the new application, and return to the caller
+        ap.save()
+        return ap

--- a/portality/api/v1/data_objects/__init__.py
+++ b/portality/api/v1/data_objects/__init__.py
@@ -1,1 +1,2 @@
 from portality.api.v1.data_objects.journal import JournalDO
+from portality.api.v1.data_objects.application import IncomingApplication

--- a/portality/api/v1/data_objects/application.py
+++ b/portality/api/v1/data_objects/application.py
@@ -1,0 +1,323 @@
+from portality.lib import dataobj
+from portality import models
+
+class IncomingApplication(dataobj.DataObj):
+    def __init__(self, raw=None):
+        struct = {
+            "fields": {
+                "id": {"coerce": "unicode"},                # Note that we'll leave these in for ease of use by the
+                "created_date": {"coerce": "utcdatetime"},  # caller, but we'll need to ignore them on the conversion
+                "last_updated": {"coerce": "utcdatetime"}   # to the real object
+            },
+            "objects": ["bibjson", "suggestion", "admin"],
+            "required" : ["bibjson", "suggestion", "admin"],
+
+            "structs": {
+                "bibjson": {
+                    "fields": {
+                        "title": {"coerce": "unicode"},
+                        "alternative_title": {"coerce": "unicode"},
+                        "country": {"coerce": "country_code"},       # FIXME: need to make sure this is the correct form
+                        "publisher": {"coerce": "unicode"},
+                        "provider": {"coerce": "unicode"},
+                        "institution": {"coerce": "unicode"},
+                        "apc_url": {"coerce": "url"},
+                        "submission_charges_url": {"coerce": "url"},
+                        "allows_fulltext_indexing": {"coerce": "bool"},
+                        "publication_time": {"coerce": "integer"},
+                    },
+                    "lists": {
+                        "identifier": {"contains": "object"},
+                        "keywords": {"coerce": "unicode", "contains": "field"},
+                        "language": {"coerce": "isolang_2letter", "contains": "field"}, # FIXME: need to make sure this is the correct form
+                        "link": {"contains": "object"},
+                        "deposit_policy": {"coerce": "unicode", "contains": "field"},
+                        "persistent_identifier_scheme": {"coerce": "unicode", "contains": "field"},
+                        "format": {"coerce": "unicode", "contains": "field"},
+                        "license": {"contains": "object"},
+                    },
+                    "objects": [
+                        "oa_start",
+                        "apc",
+                        "submission_charges",
+                        "archiving_policy",
+                        "editorial_review",
+                        "plagiarism_detection",
+                        "article_statistics",
+                        "author_copyright",
+                        "author_publishing_rights",
+                    ],
+                    "required": [
+                        "title",
+                        "publisher",
+                        "country",
+                        "apc_url",
+                        "submission_charges_url",
+                        "allows_fulltext_indexing",
+                        "publication_time",
+                        "identifier",
+                        "keywords",
+                        "language",
+                        "link",
+                        "deposit_policy",
+                        "persistent_identifier_scheme",
+                        "format",
+                        "license",
+                        "oa_start",
+                        "archiving_policy",
+                        "editorial_review",
+                        "plagiarism_detection",
+                        "article_statistics",
+                        "author_copyright",
+                        "author_publishing_rights"
+                    ],
+
+
+                    "structs": {
+                        "oa_start": {
+                            "fields": {
+                                "year": {"coerce": "integer"}
+                            },
+                            "required" : ["year"]
+                        },
+
+                        "apc": {
+                            "fields": {
+                                "currency": {"coerce": "currency_code"},
+                                "average_price": {"coerce": "integer"}
+                            }
+                        },
+
+                        "submission_charges": {
+                            "fields": {
+                                "currency": {"coerce": "currency_code"},    # FIXME: need to be implemented, but requires refactor of dataset stuff
+                                "average_price": {"coerce": "integer"}
+                            }
+                        },
+
+                        "archiving_policy": {
+                            "fields": {
+                                "url": {"coerce": "url"},
+                            },
+                            "lists": {                                                  # FIXME: this can take one of a limited set, so we may need to enforce that here
+                                "policy": {"coerce": "unicode", "contains": "field"},   # FIXME: technically, this can also contain a list - data model is a bit broken here
+                            },
+                            "required" : ["url", "policy"]
+                        },
+
+                        "editorial_review": {
+                            "fields": {
+                                "process": {"coerce": "unicode"},
+                                "url": {"coerce": "url"},
+                            },
+                            "required" : ["process", "url"]
+                        },
+
+                        "plagiarism_detection": {
+                            "fields": {
+                                "detection": {"coerce": "bool"},
+                                "url": {"coerce": "url"},
+                            },
+                            "required" : ["detection", "url"]
+                        },
+
+                        "article_statistics": {
+                            "fields": {
+                                "statistics": {"coerce": "bool"},
+                                "url": {"coerce": "url"},
+                            },
+                            "required" : ["statistics"]
+                        },
+
+                        "author_copyright": {
+                            "fields": {
+                                "copyright": {"coerce": "unicode"},     # FIXME: from a defined list
+                                "url": {"coerce": "url"},
+                            },
+                            "required" : ["copyright"]
+                        },
+
+                        "author_publishing_rights": {
+                            "fields": {
+                                "publishing_rights": {"coerce": "unicode"},
+                                "url": {"coerce": "url"},
+                            },
+                            "required" : ["publishing_rights"]
+                        },
+
+                        "identifier": {
+                            "fields": {
+                                "type": {"coerce": "unicode"},
+                                "id": {"coerce": "unicode"},
+                            },
+                            "required" : ["type", "id"]
+                        },
+
+                        "link": {
+                            "fields": {
+                                "type": {"coerce": "unicode"},
+                                "url": {"coerce": "url"},
+                            },
+                            "required" : ["type", "url"]
+                        },
+
+                        "license": {
+                            "fields": {
+                                "title": {"coerce": "unicode"},
+                                "type": {"coerce": "unicode"},
+                                "url": {"coerce": "unicode"},
+                                "version": {"coerce": "unicode"},
+                                "open_access": {"coerce": "bool"},
+                                "BY": {"coerce": "bool"},
+                                "NC": {"coerce": "bool"},
+                                "ND": {"coerce": "bool"},
+                                "SA": {"coerce": "bool"},
+                                "embedded": {"coerce": "bool"},
+                                "embedded_example_url": {"coerce": "url"},
+                            },
+                            "required" : [
+                                "embedded",
+                                "title",
+                                "type",
+                                "open_access"
+                            ]
+                        }
+                    }
+                },
+
+                "suggestion" : {
+                    "fields" : {
+                        "article_metadata" : {"coerce" : "bool"}
+                    },
+                    "objects" : [
+                        "articles_last_year"
+                    ],
+                    "required" : ["article_metadata", "articles_last_year"],
+
+                    "structs" : {
+                        "articles_last_year" : {
+                            "fields" : {
+                                "count" : {"coerce" : "integer"},
+                                "url" : {"coerce" : "url"}
+                            },
+                            "required" : ["count", "url"]
+                        }
+                    }
+                },
+
+                "admin" : {
+                    "lists" : {
+                        "contact" : {"contains" : "object"}
+                    },
+                    "required" : ["contact"],
+
+                    "structs" : {
+                        "contact": {
+                            "fields" : {
+                                "email" : {"coerce" : "unicode"},
+                                "name" : {"coerce" : "unicode"}
+                            },
+                            "required" : ["name", "email"]
+                        }
+                    }
+                }
+            }
+        }
+
+        super(IncomingApplication, self).__init__(raw, struct=struct, construct_silent_prune=True, expose_data=True)
+
+    def custom_validate(self):
+        # only attempt to validate if this is not a blank object
+        if len(self.data.keys()) == 0:
+            return
+
+        # at least one of print issn / e-issn, and they must be different
+        #
+        # check that there are identifiers at all
+        identifiers = self.bibjson.identifier
+        if identifiers is None or len(identifiers) == 0:
+            raise dataobj.DataStructureException("You must specify at least one of P-ISSN or E-ISSN in bibjson.identifier")
+
+        # extract the p/e-issn identifier objects
+        pissn = None
+        eissn = None
+        for ident in identifiers:
+            if ident.type == "pissn":
+                pissn = ident
+            elif ident.type == "eissn":
+                eissn = ident
+
+        # check that at least one of them appears
+        if pissn is None and eissn is None:
+            raise dataobj.DataStructureException("You must specify at least one of P-ISSN or E-ISSN in bibjson.identifier")
+
+        # normalise the ids
+        pissn.id = self._normalise_issn(pissn.id)
+        eissn.id = self._normalise_issn(eissn.id)
+
+        # check they are not the same
+        if pissn.id == eissn.id:
+            raise dataobj.DataStructureException("P-ISSN and E-ISSN should be different")
+
+        # A link to the journal homepage is required
+        #
+        # check that there are links at all
+        links = self.bibjson.link
+        if links is None or len(links) == 0:
+            raise dataobj.DataStructureException("You must specify the journal homepage in bibjson.link@type='homepage'")
+        found = False
+        for l in links:
+            if l.type == "homepage":
+                found = True
+                break
+        if not found:
+            raise dataobj.DataStructureException("You must specify the journal homepage in bibjson.link@type='homepage'")
+
+        # if plagiarism detection is done, then the url is a required field
+        if self.bibjson.plagiarism_detection.detection is True:
+            url = self.bibjson.plagiarism_detection.url
+            if url is None:
+                raise dataobj.DataStructureException("In this context bibjson.plagiarism_detection.url is required")
+
+        # if licence.embedded is true, then the url is a required field
+        lic = self.bibjson.license
+        if lic is not None and len(lic) > 0:
+            lic = lic[0]
+            if lic.embedded:
+                if lic.embedded_example_url is None:
+                    raise dataobj.DataStructureException("In this context bibjson.license.embedded_example_url is required")
+
+        # if the author does not hold the copyright the url is optional, otherwise it is required
+        if self.bibjson.author_copyright.copyright is not False:
+            if self.bibjson.author_copyright.url is None:
+                raise dataobj.DataStructureException("In this context bibjson.author_copyright.url is required")
+
+        # if the author does not hold the publishing rights the url is optional, otherwise it is required
+        if self.bibjson.author_publishing_rights.publishing_rights is not False:
+            if self.bibjson.author_publishing_rights.url is None:
+                raise dataobj.DataStructureException("In this context bibjson.author_copyright.url is required")
+
+    def _normalise_issn(self, issn):
+        issn = issn.upper()
+        if len(issn) > 8: return issn
+        if len(issn) == 8:
+            if "-" in issn: return "0" + issn
+            else: return issn[:4] + "-" + issn[4:]
+        if len(issn) < 8:
+            if "-" in issn: return ("0" * (9 - len(issn))) + issn
+            else:
+                issn = ("0" * (8 - len(issn))) + issn
+                return issn[:4] + "-" + issn[4:]
+
+    def to_application_model(self):
+        return models.Suggestion(**self.data)
+
+    @classmethod
+    def from_model(cls, jm):
+        assert isinstance(jm, models.Suggestion)
+        return cls(jm.data)
+
+    @classmethod
+    def from_model_by_id(cls, id_):
+        j = models.Suggestion.pull(id_)
+        return cls.from_model(j)

--- a/portality/api/v1/data_objects/journal.py
+++ b/portality/api/v1/data_objects/journal.py
@@ -3,11 +3,8 @@ from portality import models
 
 
 class JournalDO(dataobj.DataObj):
-    _type = 'journal'
 
-    def __init__(self, __raw=None):
-        self._RESERVED_ATTR_NAMES += ['from_model', 'from_model_by_id']
-
+    def __init__(self, raw=None):
         struct = {
             "objects": ["bibjson", "admin"],
             "fields": {
@@ -18,9 +15,9 @@ class JournalDO(dataobj.DataObj):
             "structs": {
                 "admin": {
                     "fields": {
-                        "in_doaj": {"coerce": "bool", "default": False},
-                        "ticked": {"coerce": "bool", "default": False},
-                        "seal": {"coerce": "bool", "default": False},
+                        "in_doaj": {"coerce": "bool", "get__default": False},
+                        "ticked": {"coerce": "bool", "get__default": False},
+                        "seal": {"coerce": "bool", "get__default": False},
                         "owner": {"coerce": "unicode"},
                     },
                     "lists": {
@@ -176,7 +173,7 @@ class JournalDO(dataobj.DataObj):
             }
         }
 
-        super(JournalDO, self).__init__(__raw, _struct=struct, _silent_drop_extra_fields=True)
+        super(JournalDO, self).__init__(raw, struct=struct, construct_silent_prune=True, expose_data=True)
 
     @classmethod
     def from_model(cls, jm):

--- a/portality/datasets.py
+++ b/portality/datasets.py
@@ -619,3 +619,6 @@ def get_country_name(code):
 
 def get_currency_name(code):
     return currencies_dict.get(code, code)  # return what was passed in if not found
+
+def get_currency_code(name):
+    pass

--- a/portality/lib/dataobj.py
+++ b/portality/lib/dataobj.py
@@ -1,17 +1,26 @@
 from portality.lib import dates
+from portality.datasets import get_country_code
 from copy import deepcopy
-import locale, json
-
-import inspect
+import locale, json, urlparse
 
 #########################################################
 ## Data coerce functions
 
+def to_currency_code(val):
+    # FIXME: implement
+    return val
+
+def to_country_code():
+
+    def cc(val):
+        val = get_country_code(val)
+        uc = to_unicode()
+        return uc(val)
+
+    return cc
+
 def to_unicode():
     def to_utf8_unicode(val):
-        if val is None:
-            return None
-
         if isinstance(val, unicode):
             return val
         elif isinstance(val, basestring):
@@ -26,9 +35,6 @@ def to_unicode():
 
 def to_int():
     def intify(val):
-        if val is None:
-            return None
-
         # strip any characters that are outside the ascii range - they won't make up the int anyway
         # and this will get rid of things like strange currency marks
         if isinstance(val, unicode):
@@ -58,9 +64,6 @@ def to_int():
 
 def to_float():
     def floatify(val):
-        if val is None:
-            return None
-
         # strip any characters that are outside the ascii range - they won't make up the float anyway
         # and this will get rid of things like strange currency marks
         if isinstance(val, unicode):
@@ -90,16 +93,12 @@ def to_float():
 
 def date_str(in_format=None, out_format=None):
     def datify(val):
-        if val is None:
-            return None
         return dates.reformat(val, in_format=in_format, out_format=out_format)
 
     return datify
 
 def to_datestamp(in_format=None):
     def stampify(val):
-        if val is None:
-            return None
         return dates.parse(val, format=in_format)
 
     return stampify
@@ -139,27 +138,34 @@ def to_isolang(output_format=None):
 def to_url(val):
     if val is None:
         return None
-    # FIXME: implement
-    return val
 
-def to_bool():
-    def boolify(val):
-        """Conservative boolean cast - don't cast lists and objects to True, just existing booleans and strings."""
-        if val is None:
-            return None
-        if val is True or val is False:
-            return val
+    # parse with urlparse
+    url = urlparse.urlparse(val)
 
-        if isinstance(val, basestring):
-            if val.lower() == 'true':
-                return True
-            elif val.lower() == 'false':
-                return False
-            raise ValueError(u"Could not convert string {val} to boolean. Expecting string to either say 'true' or 'false' (not case-sensitive).".format(val=val))
+    # now check the url has the minimum properties that we require
+    if url.scheme and url.scheme.startswith("http"):
+        uc = to_unicode()
+        return uc(val)
+    else:
+        raise ValueError(u"Could not convert string {val} to viable URL".format(val=val))
 
-        raise ValueError(u"Could not convert {val} to boolean. Expect either boolean or string.".format(val=val))
+def to_bool(val):
+    """Conservative boolean cast - don't cast lists and objects to True, just existing booleans and strings."""
+    if val is None:
+        return None
+    if val is True or val is False:
+        return val
 
-    return boolify
+    if isinstance(val, basestring):
+        if val.lower() == 'true':
+            return True
+        elif val.lower() == 'false':
+            return False
+        raise ValueError(u"Could not convert string {val} to boolean. Expecting string to either say 'true' or 'false' (not case-sensitive).".format(val=val))
+
+    raise ValueError(u"Could not convert {val} to boolean. Expect either boolean or string.".format(val=val))
+
+
 
 ############################################################
 
@@ -172,183 +178,730 @@ class DataSchemaException(Exception):
 
 class DataObj(object):
     """
-    Class which stores data according to a defined structure and provides
-    validation on setting any attribute. Recursive (if any of its attributes
-    contain an object or a list of objects, these will be wrapped in a
-    DataObj themselves and any actions delegated to the new DataObj).
+    Class which provides services to other classes which store their internal data
+    as a python data structure in the self.data field.
     """
 
-    _coerce = {
+    SCHEMA = None
+
+    DEFAULT_COERCE = {
         "unicode": to_unicode(),
         "utcdatetime": date_str(),
         "integer": to_int(),
         "float": to_float(),
         "isolang": to_isolang(),
         "url": to_url,
-        "bool": to_bool()
+        "bool": to_bool,
+        "isolang_2letter": to_isolang(output_format="alpha2"),
+        "country_code" : to_country_code(),
+        "currency_code" : to_currency_code
     }
 
-    _RESERVED_ATTR_NAMES = [
-        '__class__',
-        '__delattr__',
-        '__dict__',
-        '__doc__',
-        '__format__',
-        '__getattribute__',
-        '__hash__',
-        '__init__',
-        '__members__',
-        '__methods__',
-        '__module__',
-        '__new__',
-        '__reduce__',
-        '__reduce_ex__',
-        '__repr__',
-        '__setattr__',
-        '__sizeof__',
-        '__str__',
-        '__subclasshook__',
-        '__weakref__',
-        '_add_struct',
-        '_struct',
-        '_type',
-        '_silent_drop_extra_fields',
-        '_RESERVED_ATTR_NAMES',
-        '_coerce',
-        '_data'
-    ]
+    def __init__(self, raw=None, struct=None, construct_raw=True, expose_data=False, properties=None, coerce_map=None, construct_silent_prune=False):
+        # make a shortcut to the object.__getattribute__ function
+        og = object.__getattribute__
 
-    def __init__(self, raw=None, _struct=None, _type=None, _silent_drop_extra_fields=False):
-        assert isinstance(raw, dict), "The raw data passed in must be iterable as a dict."
+        # if no subclass has set the coerce, then set it from default
+        try:
+            og(self, "_coerce_map")
+        except:
+            self._coerce_map = coerce_map if coerce_map is not None else deepcopy(self.DEFAULT_COERCE)
 
-        self._silent_drop_extra_fields = _silent_drop_extra_fields
-
-        if _type:
-            self._type = _type
-
-        if not self._type:
-            raise ValueError("Can't create DataObj without a type")
-
-        if _struct:
-            self._struct = _struct
-        else:
-            self._struct = {}
-
-        self._data = {}
-        for k, v in raw.iteritems():
-            setattr(self, k, v)
-
-    def __getattribute__(self, name):
-        # If this attribute is not already set in the internal data
-        # but it's supposed to be an object (not primitive type)
-        # then set it to an empty DataObj with the struct it's
-        # supposed to have. That way if the caller is chaining
-        # a setter to [name] we'll keep a pointer to the right object.
-        # E.g. the caller does:
-        # j = JournalDO()
-        # j.bibjson.title = 'atitle'
-        # This function will be called with name == "bibjson".
-        # If we didn't keep track of an empty bibjson object,
-        # the .title would be set on an object we would no longer have
-        # a handle on.
-
-        # attrs used in creating a DataObj should behave as they usually
-        # would in Python
-        if name in object.__getattribute__(self, '_RESERVED_ATTR_NAMES'):
-            return object.__getattribute__(self, name)
-
-        if object.__getattribute__(self, '_data').get(name) is None:
-        # the requested attribute is not present in the data already
-
-            if name in object.__getattribute__(self, '_struct').get('objects', []):
-                object.__getattribute__(self, '_data')[name] = DataObj(raw={}, _struct=object.__getattribute__(self, '_struct')['structs'][name], _type=name)
-            elif name in object.__getattribute__(self, '_struct').get('lists', {}):
-                object.__getattribute__(self, '_data')[name] = []
-            elif name in object.__getattribute__(self, '_struct').get('fields', {}):
-            # it's a primitive field that isn't set
-                try:
-                    # if there is a default set in the struct, return it
-                    if object.__getattribute__(self, '_struct')['fields'][name].get("default") is not None:
-                        return object.__getattribute__(self, '_struct')['fields'][name]["default"]
-                    # else cast a None
-                    return object.__getattribute__(self, '_coerce')[object.__getattribute__(self, '_struct')['fields'][name]['coerce']](None)
-                except ValueError:
-                    raise AttributeError('{name} is not set'.format(name=name))
-            else:
-            # it's not a valid attribute of this object
-                raise AttributeError('{name} is not an attribute of {type}'.format(name=name, type=object.__getattribute__(self, '_type')))
-
-        # the requested attribute is in the internal data
-        return object.__getattribute__(self, '_data')[name]
-
-    # TODO note that on any serialisation each field that is not required and its contents are not truthy
-    # (unless they are False) or only an empty data object, those fields should not be serialised.
-    # TODO add .empty to data objects
-
-    def __setattr__(self, name, value):
-        # If what we're trying to set is an object itself,
-        # pass it on to its own DataObj.
-        # If it's a primitive, coerce it into the defined type.
-        # If what we're trying to set is not in the struct, bail.
-
-        # attrs used in creating a DataObj should behave as they usually
-        # would in Python
-        if name in object.__getattribute__(self, '_RESERVED_ATTR_NAMES'):
-            return object.__setattr__(self, name, value)
-
-        # it's another object, in which case we need to recurse
-        if name in self._struct.get('objects', {}):
-            self._data[name] = DataObj(raw=value, _struct=self._struct['structs'][name], _type=name, _silent_drop_extra_fields=self._silent_drop_extra_fields)
-
-        # it's a list - what we do depends on if it contains simple fields or objects (recurse if latter)
-        if name in self._struct.get('lists', {}):
-            if not isinstance(value, list):
-                raise ValueError('The "{name}" attribute of this data object is a list. Please supply a list as the value. Current value: {value}'.format(name=name, value=value))
-
-            self._data[name] = []
-            for i in value:
-                try:
-                    if self._struct['lists'][name]['contains'] == 'object':
-                        coerced_i = DataObj(raw=i, _struct=self._struct['structs'][name], _type=name, _silent_drop_extra_fields=self._silent_drop_extra_fields)
-                    elif self._struct['lists'][name]['contains'] == 'field':
-                        coerced_i = self._coerce[self._struct['lists'][name]['coerce']](i)
-                    else:
-                        raise DataStructureException("Data object struct definition error: Don't understand how to interpret struct for list '{name}'. Only allowing 'contains':'object' and 'contains':'field'.".format(name=name))
-                except KeyError as e:
-                    if e.message == 'contains':
-                        raise DataSchemaException("No information in struct provided on what {0} contains".format(name))
-                    else:
-                        raise DataSchemaException("Problem while setting {0}: KeyError for {1}".format(name, e.message))
-                self._data[name].append(coerced_i)
-
-        # it's a normal field, just set it with coercion
-        elif name in self._struct.get('fields', {}):
-            try:
-                self._data[name] = self._coerce[self._struct['fields'][name]['coerce']](value)
-            except KeyError as e:
-                if e.message == 'coerce':
-                    raise DataSchemaException("No information in struct provided on how to coerce {0}".format(name))
-                else:
-                    raise DataSchemaException("Problem while setting {0}: KeyError for {1}".format(name, e.message))
-
-
-        # not an allowed attribute
-        else:
-            if not self._silent_drop_extra_fields:
-                raise AttributeError('{name} is not an attribute of {type}'.format(name=name, type=self._type))
-            return False  # still indicate it couldn't be set, more silently
-        return True
-        
-    def _add_struct(self, struct):
-        if hasattr(self, "_struct"):
-            self._struct = construct_merge(self._struct, struct)
-        else:
+        # if no subclass has set the struct, initialise it
+        try:
+            og(self, "_struct")
+        except:
             self._struct = struct
 
+        # assign the data if not already assigned by subclass
+        # NOTE: data is not _data deliberately
+        try:
+            og(self, "data")
+        except:
+            self.data = {} if raw is None else raw
+
+        # properties to allow automatic object API construction
+        # of the form
+        #
+        # {"<public property name>" : ("<path.to.property>", "<data object wrapper>")
+        # e.g
+        # {"identifier" : ("bibjson.identifier", DataObj))}
+        try:
+            og(self, "_properties")
+        except:
+            self._properties = properties if properties is not None else {}
+
+        # if no subclass has set expose_data, set it
+        try:
+            og(self, "_expose_data")
+        except:
+            self._expose_data = expose_data
+
+        # restructure the object based on the struct if requried
+        if self._struct is not None and raw is not None and construct_raw:
+            self.data = construct(self.data, self._struct, self._coerce_map, silent_prune=construct_silent_prune)
+
+        # run against the old validation routine
+        # (now deprecated)
+        self.validate()
+
+        # run the object's native validation routine
+        self.custom_validate()
+
+    def __getattr__(self, name):
+        props, data_attrs = self._list_dynamic_properties()
+
+        # if the name is not in the dynamic properties, raise an attribute error
+        if name not in props and name not in data_attrs:
+            raise AttributeError('{name} is not set'.format(name=name))
+
+        # otherwise, extract the path from the properties list or the internal data
+        if name in props:
+            path, wrapper = self._properties.get(name)
+        else:
+            path = name
+            wrapper = DataObj
+
+        # request the internal property directly (which will in-turn raise the AttributeError if necessary)
+        try:
+            return self._get_internal_property(path, wrapper)
+        except AttributeError:
+            # re-wrap the attribute error with the name, rather than the path
+            raise AttributeError('{name} is not set'.format(name=name))
+
+    def __setattr__(self, key, value):
+        # first set the attribute on any explicitly defined property
+        try:
+            att = object.__getattribute__(self, key)
+            return object.__setattr__(self, key, value)
+        except AttributeError:
+            pass
+
+        # this could be an internal attribute from the constructor, so we need to make
+        # a special case
+        if key in ["_coerce_map", "_struct", "data", "_properties", "_expose_data"]:
+            return object.__setattr__(self, key, value)
+
+        props, data_attrs = self._list_dynamic_properties()
+
+        # extract the path from the properties list or the internal data
+        path = None
+        wrapper = None
+        if key in props:
+            path, wrapper = self._properties.get(key)
+        elif key in data_attrs:
+            path = key
+            wrapper = DataObj
+
+        # try to set the property on othe internal object
+        if path is not None:
+            wasset = self._set_internal_property(path, value, wrapper)
+            if wasset:
+                return
+
+        # fall back to the default approach of allowing any attribute to be set on the object
+        return object.__setattr__(self, key, value)
+
+    def validate(self):
+        if self.SCHEMA is not None:
+            validate(self.data, self.SCHEMA)
+        return True
+
+    def custom_validate(self):
+        pass
+
+    def populate(self, fields_and_values):
+        for k, v in fields_and_values.iteritems():
+            setattr(self, k, v)
+
+    def clone(self):
+        return self.__class__(deepcopy(self.data))
+
+    def json(self):
+        return json.dumps(self.data)
+
+    def _get_internal_property(self, path, wrapper=None):
+        # pull the object from the structure, to find out what kind of retrieve it needs
+        # (if there is a struct)
+        type, substruct, instructions = None, None, None
+        if self._struct:
+            type, substruct, instructions = construct_lookup(path, self._struct)
+
+        if type is None:
+            # if there is no struct, or no object mapping was found, try to pull the path
+            # as a single node (may be a field, list or dict, we'll find out in a mo)
+            val = self._get_single(path)
+
+            # if this is a dict or a list and a wrapper is supplied, wrap it
+            if wrapper is not None:
+                if isinstance(val, dict):
+                    return wrapper(val, expose_data=self._expose_data)
+                elif isinstance(val, list):
+                    return [wrapper(v, expose_data=self._expose_data) for v in val]
+
+            # otherwise, return the raw value if it is not None, or raise an AttributeError
+            if val is None:
+                raise AttributeError('{name} is not set'.format(name=path))
+
+            return val
+
+        # if the struct contains a reference to the path, always return something, even if it is None - don't raise an AttributeError
+        kwargs = construct_kwargs(type, "get", instructions)
+        if type == "field":
+            return self._get_single(path, **kwargs)
+        elif type == "object":
+            d = self._get_single(path, **kwargs)
+            if wrapper:
+                return wrapper(d, substruct, construct_raw=False, expose_data=self._expose_data)    # FIXME: this means all substructures are forced to use this classes expose_data policy, whatever it is
+            else:
+                return d
+        elif type == "list":
+            if instructions.get("contains") == "field":
+                return self._get_list(path, **kwargs)
+            elif instructions.get("contains") == "object":
+                l = self._get_list(path, **kwargs)
+                if wrapper:
+                    return [wrapper(o, substruct, construct_raw=False, expose_data=self._expose_data) for o in l]    # FIXME: this means all substructures are forced to use this classes expose_data policy, whatever it is
+                else:
+                    return l
+
+        # if for whatever reason we get here, raise the AttributeError
+        raise AttributeError('{name} is not set'.format(name=path))
+
+    def _set_internal_property(self, path, value, wrapper=None):
+
+        def _wrap_validate(val, wrap, substruct):
+            if wrap is None:
+                if isinstance(val, DataObj):
+                    return val.data
+                else:
+                    return val
+
+            else:
+                if isinstance(val, DataObj):
+                    if isinstance(val, wrap):
+                        return val.data
+                    else:
+                        raise AttributeError("Attempt to set {x} failed; is not of an allowed type.".format(x=path))
+                else:
+                    try:
+                        d = wrap(val, substruct)
+                        return d.data
+                    except DataStructureException as e:
+                        raise AttributeError(e.message)
+
+        # pull the object from the structure, to find out what kind of retrieve it needs
+        # (if there is a struct)
+        type, substruct, instructions = None, None, None
+        if self._struct:
+            type, substruct, instructions = construct_lookup(path, self._struct)
+
+        # if no type is found, then this means that either the struct was undefined, or the
+        # path did not point to a valid point in the struct.  In the case that the struct was
+        # defined, this means the property is trying to set something outside the struct, which
+        # isn't allowed.  So, only set types which are None against objects which don't define
+        # the struct.
+        if type is None:
+            if self._struct is None:
+                if isinstance(value, list):
+                    value = [_wrap_validate(v, wrapper, None) for v in value]
+                    self._set_list(path, value)
+                else:
+                    value = _wrap_validate(value, wrapper, None)
+                    self._set_single(path, value)
+
+                return True
+            else:
+                return False
+
+        kwargs = construct_kwargs(type, "set", instructions)
+        if type == "field":
+            self._set_single(path, value, **kwargs)
+            return True
+        elif type == "object":
+            v = _wrap_validate(value, wrapper, substruct)
+            self._set_single(path, v, **kwargs)
+            return True
+        elif type == "list":
+            if instructions.get("contains") == "field":
+                self._set_list(path, value, **kwargs)
+                return True
+            elif instructions.get("contains") == "object":
+                if not isinstance(value, list):
+                    value = [value]
+                vals = [_wrap_validate(v, wrapper, substruct) for v in value]
+                self._set_list(path, vals, **kwargs)
+                return True
+
+        return False
+
+    def _list_dynamic_properties(self):
+        # list the dynamic properties the object could have
+        props = []
+        try:
+            # props = og(self, 'properties').keys()
+            props = self._properties.keys()
+        except AttributeError:
+            pass
+
+        data_attrs = []
+        try:
+            if self._expose_data:
+                if self._struct:
+                    data_attrs = construct_data_keys(self._struct)
+                else:
+                    data_attrs = self.data.keys()
+        except AttributeError:
+            pass
+
+        return props, data_attrs
+
+    def _add_struct(self, struct):
+        # if the struct is not yet set, set it
+        try:
+            object.__getattribute__(self, "_struct")
+            self._struct = construct_merge(self._struct, struct)
+        except:
+            self._struct = struct
+
+    def _get_path(self, path, default):
+        parts = path.split(".")
+        context = self.data
+
+        for i in range(len(parts)):
+            p = parts[i]
+            d = {} if i < len(parts) - 1 else default
+            context = context.get(p, d)
+        return context
+
+    def _set_path(self, path, val):
+        parts = path.split(".")
+        context = self.data
+
+        for i in range(len(parts)):
+            p = parts[i]
+
+            if p not in context and i < len(parts) - 1:
+                context[p] = {}
+                context = context[p]
+            elif p in context and i < len(parts) - 1:
+                context = context[p]
+            else:
+                context[p] = val
+
+    def _delete_from_list(self, path, val=None, matchsub=None, prune=True):
+        l = self._get_list(path)
+
+        removes = []
+        i = 0
+        for entry in l:
+            if val is not None:
+                if entry == val:
+                    removes.append(i)
+            elif matchsub is not None:
+                matches = 0
+                for k, v in matchsub.iteritems():
+                    if entry.get(k) == v:
+                        matches += 1
+                if matches == len(matchsub.keys()):
+                    removes.append(i)
+            i += 1
+
+        removes.sort(reverse=True)
+        for r in removes:
+            del l[r]
+
+        if len(l) == 0 and prune:
+            self._delete(path, prune)
+
+    def _delete(self, path, prune=True):
+        parts = path.split(".")
+        context = self.data
+
+        stack = []
+        for i in range(len(parts)):
+            p = parts[i]
+            if p in context:
+                if i < len(parts) - 1:
+                    stack.append(context[p])
+                    context = context[p]
+                else:
+                    del context[p]
+                    if prune and len(stack) > 0:
+                        stack.pop() # the last element was just deleted
+                        self._prune_stack(stack)
+
+    def _prune_stack(self, stack):
+        while len(stack) > 0:
+            context = stack.pop()
+            todelete = []
+            for k, v in context.iteritems():
+                if isinstance(v, dict) and len(v.keys()) == 0:
+                    todelete.append(k)
+            for d in todelete:
+                del context[d]
+
+    def _coerce(self, val, cast, accept_failure=False):
+        if cast is None:
+            return val
+        try:
+            return cast(val)
+        except (ValueError, TypeError):
+            if accept_failure:
+                return val
+            raise DataSchemaException(u"Cast with {x} failed on {y}".format(x=cast, y=val))
+
+    def _get_single(self, path, coerce=None, default=None, allow_coerce_failure=True):
+        # get the value at the point in the object
+        val = self._get_path(path, default)
+
+        if coerce is not None and val is not None:
+            # if you want to coerce and there is something to coerce do it
+            return self._coerce(val, coerce, accept_failure=allow_coerce_failure)
+        else:
+            # otherwise return the value
+            return val
+
+    def _get_list(self, path, coerce=None, by_reference=True, allow_coerce_failure=True):
+        # get the value at the point in the object
+        val = self._get_path(path, None)
+
+        # if there is no value and we want to do by reference, then create it, bind it and return it
+        if val is None and by_reference:
+            mylist = []
+            self._set_single(path, mylist)
+            return mylist
+
+        # otherwise, default is an empty list
+        elif val is None and not by_reference:
+            return []
+
+        # check that the val is actually a list
+        if not isinstance(val, list):
+            raise DataSchemaException(u"Expecting a list at {x} but found {y}".format(x=path, y=val))
+
+        # if there is a value, do we want to coerce each of them
+        if coerce is not None:
+            coerced = [self._coerce(v, coerce, accept_failure=allow_coerce_failure) for v in val]
+            if by_reference:
+                self._set_single(path, coerced)
+            return coerced
+        else:
+            if by_reference:
+                return val
+            else:
+                return deepcopy(val)
+
+    def _set_single(self, path, val, coerce=None, allow_coerce_failure=False, allowed_values=None, allowed_range=None,
+                    allow_none=True, ignore_none=False):
+
+        if val is None and ignore_none:
+            return
+
+        if val is None and not allow_none:
+            raise DataSchemaException(u"NoneType is not allowed at {x}".format(x=path))
+
+        # first see if we need to coerce the value (and don't coerce None)
+        if coerce is not None and val is not None:
+            val = self._coerce(val, coerce, accept_failure=allow_coerce_failure)
+
+        if allowed_values is not None and val not in allowed_values:
+            raise DataSchemaException(u"Value {x} is not permitted at {y}".format(x=val, y=path))
+
+        if allowed_range is not None:
+            lower, upper = allowed_range
+            if (lower is not None and val < lower) or (upper is not None and val > upper):
+                raise DataSchemaException("Value {x} is outside the allowed range: {l} - {u}".format(x=val, l=lower, u=upper))
+
+        # now set it at the path point in the object
+        self._set_path(path, val)
+
+    def _set_list(self, path, val, coerce=None, allow_coerce_failure=False, allow_none=True, ignore_none=False):
+        # first ensure that the value is a list
+        if not isinstance(val, list):
+            val = [val]
+
+        # now carry out the None check
+        # for each supplied value, if it is none, and none is not allowed, raise an error if we do not
+        # plan to ignore the nones.
+        for v in val:
+            if v is None and not allow_none:
+                if not ignore_none:
+                    raise DataSchemaException(u"NoneType is not allowed at {x}".format(x=path))
+
+        # now coerce each of the values, stripping out Nones if necessary
+        val = [self._coerce(v, coerce, accept_failure=allow_coerce_failure) for v in val if v is not None or not ignore_none]
+
+        # check that the cleaned array isn't empty, and if it is behave appropriately
+        if len(val) == 0:
+            # this is equivalent to a None, so we need to decide what to do
+            if ignore_none:
+                # if we are ignoring nones, just do nothing
+                return
+            elif not allow_none:
+                # if we are not ignoring nones, and not allowing them, raise an error
+                raise DataSchemaException(u"Empty array not permitted at {x}".format(x=path))
+
+        # now set it on the path
+        self._set_path(path, val)
+
+    def _add_to_list(self, path, val, coerce=None, allow_coerce_failure=False, allow_none=False, ignore_none=True, unique=False):
+        if val is None and ignore_none:
+            return
+
+        if val is None and not allow_none:
+            raise DataSchemaException(u"NoneType is not allowed in list at {x}".format(x=path))
+
+        # first coerce the value
+        if coerce is not None:
+            val = self._coerce(val, coerce, accept_failure=allow_coerce_failure)
+        current = self._get_list(path, by_reference=True)
+
+        # if we require the list to be unique, check for the value first
+        if unique:
+            if val in current:
+                return
+
+        # otherwise, append
+        current.append(val)
+
+    def _utf8_unicode(self):
+        """
+        DEPRECATED - use dataobj.to_unicode() instead
+        """
+        return to_unicode()
+
+    def _int(self):
+        """
+        DEPRECATED - use dataobj.to_int() instead
+        """
+        return to_int()
+
+    def _float(self):
+        """
+        DEPRECATED - use dataobj.to_float() instead
+        """
+        return to_float()
+
+    def _date_str(self, in_format=None, out_format=None):
+        """
+        DEPRECATED - use dataobj.date_str instead
+        """
+        return date_str(in_format=in_format, out_format=out_format)
+
+
+
+############################################################
+## Primitive object schema validation
+
+class ObjectSchemaValidationError(Exception):
+    pass
+
+
+def validate(obj, schema):
+    """
+    DEPRECATED - use "construct" instead
+
+    :param obj:
+    :param schema:
+    :return:
+    """
+    # all fields
+    allowed = schema.get("bools", []) + schema.get("fields", []) + schema.get("lists", []) + schema.get("objects", [])
+
+    for k, v in obj.iteritems():
+        # is k allowed at all
+        if k not in allowed:
+            raise ObjectSchemaValidationError("object contains key " + k + " which is not permitted by schema")
+
+        # check the bools are bools
+        if k in schema.get("bools", []):
+            if type(v) != bool:
+                raise ObjectSchemaValidationError("object contains " + k + " = " + str(v) + " but expected boolean")
+
+        # check that the fields are plain old strings
+        if k in schema.get("fields", []):
+            if type(v) != str and type(v) != unicode and type(v) != int and type(v) != float:
+                raise ObjectSchemaValidationError("object contains " + k + " = " + str(v) + " but expected string, unicode or a number")
+
+        # check that the lists are really lists
+        if k in schema.get("lists", []):
+            if type(v) != list:
+                raise ObjectSchemaValidationError("object contains " + k + " = " + str(v) + " but expected list")
+            # if it is a list, then for each member validate
+            entry_schema = schema.get("list_entries", {}).get(k)
+            if entry_schema is None:
+                # validate the entries as fields
+                for e in v:
+                    if type(e) != str and type(e) != unicode and type(e) != int and type(e) != float:
+                        raise ObjectSchemaValidationError("list in object contains " + str(type(e)) + " but expected string, unicode or a number in " + k)
+            else:
+                # validate each entry against the schema
+                for e in v:
+                    validate(e, entry_schema)
+
+        # check that the objects are objects
+        if k in schema.get("objects", []):
+            if type(v) != dict:
+                raise ObjectSchemaValidationError("object contains " + k + " = " + str(v) + " but expected object/dict")
+            # if it is an object, then validate
+            object_schema = schema.get("object_entries", {}).get(k)
+            if object_schema is None:
+                #raise ObjectSchemaValidationError("no object entry for object " + k)
+                pass # we are not imposing a schema on this object
+            else:
+                validate(v, object_schema)
+
+############################################################
 ## Data structure coercion
 
 class DataStructureException(Exception):
     pass
+
+def construct(obj, struct, coerce, context="", silent_prune=False):
+    """
+    {
+        "fields" : {
+            "field_name" : {"coerce" :"coerce_function", **kwargs}
+
+        },
+        "objects" : [
+            "field_name"
+        ],
+        "lists" : {
+            "field_name" : {"contains" : "object|field", "coerce" : "field_coerce_function, **kwargs}
+        },
+        "required" : ["field_name"],
+        "structs" : {
+            "field_name" : {
+                <construct>
+            }
+        }
+    }
+
+    :param obj:
+    :param struct:
+    :param coerce:
+    :return:
+    """
+    if obj is None:
+        return None
+
+    # check that all the required fields are there
+    keys = obj.keys()
+    for r in struct.get("required", []):
+        if r not in keys:
+            c = context if context != "" else "root"
+            raise DataStructureException("Field '{r}' is required but not present at '{c}'".format(r=r, c=c))
+
+    # check that there are no fields that are not allowed
+    # Note that since the construct mechanism copies fields explicitly, silent_prune literally just turns off this
+    # check
+    if not silent_prune:
+        allowed = struct.get("fields", {}).keys() + struct.get("objects", []) + struct.get("lists", {}).keys()
+        for k in keys:
+            if k not in allowed:
+                c = context if context != "" else "root"
+                raise DataStructureException("Field '{k}' is not permitted at '{c}'".format(k=k, c=c))
+
+
+    # this is the new object we'll be creating from the old
+    constructed = DataObj()
+
+    # now check all the fields
+    for field_name, instructions in struct.get("fields", {}).iteritems():
+        val = obj.get(field_name)
+        if val is None:
+            continue
+        coerce_fn = coerce.get(instructions.get("coerce", "unicode"))
+        if coerce_fn is None:
+            raise DataStructureException("No coersion function defined for type '{x}' at '{c}'".format(x=instructions.get("coerce", "unicode"), c=context + field_name))
+
+        kwargs = construct_kwargs("field", "set", instructions)
+
+        try:
+            constructed._set_single(field_name, val, coerce=coerce_fn, **kwargs)
+        except DataSchemaException as e:
+            raise DataStructureException(e.message)
+
+    # next check all the objetcs (which will involve a recursive call to this function)
+    for field_name in struct.get("objects", []):
+        val = obj.get(field_name)
+        if val is None:
+            continue
+        if type(val) != dict:
+            raise DataStructureException("Found '{x}' = '{y}' but expected object/dict".format(x=context + field_name, y=val))
+
+        instructions = struct.get("structs", {}).get(field_name)
+
+        if instructions is None:
+            # this is the lowest point at which we have instructions, so just accept the data structure as-is
+            # (taking a deep copy to destroy any references)
+            try:
+                constructed._set_single(field_name, deepcopy(val))
+            except DataSchemaException as e:
+                raise DataStructureException(e.message)
+        else:
+            # we need to recurse further down
+            beneath = construct(val, instructions, coerce=coerce, context=context + field_name + ".", silent_prune=silent_prune)
+
+            # what we get back is the correct sub-data structure, which we can then store
+            try:
+                constructed._set_single(field_name, beneath)
+            except DataSchemaException as e:
+                raise DataStructureException(e.message)
+
+    # now check all the lists
+    for field_name, instructions in struct.get("lists", {}).iteritems():
+        vals = obj.get(field_name)
+        if vals is None:
+            continue
+
+        # prep the keyword arguments for the setters
+        kwargs = construct_kwargs("list", "set", instructions)
+
+        contains = instructions.get("contains")
+        if contains == "field":
+            # coerce all the values in the list
+            coerce_fn = coerce.get(instructions.get("coerce", "unicode"))
+            if coerce_fn is None:
+                raise DataStructureException("No coersion function defined for type '{x}' at '{c}'".format(x=instructions.get("coerce", "unicode"), c=context + field_name))
+
+            for i in xrange(len(vals)):
+                val = vals[i]
+                try:
+                    constructed._add_to_list(field_name, val, coerce=coerce_fn, **kwargs)
+                except DataSchemaException as e:
+                    raise DataStructureException(e.message)
+
+        elif contains == "object":
+            # for each object in the list, send it for construction
+            for i in range(len(vals)):
+                val = vals[i]
+
+                if type(val) != dict:
+                    raise DataStructureException("Found '{x}[{p}]' = '{y}' but expected object/dict".format(x=context + field_name, y=val, p=i))
+
+                subinst = struct.get("structs", {}).get(field_name)
+                if subinst is None:
+                    try:
+                        constructed._add_to_list(field_name, deepcopy(val))
+                    except DataSchemaException as e:
+                        raise DataStructureException(e.message)
+                else:
+                    # we need to recurse further down
+                    beneath = construct(val, subinst, coerce=coerce, context=context + field_name + "[" + str(i) + "].", silent_prune=silent_prune)
+
+                    # what we get back is the correct sub-data structure, which we can then store
+                    try:
+                        constructed._add_to_list(field_name, beneath)
+                    except DataSchemaException as e:
+                        raise DataStructureException(e.message)
+
+        else:
+            raise DataStructureException("Cannot understand structure where list '{x}' elements contain '{y}'".format(x=context + field_name, y=contains))
+
+    return constructed.data
 
 
 def construct_merge(target, source):
@@ -386,6 +939,73 @@ def construct_merge(target, source):
 
     return merged
 
+def construct_lookup(path, struct):
+    bits = path.split(".")
+
+    # if there's more than one path element, we will need to recurse
+    if len(bits) > 1:
+        # it has to be an object, in order for the path to still have multiple
+        # segments
+        if bits[0] not in struct.get("objects", []):
+            return None, None, None
+        substruct = struct.get("structs", {}).get(bits[0])
+        return construct_lookup(".".join(bits[1:]), substruct)
+    elif len(bits) == 1:
+        # first check the fields
+        instructions = struct.get("fields", {}).get(bits[0])
+        if instructions is not None:
+            return "field", None, instructions
+
+        # then check the lists
+        instructions = struct.get("lists", {}).get(bits[0])
+        if instructions is not None:
+            structure = struct.get("structs", {}).get(bits[0])
+            return "list", structure, instructions
+
+        # then check the objects
+        if bits[0] in struct.get("objects", []):
+            structure = struct.get("structs", {}).get(bits[0])
+            return "object", structure, None
+
+    return None, None, None
+
+def construct_kwargs(type, dir, instructions):
+    # if there are no instructions there are no kwargs
+    if instructions is None:
+        return {}
+
+    # take a copy of the instructions that we can modify
+    kwargs = deepcopy(instructions)
+
+    # remove the known arguments for the field type
+    if type == "field":
+        if "coerce" in kwargs:
+            del kwargs["coerce"]
+
+    elif type == "list":
+        if "coerce" in kwargs:
+            del kwargs["coerce"]
+        if "contains" in kwargs:
+            del kwargs["contains"]
+
+    nk = {}
+    if dir == "set":
+        for k, v in kwargs.iteritems():
+            # basically everything is a "set" argument unless explicitly stated to be a "get" argument
+            if not k.startswith("get__"):
+                if k.startswith("set__"):    # if it starts with the set__ prefix, remove it
+                    k = k[5:]
+                nk[k] = v
+    elif dir == "get":
+        for k, v in kwargs.iteritems():
+            # must start with "get" argument
+            if k.startswith("get__"):
+                nk[k[5:]] = v
+
+    return nk
+
+def construct_data_keys(struct):
+    return struct.get("fields", {}).keys() + struct.get("objects", []) + struct.get("lists", {}).keys()
 
 ############################################################
 ## Unit test support
@@ -395,7 +1015,7 @@ def test_dataobj(obj, fields_and_values):
     Test a dataobj to make sure that the getters and setters you have specified
     are working correctly.
 
-    Provide it a data object and a list of fields with the values to set and the expected return values (if required):
+    Provide it a data object and a list of fields with the values to set and the expeceted return values (if required):
 
     {
         "key" : ("set value", "get value")
@@ -427,4 +1047,4 @@ def test_dataobj(obj, fields_and_values):
         if len(valtup) > 1:
             get_val = valtup[1]
         val = getattr(obj, k)
-        assert val == get_val, ("Problem get-ting attribute", k, val, get_val)
+        assert val == get_val, (k, val, get_val)

--- a/portality/models/journal.py
+++ b/portality/models/journal.py
@@ -985,6 +985,24 @@ class JournalBibJSON(GenericBibJSON):
     def submission_charges(self):
         return self.bibjson.get("submission_charges", {})
 
+    """
+    FIXME: when the models are updated, we want to change the storage structure to
+    {
+        "other" : "other value"
+        "nat_lib" : "library value",
+        "known" : ["known values"],
+        "url" : "url>
+    }
+    The below methods then need to receive and expose data in the original form
+    {
+        "policy" : [
+            "<known policy type (e.g. LOCKSS)>",
+            ["<policy category>", "<previously unknown policy type>"]
+        ],
+        "url" : "<url to policy information page>"
+    }
+    """
+
     def set_archiving_policy(self, policies, policy_url):
         if "archiving_policy" not in self.bibjson:
             self.bibjson["archiving_policy"] = {}

--- a/portality/view/api_v1.py
+++ b/portality/view/api_v1.py
@@ -5,7 +5,7 @@ from flask_swagger import swagger
 
 from portality.api.v1 import DiscoveryApi, DiscoveryException
 from portality.api.v1 import ApplicationsCrudApi, ArticlesCrudApi, JournalsCrudApi
-from portality.api.v1 import jsonify_models, jsonify_data_object, Api400Error, Api401Error, Api404Error
+from portality.api.v1 import jsonify_models, jsonify_data_object, Api400Error, Api401Error, Api404Error, created
 from portality.core import app
 from portality.decorators import api_key_required, api_key_optional
 
@@ -915,3 +915,36 @@ def retrieve_journal(jid):
     # Api400Error(message)
     # Api401Error(message)
     # Api404Error(message)
+
+#########################################
+## Application CRUD API
+
+@blueprint.route("/applications", methods=["POST"])
+@api_key_required
+def create_application():
+    # get the data from the request
+    try:
+        data = json.loads(request.data)
+    except:
+        raise Api400Error("Supplied data was not valid JSON")
+
+    # delegate to the API implementation
+    a = ApplicationsCrudApi.create(data, current_user)
+
+    # respond with a suitable Created response
+    return created(a, url_for("api_v1.retrieve_application", aid=a.id))
+
+@blueprint.route("/application/<aid>", methods=["GET"])
+@api_key_required
+def retrieve_application(aid):
+    pass
+
+@blueprint.route("/application/<aid>", methods=["PUT"])
+@api_key_required
+def update_application(aid):
+    pass
+
+@blueprint.route("/application/<aid>", methods=["DELETE"])
+@api_key_required
+def delete_application(aid):
+    pass


### PR DESCRIPTION
This provides the following:
* A new data object based on the previous iteration, but with more features
* Revised model objects and tests for journal/vanilla data object
* The Create portion of the Application CRUD API
* Some additions to the api common library which may be shared over all object types
* a README which outlines the API interactions planned for the Applications

It isn't the final Application CRUD but because of the new data object, and the overall pattern demonstrated around Application Create I think it is useful to merge this now.  It also has common code that other CRUD endpoints will want to make use of.