### PR TITLE
[hotfix] Fix invisible close button on filters

### DIFF
--- a/portality/static/doaj/js/available_facetviews/admin.applications.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.applications.facetview.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/admin_query/suggestion/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         post_render_callback: doajScrollTop,
 
         sharesave_link: false,

--- a/portality/static/doaj/js/available_facetviews/admin.editorgroups.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.editorgroups.facetview.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/admin_query/editor,group/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         post_render_callback: doajEGPostRender,
 
         sharesave_link: false,

--- a/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
@@ -130,6 +130,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/admin_query/journal,article/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         post_render_callback: adminJAPostRender,
         post_search_callback: adminButtons,
 

--- a/portality/static/doaj/js/available_facetviews/admin.journals.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.journals.facetview.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/admin_query/journal/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         post_render_callback: doajScrollTop,
 
         sharesave_link: false,

--- a/portality/static/doaj/js/available_facetviews/associate.applications.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/associate.applications.facetview.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/associate_query/suggestion/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         render_not_found: associateApplicationNotFound,
         post_render_callback: doajScrollTop,
 

--- a/portality/static/doaj/js/available_facetviews/associate.journals.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/associate.journals.facetview.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/associate_query/journal/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         render_not_found: associateJournalNotFound,
         post_render_callback: doajScrollTop,
 

--- a/portality/static/doaj/js/available_facetviews/editor.groupapplications.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/editor.groupapplications.facetview.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/editor_query/suggestion/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         render_not_found: editorGroupApplicationNotFound,
         post_render_callback: doajScrollTop,
 

--- a/portality/static/doaj/js/available_facetviews/editor.groupjournals.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/editor.groupjournals.facetview.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/editor_query/journal/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         render_not_found: editorGroupJournalNotFound,
         post_render_callback: doajScrollTop,
 

--- a/portality/static/doaj/js/available_facetviews/public.journalarticle.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/public.journalarticle.facetview.js
@@ -529,6 +529,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/query/journal,article/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         render_result_record: publicSearchResult,
 
         pre_search_callback: dynamicFacets,

--- a/portality/static/doaj/js/available_facetviews/publisher.journals.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/publisher.journals.facetview.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/publisher_query/journal/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         render_not_found: publisherJournalNotFound,
         post_render_callback: doajScrollTop,
 

--- a/portality/static/doaj/js/available_facetviews/publisher.reapplications.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/publisher.reapplications.facetview.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function ($) {
         search_url: es_scheme + '//' + es_domain + '/publisher_reapp_query/suggestion/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         render_not_found: publisherReapplicationNotFound,
         post_render_callback: doajScrollTop,
 

--- a/portality/static/doaj/js/available_facetviews/users.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/users.facetview.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function($) {
         search_url: es_scheme + '//' + es_domain + '/admin_query/account/_search?',
 
         render_results_metadata: doajPager,
+        render_active_terms_filter: doajRenderActiveTermsFilter,
         post_render_callback: doajScrollTop,
 
         sharesave_link: false,

--- a/portality/static/doaj/js/doaj.facetview.theme.js
+++ b/portality/static/doaj/js/doaj.facetview.theme.js
@@ -209,6 +209,55 @@ function doajEGPostRender(options, context) {
     });
 }
 
+function doajRenderActiveTermsFilter(options, facet, field, filter_list) {
+    /*****************************************
+     * overrides must provide the following classes and ids
+     *
+     * class: facetview_filterselected - anchor tag for any clickable filter selection
+     * class: facetview_clear - anchor tag for any link which will remove the filter (should also provide data-value and data-field)
+     * class: facetview_inactive_link - any link combined with facetview_filterselected which should not execute when clicked
+     *
+     * should (not must) respect the config
+     *
+     * options.show_filter_field - whether to include the name of the field the filter is active on
+     * options.show_filter_logic - whether to include AND/OR along with filters
+     * facet.value_function - the value function to be applied to all displayed values
+     */
+
+    // DOAJ note: we are overriding this (99.9% the same as facetview2's bootstrap2 theme)
+    // because we need to change the class of the cross icon used to close active filters.
+    // We use FontAwesome at the DOAJ because the colours are overridable unlike Bootstrap's glyphicons.
+
+    var clean = safeId(field);
+    var display = facet.display ? facet.display : facet.field;
+    var logic = facet.logic ? facet.logic : options.default_facet_operator;
+
+    var frag = "<div id='facetview_filter_group_" + clean + "' class='btn-group'>";
+
+    if (options.show_filter_field) {
+        frag += '<span class="facetview_filterselected_text"><strong>' + display + ':</strong>&nbsp;</span>';
+    }
+
+    for (var i = 0; i < filter_list.length; i++) {
+        var value = filter_list[i];
+        if (facet.value_function) {
+            value = facet.value_function(value)
+        }
+
+        frag += '<span class="facetview_filterselected_text">' + value + '</span>&nbsp;';
+        frag += '<a class="facetview_filterselected facetview_clear" data-field="' + field + '" data-value="' + value + '" alt="remove" title="Remove" href="' + value + '">';
+        frag += '<i class="fa fa-remove" style="margin-top:1px;"></i>';
+        frag += "</a>";
+
+        if (i !== filter_list.length - 1 && options.show_filter_logic) {
+            frag += '<span class="facetview_filterselected_text">&nbsp;<strong>' + logic + '</strong>&nbsp;</span>';
+        }
+    }
+    frag += "</div>";
+
+    return frag
+}
+
 function editorGroupJournalNotFound() {
     return "<tr class='facetview_not_found'>" +
         "<td><p>There are no journals for your editor group(s) that meet the search criteria</p>" +


### PR DESCRIPTION
# HOTFIX, DO NOT MERGE HERE

For #854 

There are many ways I could've done this including just removing .icon-white and .icon-remove with Javascript on page load, and then replacing with .fa .fa-remove . But that feels hackier, I think the HTML should contain the intent (otherwise as a dev I will one day wonder why the hell are my bootstrap icons coloured when that's impossible and I don't seem to be using FontAwesome ones - the override is too easy to miss).

I wanted to do it the right way which to me seems to be to use the callback functionality and just render custom filters, identical in every way except the remove icon.