### PR TITLE
Complete treatment of application object validation

### DIFF
--- a/doajtest/fixtures/applications.py
+++ b/doajtest/fixtures/applications.py
@@ -61,8 +61,23 @@ APPLICATION_SOURCE = {
     }
 }
 
+_isbj = deepcopy(JOURNAL_SOURCE['bibjson'])
+_isbj["archiving_policy"] = {
+    "policy" : [
+        {"name" : "LOCKSS"},
+        {"name" : "CLOCKSS"},
+        {"name" : "Trinity", "domain" : "A national library"},
+        {"name" : "A safe place", "domain" : "Other"}
+    ],
+    "url": "http://digital.archiving.policy"
+}
+
 INCOMING_SOURCE = {
-    "bibjson": deepcopy(JOURNAL_SOURCE['bibjson']),
+    "id" : "ignore_me",
+    "created_date" : "2001-01-01T00:00:00Z",
+    "last_updated" : "2001-01-01T00:00:00Z",
+
+    "bibjson": _isbj,
     "suggestion" : {
         "articles_last_year" : {
             "count" : 16,

--- a/doajtest/fixtures/applications.py
+++ b/doajtest/fixtures/applications.py
@@ -71,6 +71,7 @@ _isbj["archiving_policy"] = {
     ],
     "url": "http://digital.archiving.policy"
 }
+del _isbj["subject"]
 
 INCOMING_SOURCE = {
     "id" : "ignore_me",

--- a/doajtest/unit/test_api_crud_application.py
+++ b/doajtest/unit/test_api_crud_application.py
@@ -92,6 +92,12 @@ class TestCrudApplication(DoajTestCase):
         with self.assertRaises(DataStructureException):
             ia = IncomingApplication(data)
 
+        # too many keywords
+        data = ApplicationFixtureFactory.incoming_application()
+        data["bibjson"]["keywords"] = ["one", "two", "three", "four", "five", "six", "seven"]
+        with self.assertRaises(DataStructureException):
+            ia = IncomingApplication(data)
+
     def test_02_create_application_success(self):
         # set up all the bits we need
         data = ApplicationFixtureFactory.incoming_application()
@@ -159,6 +165,11 @@ class TestCrudApplication(DoajTestCase):
         data["bibjson"]["allows_fulltext_indexing"] = "true"
         data["bibjson"]["publication_time"] = "15"
         data["bibjson"]["language"] = ["French", "English"]
+        data["bibjson"]["persistent_identifier_scheme"] = ["doi", "HandleS", "something"]
+        data["bibjson"]["format"] = ["pdf", "html", "doc"]
+        data["bibjson"]["license"][0]["title"] = "cc by"
+        data["bibjson"]["license"][0]["type"] = "CC by"
+        data["bibjson"]["deposit_policy"] = ["sherpa/romeo", "other"]
 
         ia = IncomingApplication(data)
 
@@ -170,6 +181,16 @@ class TestCrudApplication(DoajTestCase):
         assert "fr" in ia.bibjson.language
         assert "en" in ia.bibjson.language
         assert len(ia.bibjson.language) == 2
+        assert ia.bibjson.persistent_identifier_scheme[0] == "DOI"
+        assert ia.bibjson.persistent_identifier_scheme[1] == "Handles"
+        assert ia.bibjson.persistent_identifier_scheme[2] == "something"
+        assert ia.bibjson.format[0] == "PDF"
+        assert ia.bibjson.format[1] == "HTML"
+        assert ia.bibjson.format[2] == "doc"
+        assert ia.bibjson.license[0].title == "CC BY"
+        assert ia.bibjson.license[0].type == "CC BY"
+        assert ia.bibjson.deposit_policy[0] == "Sherpa/Romeo"
+        assert ia.bibjson.deposit_policy[1] == "other"
 
         # now test some failures
         # invalid country name

--- a/portality/api/v1/crud/applications.py
+++ b/portality/api/v1/crud/applications.py
@@ -22,6 +22,11 @@ class ApplicationsCrudApi(CrudApi):
         # if that works, convert it to a Suggestion object
         ap = ia.to_application_model()
 
+        # if the caller set the id, created_date or last_updated, then can the data, and apply our
+        # own values (note that last_updated will get overwritten anyway)
+        ap.set_id()
+        ap.set_created()
+
         # now augment the suggestion object with all the additional information it requires
         #
         # suggester name and email from the user account

--- a/portality/api/v1/data_objects/application.py
+++ b/portality/api/v1/data_objects/application.py
@@ -13,10 +13,27 @@ class IncomingApplication(dataobj.DataObj):
                 "created_date": {"coerce": "utcdatetime"},  # caller, but we'll need to ignore them on the conversion
                 "last_updated": {"coerce": "utcdatetime"}   # to the real object
             },
-            "objects": ["bibjson", "suggestion", "admin"],
-            "required" : ["bibjson", "suggestion", "admin"],
+            "objects": ["admin", "bibjson", "suggestion"],
+            "required" : ["admin", "bibjson", "suggestion"],
 
             "structs": {
+                "admin" : {
+                    "lists" : {
+                        "contact" : {"contains" : "object"}
+                    },
+                    "required" : ["contact"],
+
+                    "structs" : {
+                        "contact": {
+                            "fields" : {
+                                "email" : {"coerce" : "unicode"},
+                                "name" : {"coerce" : "unicode"}
+                            },
+                            "required" : ["name", "email"]
+                        }
+                    }
+                },
+
                 "bibjson": {
                     "fields": {
                         "allows_fulltext_indexing": {"coerce": "bool"},
@@ -52,47 +69,32 @@ class IncomingApplication(dataobj.DataObj):
                         "submission_charges",
                     ],
                     "required": [
-                        "title",
-                        "publisher",
-                        "country",
-                        "apc_url",
-                        "submission_charges_url",
                         "allows_fulltext_indexing",
-                        "publication_time",
+                        "apc_url",
+                        "archiving_policy",
+                        "article_statistics",
+                        "author_copyright",
+                        "author_publishing_rights",
+                        "country",
+                        "deposit_policy",
+                        "editorial_review",
+                        "format",
                         "identifier",
                         "keywords",
                         "language",
-                        "link",
-                        "deposit_policy",
-                        "persistent_identifier_scheme",
-                        "format",
                         "license",
+                        "link",
                         "oa_start",
-                        "archiving_policy",
-                        "editorial_review",
+                        "persistent_identifier_scheme",
                         "plagiarism_detection",
-                        "article_statistics",
-                        "author_copyright",
-                        "author_publishing_rights"
+                        "publication_time",
+                        "publisher",
+                        "submission_charges_url",
+                        "title"
                     ],
 
-
                     "structs": {
-                        "oa_start": {
-                            "fields": {
-                                "year": {"coerce": "integer"}
-                            },
-                            "required" : ["year"]
-                        },
-
                         "apc": {
-                            "fields": {
-                                "currency": {"coerce": "currency_code"},
-                                "average_price": {"coerce": "integer"}
-                            }
-                        },
-
-                        "submission_charges": {
                             "fields": {
                                 "currency": {"coerce": "currency_code"},
                                 "average_price": {"coerce": "integer"}
@@ -119,22 +121,6 @@ class IncomingApplication(dataobj.DataObj):
                             }
                         },
 
-                        "editorial_review": {
-                            "fields": {
-                                "process": {"coerce": "unicode", "allowed_values" : ["Editorial review", "Peer review", "Blind peer review", "Double blind peer review", "Open peer review", "None"]},
-                                "url": {"coerce": "url"},
-                            },
-                            "required" : ["process", "url"]
-                        },
-
-                        "plagiarism_detection": {
-                            "fields": {
-                                "detection": {"coerce": "bool"},
-                                "url": {"coerce": "url"},
-                            },
-                            "required" : ["detection", "url"]
-                        },
-
                         "article_statistics": {
                             "fields": {
                                 "statistics": {"coerce": "bool"},
@@ -159,20 +145,20 @@ class IncomingApplication(dataobj.DataObj):
                             "required" : ["publishing_rights"]
                         },
 
+                        "editorial_review": {
+                            "fields": {
+                                "process": {"coerce": "unicode", "allowed_values" : ["Editorial review", "Peer review", "Blind peer review", "Double blind peer review", "Open peer review", "None"]},
+                                "url": {"coerce": "url"},
+                            },
+                            "required" : ["process", "url"]
+                        },
+
                         "identifier": {
                             "fields": {
                                 "type": {"coerce": "unicode"},
                                 "id": {"coerce": "unicode"},
                             },
                             "required" : ["type", "id"]
-                        },
-
-                        "link": {
-                            "fields": {
-                                "type": {"coerce": "unicode"},
-                                "url": {"coerce": "url"},
-                            },
-                            "required" : ["type", "url"]
                         },
 
                         "license": {
@@ -195,6 +181,36 @@ class IncomingApplication(dataobj.DataObj):
                                 "type",
                                 "open_access"
                             ]
+                        },
+
+                        "link": {
+                            "fields": {
+                                "type": {"coerce": "unicode"},
+                                "url": {"coerce": "url"},
+                            },
+                            "required" : ["type", "url"]
+                        },
+
+                        "oa_start": {
+                            "fields": {
+                                "year": {"coerce": "integer"}
+                            },
+                            "required" : ["year"]
+                        },
+
+                        "plagiarism_detection": {
+                            "fields": {
+                                "detection": {"coerce": "bool"},
+                                "url": {"coerce": "url"},
+                            },
+                            "required" : ["detection", "url"]
+                        },
+
+                        "submission_charges": {
+                            "fields": {
+                                "currency": {"coerce": "currency_code"},
+                                "average_price": {"coerce": "integer"}
+                            }
                         }
                     }
                 },
@@ -215,23 +231,6 @@ class IncomingApplication(dataobj.DataObj):
                                 "url" : {"coerce" : "url"}
                             },
                             "required" : ["count", "url"]
-                        }
-                    }
-                },
-
-                "admin" : {
-                    "lists" : {
-                        "contact" : {"contains" : "object"}
-                    },
-                    "required" : ["contact"],
-
-                    "structs" : {
-                        "contact": {
-                            "fields" : {
-                                "email" : {"coerce" : "unicode"},
-                                "name" : {"coerce" : "unicode"}
-                            },
-                            "required" : ["name", "email"]
                         }
                     }
                 }

--- a/portality/datasets.py
+++ b/portality/datasets.py
@@ -22,8 +22,9 @@ country_options_two_char_code_index = []
 
 currency_options = [('','')]
 currency_options_code_index = []
+currency_name_opts = []
 
-for code, country_info in countries:
+for code, country_info in countries:        # FIXME: a bit of a mess - would be better to have an object that just gave us the answers on demand
     country_options.append((code, country_info['name']))
     country_options_two_char_code_index.append(code)
     if 'currency_alphabetic_code' in country_info and 'currency_name' in country_info:
@@ -37,9 +38,16 @@ for code, country_info in countries:
                     country_info['currency_alphabetic_code'] + ' - ' + country_info['currency_name']
                 )
             )
+            currency_name_opts.append(
+                (
+                    country_info['currency_alphabetic_code'],
+                    country_info['currency_name']
+                )
+            )
             currency_options_code_index.append(country_info['currency_alphabetic_code'])
 
 currencies_dict = dict(currency_options)
+currency_name_map = dict(currency_name_opts)
 
 # languages
 languages_iso639_2 = [
@@ -594,24 +602,24 @@ def name_for_lang(rep):
     else:
         return rep
 
-def get_country_code(current_country):
+def get_country_code(current_country, fail_if_not_found=False):
     new_country = current_country
     if new_country:
-        if new_country not in country_options_two_char_code_index:
+        if new_country in country_options_two_char_code_index:
+            return new_country
+        else:
             for two_char_code, info in countries:
-
                 if new_country.lower() == info['name'].lower():
-                    new_country = two_char_code
-                    break
+                    return two_char_code
 
                 if new_country.lower() == info['ISO3166-1-Alpha-3'].lower():
-                    new_country = two_char_code
-                    break
+                    return two_char_code
 
                 if info['name'].lower().startswith(new_country.lower()):
-                    new_country = two_char_code
-                    break
+                    return two_char_code
 
+    if fail_if_not_found:
+        return None
     return new_country
 
 def get_country_name(code):
@@ -621,4 +629,9 @@ def get_currency_name(code):
     return currencies_dict.get(code, code)  # return what was passed in if not found
 
 def get_currency_code(name):
-    pass
+    if name in currency_name_map.keys():
+        return name
+    for k, v in currency_name_map.iteritems():
+        if v.lower() == name.lower():
+            return k
+    return None

--- a/portality/formcontext/choices.py
+++ b/portality/formcontext/choices.py
@@ -220,6 +220,8 @@ class Choices(object):
     def digital_archiving_policy_list(cls, type=None):
         if type is None:
             return [v[0] for v in cls._digital_archiving_policy]
+        elif type == "named":
+            return [v[0] for v in cls._digital_archiving_policy if v not in [cls.digital_archiving_policy_val("library"), cls.digital_archiving_policy_val("other")]]
         elif type == "optional":
             return [cls.digital_archiving_policy_val("library"), cls.digital_archiving_policy_val("other")]
 

--- a/portality/lib/dataobj.py
+++ b/portality/lib/dataobj.py
@@ -172,7 +172,31 @@ def to_bool(val):
 
     raise ValueError(u"Could not convert {val} to boolean. Expect either boolean or string.".format(val=val))
 
+def string_canonicalise(canon, allow_fail=False):
+    normalised = {}
+    for a in canon:
+        normalised[a.strip().lower()] = a
 
+    def sn(val):
+        if val is None:
+            if allow_fail:
+                return None
+            raise ValueError("NoneType not permitted")
+
+        try:
+            norm = val.strip().lower()
+        except:
+            raise ValueError("Unable to treat value as a string")
+
+        uc = to_unicode()
+        if norm in normalised:
+            return uc(normalised[norm])
+        if allow_fail:
+            return uc(val)
+
+        raise ValueError("Unable to canonicalise string")
+
+    return sn
 
 ############################################################
 
@@ -863,6 +887,8 @@ def construct(obj, struct, coerce, context="", silent_prune=False):
         vals = obj.get(field_name)
         if vals is None:
             continue
+        if not isinstance(vals, list):
+            vals = [vals]
 
         # prep the keyword arguments for the setters
         kwargs = construct_kwargs("list", "set", instructions)

--- a/portality/lib/dataobj.py
+++ b/portality/lib/dataobj.py
@@ -1,5 +1,5 @@
 from portality.lib import dates
-from portality.datasets import get_country_code
+from portality.datasets import get_country_code, get_currency_code
 from copy import deepcopy
 import locale, json, urlparse
 
@@ -7,17 +7,22 @@ import locale, json, urlparse
 ## Data coerce functions
 
 def to_currency_code(val):
-    # FIXME: implement
-    return val
+    if val is None:
+        return None
+    nv = get_currency_code(val)
+    if nv is None:
+        raise ValueError("Unable to convert {x} to a valid currency code".format(x=val))
+    uc = to_unicode()
+    return uc(nv)
 
-def to_country_code():
-
-    def cc(val):
-        val = get_country_code(val)
-        uc = to_unicode()
-        return uc(val)
-
-    return cc
+def to_country_code(val):
+    if val is None:
+        return None
+    nv = get_country_code(val, fail_if_not_found=True)
+    if nv is None:
+        raise ValueError("Unable to convert {x} to a valid country code".format(x=val))
+    uc = to_unicode()
+    return uc(nv)
 
 def to_unicode():
     def to_utf8_unicode(val):
@@ -127,6 +132,8 @@ def to_isolang(output_format=None):
         if val is None:
             return None
         l = dataset.find(val)
+        if l is None:
+            raise ValueError("Unable to find iso code for language {x}".format(x=val))
         for f in output_format:
             v = l.get(f)
             if v is None or v == "":
@@ -193,7 +200,7 @@ class DataObj(object):
         "url": to_url,
         "bool": to_bool,
         "isolang_2letter": to_isolang(output_format="alpha2"),
-        "country_code" : to_country_code(),
+        "country_code" : to_country_code,
         "currency_code" : to_currency_code
     }
 


### PR DESCRIPTION
Thought it would be useful to make another PR, as I've now done a full treatment of the validation requirements for the application model, and this will be useful in the implementation of the journal crud.

Note the addition of custom coerce functions in the constructor, which use a newly created string_canonicalise dataobj coerce routine, giving us parity with the behaviour of the submission form.