### PR TITLE
add journal retrieval to crud

### DIFF
--- a/doajtest/fixtures/article.py
+++ b/doajtest/fixtures/article.py
@@ -37,6 +37,10 @@ class ArticleFixtureFactory(object):
     def make_article_source():
         return deepcopy(ARTICLE_SOURCE)
 
+    @staticmethod
+    def make_article_apido_struct():
+        return deepcopy(ARTICLE_STRUCT)
+
 ARTICLE_SOURCE = {
     "id" : "abcdefghijk_article",
     "admin" : {
@@ -108,4 +112,76 @@ ARTICLE_SOURCE = {
         ],
     },
     "created_date": "2000-01-01T00:00:00Z"
+}
+
+ARTICLE_STRUCT = {
+    "fields": {
+        "id": {"coerce": "unicode"},                # Note that we'll leave these in for ease of use by the
+        "created_date": {"coerce": "utcdatetime"},  # caller, but we'll need to ignore them on the conversion
+        "last_updated": {"coerce": "utcdatetime"}   # to the real object
+    },
+    "objects": ["admin", "bibjson"],
+
+    "structs": {
+
+        "admin": {
+            "fields": {
+                "in_doaj": {"coerce": "bool", "get__default": False},
+                "publisher_record_id": {"coerce": "unicode"},
+                "upload_id": {"coerce": "unicode"}
+            }
+        },
+
+        "bibjson": {
+            "fields": {
+                "title": {"coerce": "unicode"},
+                "year": {"coerce": "unicode"},
+                "month": {"coerce": "unicode"},
+                "start_page": {"coerce": "unicode"},
+                "end_page": {"coerce": "unicode"},
+                "abstract": {"coerce": "unicode"}
+            },
+            "lists": {
+                "identifier": {"contains": "object"},
+                "link": {"contains": "object"},
+                "author": {"contains": "object"},
+                "keywords": {"coerce": "unicode", "contains": "field"},
+            },
+            "objects": [
+                "journal",
+            ],
+            "structs": {
+
+                "identifier": {
+                    "fields": {
+                        "type": {"coerce": "unicode"},
+                        "id": {"coerce": "unicode"}
+                    }
+                },
+
+                "link": {
+                    "fields": {
+                        "type": {"coerce": "link_type"},
+                        "url": {"coerce": "url"},
+                        "content_type": {"coerce": "link_content_type"}
+                    }
+                },
+
+                "author": {
+                    "fields": {
+                        "name": {"coerce": "unicode"},
+                        "email": {"coerce": "unicode"},
+                        "affiliation": {"coerce": "unicode"}
+                    }
+                },
+
+                "journal": {
+                    "fields": {
+                        "volume": {"coerce": "unicode"},
+                        "number": {"coerce": "unicode"}
+                    },
+                }
+            }
+        }
+    }
 }

--- a/doajtest/fixtures/journals.py
+++ b/doajtest/fixtures/journals.py
@@ -84,7 +84,14 @@ JOURNAL_SOURCE = {
         ],
 
         "oa_start": {
-            "year": 1980,
+            "volume": "1",
+            "number": "1",
+            "year": "1980",
+        },
+        "oa_end": {
+            "volume": "10",
+            "number": "10",
+            "year": "1985",
         },
         "apc_url" : "http://apc.com",
         "apc": {

--- a/doajtest/fixtures/journals.py
+++ b/doajtest/fixtures/journals.py
@@ -87,7 +87,7 @@ JOURNAL_SOURCE = {
         ],
 
         "oa_start": {
-            "year": "1980",
+            "year": 1980,
         },
         "apc_url" : "http://apc.com",
         "apc": {
@@ -169,7 +169,8 @@ JOURNAL_OBSOLETE_OA_START = {
     "bibjson": {
         "oa_start": {
             "volume": "1",
-            "number": "1"
+            "number": "1",
+            "year": "1980",  # some journals do have those as strings in live
         }
     }
 }

--- a/doajtest/fixtures/journals.py
+++ b/doajtest/fixtures/journals.py
@@ -4,8 +4,11 @@ from doajtest.fixtures.common import EDITORIAL, SUBJECT, NOTES, OWNER, SEAL
 
 class JournalFixtureFactory(object):
     @staticmethod
-    def make_journal_source(in_doaj=False):
+    def make_journal_source(in_doaj=False, include_obsolete_fields=False):
         template = deepcopy(JOURNAL_SOURCE)
+        if include_obsolete_fields:
+            template.update(JOURNAL_OBSOLETE_OA_START)
+            template.update(JOURNAL_OA_END)
         template['admin']['in_doaj'] = in_doaj
         return template
 
@@ -84,14 +87,7 @@ JOURNAL_SOURCE = {
         ],
 
         "oa_start": {
-            "volume": "1",
-            "number": "1",
             "year": "1980",
-        },
-        "oa_end": {
-            "volume": "10",
-            "number": "10",
-            "year": "1985",
         },
         "apc_url" : "http://apc.com",
         "apc": {
@@ -168,6 +164,26 @@ JOURNAL_SOURCE = {
         "seal": True
     }
 }
+
+JOURNAL_OBSOLETE_OA_START = {
+    "bibjson": {
+        "oa_start": {
+            "volume": "1",
+            "number": "1"
+        }
+    }
+}
+
+JOURNAL_OA_END = {
+    "bibjson": {
+        "oa_end": {
+            "volume": "10",
+            "number": "10",
+            "year": "1985",
+        }
+    }
+}
+
 
 JOURNAL_SOURCE_WITH_LEGACY_INFO = deepcopy(JOURNAL_SOURCE)
 JOURNAL_SOURCE_WITH_LEGACY_INFO['bibjson']["author_pays"] = "Y"
@@ -295,49 +311,131 @@ JOURNAL_APIDO_STRUCT = {
         },
         "bibjson": {
             "fields": {
-                "title": {"coerce": "unicode"},
-                "alternative_title": {"coerce": "unicode"},
-                "country": {"coerce": "unicode"},
-                "publisher": {"coerce": "unicode"},
-                "provider": {"coerce": "unicode"},
-                "institution": {"coerce": "unicode"},
-                "apc_url": {"coerce": "unicode"},
-                "submission_charges_url": {"coerce": "unicode"},
                 "allows_fulltext_indexing": {"coerce": "bool"},
+                "alternative_title": {"coerce": "unicode"},
+                "apc_url": {"coerce": "url"},
+                "country": {"coerce": "country_code"},
+                "institution": {"coerce": "unicode"},
+                "provider": {"coerce": "unicode"},
                 "publication_time": {"coerce": "integer"},
+                "publisher": {"coerce": "unicode"},
+                "submission_charges_url": {"coerce": "url"},
+                "title": {"coerce": "unicode"},
+            },
+            "lists": {
+                "deposit_policy": {"coerce": "deposit_policy", "contains": "field"},
+                "format": {"coerce": "format", "contains": "field"},
+                "identifier": {"contains": "object"},
+                "keywords": {"coerce": "unicode", "contains": "field"},
+                "language": {"coerce": "isolang_2letter", "contains": "field"},
+                "license": {"contains": "object"},
+                "link": {"contains": "object"},
+                "persistent_identifier_scheme": {"coerce": "persistent_identifier_scheme", "contains": "field"},
+                "subject": {"contains": "object"}
             },
             "objects": [
-                "oa_start",
-                "oa_end",
                 "apc",
-                "submission_charges",
                 "archiving_policy",
-                "editorial_review",
-                "plagiarism_detection",
                 "article_statistics",
                 "author_copyright",
                 "author_publishing_rights",
+                "editorial_review",
+                "oa_start",
+                "oa_end",
+                "plagiarism_detection",
+                "submission_charges",
             ],
-            "lists": {
-                "identifier": {"contains": "object"},
-                "keywords": {"coerce": "unicode", "contains": "field"},
-                "language": {"coerce": "unicode", "contains": "field"},
-                "link": {"contains": "object"},
-                "subject": {"contains": "object"},
-                "deposit_policy": {"coerce": "unicode", "contains": "field"},
-                "persistent_identifier_scheme": {"coerce": "unicode", "contains": "field"},
-                "format": {"coerce": "unicode", "contains": "field"},
-                "license": {"contains": "object"},
-            },
-            "required": [],
+
             "structs": {
-                "oa_start": {
+                "apc": {
                     "fields": {
-                        "year": {"coerce": "integer"},
-                        "volume": {"coerce": "integer"},
-                        "number": {"coerce": "integer"},
+                        "currency": {"coerce": "currency_code"},
+                        "average_price": {"coerce": "integer"}
                     }
                 },
+
+                "archiving_policy": {               # NOTE: this is not the same as the storage model, so beware when working with this
+                    "fields": {
+                        "url": {"coerce": "url"},
+                    },
+                    "lists": {
+                        "policy": {"coerce": "unicode", "contains": "object"},
+                    },
+
+                    "structs" : {
+                        "policy" : {
+                            "fields" : {
+                                "name" : {"coerce": "unicode"},
+                                "domain" : {"coerce" : "unicode"}
+                            }
+                        }
+                    }
+                },
+
+                "article_statistics": {
+                    "fields": {
+                        "statistics": {"coerce": "bool"},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "author_copyright": {
+                    "fields": {
+                        "copyright": {"coerce": "unicode"},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "author_publishing_rights": {
+                    "fields": {
+                        "publishing_rights": {"coerce": "unicode"},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "editorial_review": {
+                    "fields": {
+                        "process": {"coerce": "unicode", "allowed_values" : ["Editorial review", "Peer review", "Blind peer review", "Double blind peer review", "Open peer review", "None"]},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "identifier": {
+                    "fields": {
+                        "type": {"coerce": "unicode"},
+                        "id": {"coerce": "unicode"},
+                    }
+                },
+
+                "license": {
+                    "fields": {
+                        "title": {"coerce": "license"},
+                        "type": {"coerce": "license"},
+                        "url": {"coerce": "url"},
+                        "version": {"coerce": "unicode"},
+                        "open_access": {"coerce": "bool"},
+                        "BY": {"coerce": "bool"},
+                        "NC": {"coerce": "bool"},
+                        "ND": {"coerce": "bool"},
+                        "SA": {"coerce": "bool"},
+                        "embedded": {"coerce": "bool"},
+                        "embedded_example_url": {"coerce": "url"},
+                    }
+                },
+
+                "link": {
+                    "fields": {
+                        "type": {"coerce": "unicode"},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "oa_start": {
+                    "fields": {
+                        "year": {"coerce": "integer"}
+                    }
+                },
+
                 "oa_end": {
                     "fields": {
                         "year": {"coerce": "integer"},
@@ -345,66 +443,18 @@ JOURNAL_APIDO_STRUCT = {
                         "number": {"coerce": "integer"},
                     }
                 },
-                "apc": {
-                    "fields": {
-                        "currency": {"coerce": "unicode"},
-                        "average_price": {"coerce": "integer"}
-                    }
-                },
-                "submission_charges": {
-                    "fields": {
-                        "currency": {"coerce": "unicode"},
-                        "average_price": {"coerce": "integer"}
-                    }
-                },
-                "archiving_policy": {
-                    "fields": {
-                        "url": {"coerce": "unicode"},
-                    },
-                    "lists": {
-                        "policy": {"coerce": "unicode", "contains": "field"},
-                    }
-                },
-                "editorial_review": {
-                    "fields": {
-                        "process": {"coerce": "unicode"},
-                        "url": {"coerce": "unicode"},
-                    }
-                },
+
                 "plagiarism_detection": {
                     "fields": {
                         "detection": {"coerce": "bool"},
-                        "url": {"coerce": "unicode"},
+                        "url": {"coerce": "url"},
                     }
                 },
-                "article_statistics": {
+
+                "submission_charges": {
                     "fields": {
-                        "detection": {"coerce": "bool"},
-                        "url": {"coerce": "unicode"},
-                    }
-                },
-                "author_copyright": {
-                    "fields": {
-                        "copyright": {"coerce": "unicode"},
-                        "url": {"coerce": "unicode"},
-                    }
-                },
-                "author_publishing_rights": {
-                    "fields": {
-                        "publishing_rights": {"coerce": "unicode"},
-                        "url": {"coerce": "unicode"},
-                    }
-                },
-                "identifier": {
-                    "fields": {
-                        "type": {"coerce": "unicode"},
-                        "id": {"coerce": "unicode"},
-                    }
-                },
-                "link": {
-                    "fields": {
-                        "type": {"coerce": "unicode"},
-                        "url": {"coerce": "unicode"},
+                        "currency": {"coerce": "currency_code"},
+                        "average_price": {"coerce": "integer"}
                     }
                 },
                 "subject": {
@@ -413,22 +463,7 @@ JOURNAL_APIDO_STRUCT = {
                         "term": {"coerce": "unicode"},
                         "code": {"coerce": "unicode"},
                     }
-                },
-                "license": {
-                    "fields": {
-                        "title": {"coerce": "unicode"},
-                        "type": {"coerce": "unicode"},
-                        "url": {"coerce": "unicode"},
-                        "version": {"coerce": "unicode"},
-                        "open_access": {"coerce": "bool"},
-                        "BY": {"coerce": "bool"},
-                        "NC": {"coerce": "bool"},
-                        "ND": {"coerce": "bool"},
-                        "SA": {"coerce": "bool"},
-                        "embedded": {"coerce": "bool"},
-                        "embedded_example_url": {"coerce": "unicode"},
-                    }
-                },
+                }
             }
         }
     }

--- a/doajtest/fixtures/journals.py
+++ b/doajtest/fixtures/journals.py
@@ -7,8 +7,8 @@ class JournalFixtureFactory(object):
     def make_journal_source(in_doaj=False, include_obsolete_fields=False):
         template = deepcopy(JOURNAL_SOURCE)
         if include_obsolete_fields:
-            template.update(JOURNAL_OBSOLETE_OA_START)
-            template.update(JOURNAL_OA_END)
+            template['bibjson']['oa_start'] = JOURNAL_OBSOLETE_OA_START
+            template['bibjson']['oa_end'] = JOURNAL_OBSOLETE_OA_END
         template['admin']['in_doaj'] = in_doaj
         return template
 
@@ -166,23 +166,15 @@ JOURNAL_SOURCE = {
 }
 
 JOURNAL_OBSOLETE_OA_START = {
-    "bibjson": {
-        "oa_start": {
-            "volume": "1",
-            "number": "1",
-            "year": "1980",  # some journals do have those as strings in live
-        }
-    }
+    "volume": "1",
+    "number": "1",
+    "year": "1980",  # some journals do have those as strings in live
 }
 
-JOURNAL_OA_END = {
-    "bibjson": {
-        "oa_end": {
-            "volume": "10",
-            "number": "10",
-            "year": "1985",
-        }
-    }
+JOURNAL_OBSOLETE_OA_END = {  # the entire oa_end is obsolete
+    "volume": "10",
+    "number": "10",
+    "year": "1985",
 }
 
 

--- a/doajtest/fixtures/journals.py
+++ b/doajtest/fixtures/journals.py
@@ -433,7 +433,9 @@ JOURNAL_APIDO_STRUCT = {
 
                 "oa_start": {
                     "fields": {
-                        "year": {"coerce": "integer"}
+                        "year": {"coerce": "integer"},
+                        "volume": {"coerce": "integer"},
+                        "number": {"coerce": "integer"},
                     }
                 },
 

--- a/doajtest/unit/test_api_crud_journal.py
+++ b/doajtest/unit/test_api_crud_journal.py
@@ -1,0 +1,108 @@
+from doajtest.helpers import DoajTestCase
+from portality.api.v1.data_objects import OutgoingJournal
+from portality.api.v1 import JournalsCrudApi, Api401Error, Api404Error, Api403Error
+from portality import models
+from doajtest.fixtures import JournalFixtureFactory
+import time
+
+class TestCrudJournal(DoajTestCase):
+
+    def setUp(self):
+        super(TestCrudJournal, self).setUp()
+
+    def tearDown(self):
+        super(TestCrudJournal, self).tearDown()
+
+    def test_01_outgoing_journal_do(self):
+        # make a blank one successfully
+        oj = OutgoingJournal()
+
+        # make one from an incoming journal model fixture
+        data = JournalFixtureFactory.make_journal_source()
+        j = models.Journal(**data)
+        oj = OutgoingJournal.from_model(j)
+
+        # check that it does not contain information that it shouldn't
+        assert oj.data.get("index") is None
+        assert oj.data.get("history") is None
+        assert oj.data.get("admin", {}).get("active") is None
+        assert oj.data.get("admin", {}).get("notes") is None
+        assert oj.data.get("admin", {}).get("editor_group") is None
+        assert oj.data.get("admin", {}).get("editor") is None
+
+    def test_02_retrieve_public_journal_success(self):
+        # set up all the bits we need
+        data = JournalFixtureFactory.make_journal_source(in_doaj=True)
+        j = models.Journal(**data)
+        j.save()
+        time.sleep(2)
+        
+        a = JournalsCrudApi.retrieve(j.id, account=None)
+        # check that we got back the object we expected
+        assert isinstance(a, OutgoingJournal)
+        assert a.id == j.id
+        
+        # it should also work if we're logged in with the owner or another user
+        # owner first
+        account = models.Account()
+        account.set_id(j.owner)
+        account.set_name("Tester")
+        account.set_email("test@test.com")
+        
+        a = JournalsCrudApi.retrieve(j.id, account)
+
+        assert isinstance(a, OutgoingJournal)
+        assert a.id == j.id
+        
+        # try with another account
+        not_owner = models.Account()
+        not_owner.set_id("asdklfjaioefwe")
+        a = JournalsCrudApi.retrieve(j.id, not_owner)
+        assert isinstance(a, OutgoingJournal)
+        assert a.id == j.id
+
+    def test_03_retrieve_public_journal_fail(self):
+        with self.assertRaises(Api404Error):
+            a = JournalsCrudApi.retrieve("ijsidfawefwefw", account=None)
+
+    def test_04_retrieve_private_journal_success(self):
+        # set up all the bits we need
+        data = JournalFixtureFactory.make_journal_source()
+        j = models.Journal(**data)
+        j.save()
+        time.sleep(2)
+
+        account = models.Account()
+        account.set_id(j.owner)
+        account.set_name("Tester")
+        account.set_email("test@test.com")
+
+        # call retrieve on the object
+        a = JournalsCrudApi.retrieve(j.id, account)
+
+        # check that we got back the object we expected
+        assert isinstance(a, OutgoingJournal)
+        assert a.id == j.id
+
+    def test_05_retrieve_private_journal_fail(self):
+        # set up all the bits we need
+        data = JournalFixtureFactory.make_journal_source(in_doaj=False)
+        j = models.Journal(**data)
+        j.save()
+        time.sleep(2)
+
+        # no user
+        with self.assertRaises(Api401Error):
+            a = JournalsCrudApi.retrieve(j.id, None)
+
+        # wrong user
+        account = models.Account()
+        account.set_id("asdklfjaioefwe")
+        with self.assertRaises(Api404Error):
+            a = JournalsCrudApi.retrieve(j.id, account)
+
+        # non-existant journal
+        account = models.Account()
+        account.set_id(j.id)
+        with self.assertRaises(Api404Error):
+            a = JournalsCrudApi.retrieve("ijsidfawefwefw", account)

--- a/doajtest/unit/test_api_crud_journal.py
+++ b/doajtest/unit/test_api_crud_journal.py
@@ -18,7 +18,7 @@ class TestCrudJournal(DoajTestCase):
         oj = OutgoingJournal()
 
         # make one from an incoming journal model fixture
-        data = JournalFixtureFactory.make_journal_source()
+        data = JournalFixtureFactory.make_journal_source(include_obsolete_fields=True)
         j = models.Journal(**data)
         oj = OutgoingJournal.from_model(j)
 
@@ -32,7 +32,7 @@ class TestCrudJournal(DoajTestCase):
 
     def test_02_retrieve_public_journal_success(self):
         # set up all the bits we need
-        data = JournalFixtureFactory.make_journal_source(in_doaj=True)
+        data = JournalFixtureFactory.make_journal_source(in_doaj=True, include_obsolete_fields=True)
         j = models.Journal(**data)
         j.save()
         time.sleep(2)
@@ -67,7 +67,7 @@ class TestCrudJournal(DoajTestCase):
 
     def test_04_retrieve_private_journal_success(self):
         # set up all the bits we need
-        data = JournalFixtureFactory.make_journal_source()
+        data = JournalFixtureFactory.make_journal_source(include_obsolete_fields=True)
         j = models.Journal(**data)
         j.save()
         time.sleep(2)
@@ -86,7 +86,7 @@ class TestCrudJournal(DoajTestCase):
 
     def test_05_retrieve_private_journal_fail(self):
         # set up all the bits we need
-        data = JournalFixtureFactory.make_journal_source(in_doaj=False)
+        data = JournalFixtureFactory.make_journal_source(in_doaj=False, include_obsolete_fields=True)
         j = models.Journal(**data)
         j.save()
         time.sleep(2)

--- a/doajtest/unit/test_api_dataobj.py
+++ b/doajtest/unit/test_api_dataobj.py
@@ -1,6 +1,6 @@
 from doajtest.helpers import DoajTestCase
 from portality.lib.dataobj import DataObj, merge_outside_construct
-from portality.api.v1.data_objects import JournalDO
+from portality.api.v1.data_objects import OutgoingJournal
 from portality import models
 from datetime import datetime
 from doajtest.fixtures import ApplicationFixtureFactory, JournalFixtureFactory, ArticleFixtureFactory
@@ -31,7 +31,7 @@ class TestAPIDataObj(DoajTestCase):
 
     def test_03_create_from_model(self):
         expected_struct = JournalFixtureFactory.make_journal_apido_struct()
-        do = JournalDO.from_model(self.jm)
+        do = OutgoingJournal.from_model(self.jm)
         assert do._struct == expected_struct
         self.check_do(do, expected_struct)
 

--- a/doajtest/unit/test_api_dataobj.py
+++ b/doajtest/unit/test_api_dataobj.py
@@ -10,7 +10,7 @@ class TestAPIDataObj(DoajTestCase):
 
     # we aren't going to talk to ES so override setup and teardown of index
     def setUp(self):
-        self.jm = models.Journal(**JournalFixtureFactory.make_journal_source())
+        self.jm = models.Journal(**JournalFixtureFactory.make_journal_source(include_obsolete_fields=True))
 
     def tearDown(self):
         pass
@@ -73,9 +73,9 @@ class TestAPIDataObj(DoajTestCase):
         assert do.bibjson.oa_start.volume == self.jm.bibjson().oa_start.get('volume')
         assert do.bibjson.oa_start.number == self.jm.bibjson().oa_start.get('number')
 
-        assert do.bibjson.oa_end.year == self.jm.bibjson().oa_end.get('year')
-        assert do.bibjson.oa_end.volume == self.jm.bibjson().oa_end.get('volume')
-        assert do.bibjson.oa_end.number == self.jm.bibjson().oa_end.get('number')
+        assert do.bibjson.oa_end.year == int(self.jm.bibjson().oa_end.get('year'))
+        assert do.bibjson.oa_end.volume == int(self.jm.bibjson().oa_end.get('volume'))
+        assert do.bibjson.oa_end.number == int(self.jm.bibjson().oa_end.get('number'))
 
         assert do.bibjson.apc.currency == self.jm.bibjson().apc['currency']
         assert do.bibjson.apc.average_price == self.jm.bibjson().apc['average_price']

--- a/portality/api/v1/crud/applications.py
+++ b/portality/api/v1/crud/applications.py
@@ -111,7 +111,7 @@ class ApplicationsCrudApi(CrudApi):
         new_ap.set_owner(ap.owner)
         new_ap.set_suggester(ap.suggester['name'], ap.suggester['email'])
         new_ap.suggested_on = ap.suggested_on
-        new_ap.bibjson().set_subjects(ap.bibjson().subjects)
+        new_ap.bibjson().set_subjects(ap.bibjson().subjects())
 
         # reset the status on the application
         new_ap.set_application_status('pending')

--- a/portality/api/v1/crud/applications.py
+++ b/portality/api/v1/crud/applications.py
@@ -43,6 +43,11 @@ class ApplicationsCrudApi(CrudApi):
         # set the owner to the current account
         ap.set_owner(account.id)
 
+        # they are not allowed to set "subject" and we don't want it just empty either, so remove it
+        bj = ap.bibjson()
+        if "subject" in bj:
+            del bj['subject']
+
         # finally save the new application, and return to the caller
         ap.save()
         return ap
@@ -104,6 +109,10 @@ class ApplicationsCrudApi(CrudApi):
         # are copied over
         new_ap.set_id(id)
         new_ap.set_created(ap.created_date)
+        new_ap.set_owner(ap.owner)
+        new_ap.set_suggester(ap.suggester['name'], ap.suggester['email'])
+        new_ap.suggested_on = ap.suggested_on
+        new_ap.bibjson().set_subjects(ap.bibjson().subjects)
 
         # reset the status on the application
         new_ap.set_application_status('pending')

--- a/portality/api/v1/crud/applications.py
+++ b/portality/api/v1/crud/applications.py
@@ -43,10 +43,9 @@ class ApplicationsCrudApi(CrudApi):
         # set the owner to the current account
         ap.set_owner(account.id)
 
-        # they are not allowed to set "subject" and we don't want it just empty either, so remove it
+        # they are not allowed to set "subject"
         bj = ap.bibjson()
-        if "subject" in bj:
-            del bj['subject']
+        bj.remove_subjects()
 
         # finally save the new application, and return to the caller
         ap.save()

--- a/portality/api/v1/crud/journals.py
+++ b/portality/api/v1/crud/journals.py
@@ -1,25 +1,32 @@
+from portality import models
 from portality.api.v1.crud.common import CrudApi
+from portality.api.v1.data_objects.journal import OutgoingJournal
+from portality.api.v1 import Api401Error, Api404Error
 
 
 class JournalsCrudApi(CrudApi):
     @classmethod
-    def __retrieve(cls, jid):
-        pass
-        # TODO define task anew based on new API data objects
+    def retrieve(cls, jid, account):
+        # is the journal id valid
+        j = models.Journal.pull(jid)
+        if j is None:
+            raise Api404Error()
 
-        # exclude from response: bibjson.active
-        # include in response: bibjson, id, created_date, last_updated
+        # at this point we're happy to return the journal if it's
+        # meant to be seen by the public
+        if j.get('admin').get('in_doaj', False):
+            return OutgoingJournal.from_model(j)
 
-    @classmethod
-    def retrieve_public(cls, jid):
-        j = cls.__retrieve(jid)
-        # return j
+        # as long as authentication (in the layer above) has been successful, and the account exists, then
+        # we are good to proceed
+        if account is None:
+            raise Api401Error()
 
-    @classmethod
-    def retrieve_auth(cls, jid, owner):
-        j = cls.__retrieve(jid)
-        # check if owner arg above is the same as the journal's owner (see portality.models.Journal for owner property)
-        # authenticated owners of a journal are allowed to see journals where .is_in_doaj() == False
-        # if yes
-        # return j
-        # if not return something or define and raise a custom exception to cause 404 Not Found in the view
+        # this journal's metadata is not currently published in DOAJ, so
+        # we need to check ownership
+        # is the current account the owner of the journal
+        # if not we raise a 404 because that id does not exist for that user account.
+        if j.owner != account.id:
+            raise Api404Error()
+
+        return OutgoingJournal.from_model(j)

--- a/portality/api/v1/data_objects/__init__.py
+++ b/portality/api/v1/data_objects/__init__.py
@@ -1,3 +1,3 @@
-from portality.api.v1.data_objects.journal import JournalDO
+from portality.api.v1.data_objects.journal import OutgoingJournal
 from portality.api.v1.data_objects.application import IncomingApplication, OutgoingApplication
 from portality.api.v1.data_objects.article import IncomingArticleDO, OutgoingArticleDO

--- a/portality/api/v1/data_objects/common_journal_application.py
+++ b/portality/api/v1/data_objects/common_journal_application.py
@@ -1,0 +1,27 @@
+from copy import deepcopy
+
+from portality.lib import dataobj
+
+class OutgoingCommonJournalApplication(dataobj.DataObj):
+
+    @classmethod
+    def from_model(cls, journal_or_app):
+        d = deepcopy(journal_or_app.data)
+
+        # we need to re-write the archiving policy section
+        joa = d.get("bibjson", {}).get("archiving_policy")
+        if joa is not None:
+            njoa = {}
+            if "url" in joa:
+                njoa["url"] = joa["url"]
+            if "policy" in joa:
+                npol = []
+                for pol in joa["policy"]:
+                    if isinstance(pol, list):
+                        npol.append({"name" : pol[1], "domain" : pol[0]})
+                    else:
+                        npol.append({"name" : pol})
+                njoa["policy"] = npol
+            d["bibjson"]["archiving_policy"] = njoa
+
+        return cls(d)

--- a/portality/api/v1/data_objects/journal.py
+++ b/portality/api/v1/data_objects/journal.py
@@ -154,7 +154,9 @@ JOURNAL_STRUCT = {
 
                 "oa_start": {
                     "fields": {
-                        "year": {"coerce": "integer"}
+                        "year": {"coerce": "integer"},
+                        "volume": {"coerce": "integer"},
+                        "number": {"coerce": "integer"},
                     }
                 },
 

--- a/portality/api/v1/data_objects/journal.py
+++ b/portality/api/v1/data_objects/journal.py
@@ -1,184 +1,206 @@
 from portality.lib import dataobj
 from portality import models
 
+from portality.api.v1.data_objects.common_journal_application import OutgoingCommonJournalApplication
 
-class JournalDO(dataobj.DataObj):
-
-    def __init__(self, raw=None):
-        struct = {
-            "objects": ["bibjson", "admin"],
+# we only have outgoing journals for the moment
+JOURNAL_STRUCT = {
+    "objects": ["bibjson", "admin"],
+    "fields": {
+        "id": {"coerce": "unicode"},
+        "created_date": {"coerce": "utcdatetime"},
+        "last_updated": {"coerce": "utcdatetime"}
+    },
+    "structs": {
+        "admin": {
             "fields": {
-                "id": {"coerce": "unicode"},
-                "created_date": {"coerce": "utcdatetime"},
-                "last_updated": {"coerce": "utcdatetime"}
+                "in_doaj": {"coerce": "bool", "get__default": False},
+                "ticked": {"coerce": "bool", "get__default": False},
+                "seal": {"coerce": "bool", "get__default": False},
+                "owner": {"coerce": "unicode"},
+            },
+            "lists": {
+                "contact": {"contains": "object"}
             },
             "structs": {
-                "admin": {
+                "contact": {
                     "fields": {
-                        "in_doaj": {"coerce": "bool", "get__default": False},
-                        "ticked": {"coerce": "bool", "get__default": False},
-                        "seal": {"coerce": "bool", "get__default": False},
-                        "owner": {"coerce": "unicode"},
+                        "email": {"coerce": "unicode"},
+                        "name": {"coerce": "unicode"},
+                    }
+                }
+            }
+        },
+        "bibjson": {
+            "fields": {
+                "allows_fulltext_indexing": {"coerce": "bool"},
+                "alternative_title": {"coerce": "unicode"},
+                "apc_url": {"coerce": "url"},
+                "country": {"coerce": "country_code"},
+                "institution": {"coerce": "unicode"},
+                "provider": {"coerce": "unicode"},
+                "publication_time": {"coerce": "integer"},
+                "publisher": {"coerce": "unicode"},
+                "submission_charges_url": {"coerce": "url"},
+                "title": {"coerce": "unicode"},
+            },
+            "lists": {
+                "deposit_policy": {"coerce": "deposit_policy", "contains": "field"},
+                "format": {"coerce": "format", "contains": "field"},
+                "identifier": {"contains": "object"},
+                "keywords": {"coerce": "unicode", "contains": "field"},
+                "language": {"coerce": "isolang_2letter", "contains": "field"},
+                "license": {"contains": "object"},
+                "link": {"contains": "object"},
+                "persistent_identifier_scheme": {"coerce": "persistent_identifier_scheme", "contains": "field"},
+                "subject": {"contains": "object"}
+            },
+            "objects": [
+                "apc",
+                "archiving_policy",
+                "article_statistics",
+                "author_copyright",
+                "author_publishing_rights",
+                "editorial_review",
+                "oa_start",
+                "oa_end",
+                "plagiarism_detection",
+                "submission_charges",
+            ],
+
+            "structs": {
+                "apc": {
+                    "fields": {
+                        "currency": {"coerce": "currency_code"},
+                        "average_price": {"coerce": "integer"}
+                    }
+                },
+
+                "archiving_policy": {               # NOTE: this is not the same as the storage model, so beware when working with this
+                    "fields": {
+                        "url": {"coerce": "url"},
                     },
                     "lists": {
-                        "contact": {"contains": "object"}
+                        "policy": {"coerce": "unicode", "contains": "object"},
                     },
-                    "structs": {
-                        "contact": {
-                            "fields": {
-                                "email": {"coerce": "unicode"},
-                                "name": {"coerce": "unicode"},
+
+                    "structs" : {
+                        "policy" : {
+                            "fields" : {
+                                "name" : {"coerce": "unicode"},
+                                "domain" : {"coerce" : "unicode"}
                             }
                         }
                     }
                 },
-                "bibjson": {
+
+                "article_statistics": {
                     "fields": {
-                        "title": {"coerce": "unicode"},
-                        "alternative_title": {"coerce": "unicode"},
-                        "country": {"coerce": "unicode"},
-                        "publisher": {"coerce": "unicode"},
-                        "provider": {"coerce": "unicode"},
-                        "institution": {"coerce": "unicode"},
-                        "apc_url": {"coerce": "unicode"},
-                        "submission_charges_url": {"coerce": "unicode"},
-                        "allows_fulltext_indexing": {"coerce": "bool"},
-                        "publication_time": {"coerce": "integer"},
-                    },
-                    "objects": [
-                        "oa_start",
-                        "oa_end",
-                        "apc",
-                        "submission_charges",
-                        "archiving_policy",
-                        "editorial_review",
-                        "plagiarism_detection",
-                        "article_statistics",
-                        "author_copyright",
-                        "author_publishing_rights",
-                    ],
-                    "lists": {
-                        "identifier": {"contains": "object"},
-                        "keywords": {"coerce": "unicode", "contains": "field"},
-                        "language": {"coerce": "unicode", "contains": "field"},
-                        "link": {"contains": "object"},
-                        "subject": {"contains": "object"},
-                        "deposit_policy": {"coerce": "unicode", "contains": "field"},
-                        "persistent_identifier_scheme": {"coerce": "unicode", "contains": "field"},
-                        "format": {"coerce": "unicode", "contains": "field"},
-                        "license": {"contains": "object"},
-                    },
-                    "required": [],
-                    "structs": {
-                        "oa_start": {
-                            "fields": {
-                                "year": {"coerce": "integer"},
-                                "volume": {"coerce": "integer"},
-                                "number": {"coerce": "integer"},
-                            }
-                        },
-                        "oa_end": {
-                            "fields": {
-                                "year": {"coerce": "integer"},
-                                "volume": {"coerce": "integer"},
-                                "number": {"coerce": "integer"},
-                            }
-                        },
-                        "apc": {
-                            "fields": {
-                                "currency": {"coerce": "unicode"},
-                                "average_price": {"coerce": "integer"}
-                            }
-                        },
-                        "submission_charges": {
-                            "fields": {
-                                "currency": {"coerce": "unicode"},
-                                "average_price": {"coerce": "integer"}
-                            }
-                        },
-                        "archiving_policy": {
-                            "fields": {
-                                "url": {"coerce": "unicode"},
-                            },
-                            "lists": {
-                                "policy": {"coerce": "unicode", "contains": "field"},
-                            }
-                        },
-                        "editorial_review": {
-                            "fields": {
-                                "process": {"coerce": "unicode"},
-                                "url": {"coerce": "unicode"},
-                            }
-                        },
-                        "plagiarism_detection": {
-                            "fields": {
-                                "detection": {"coerce": "bool"},
-                                "url": {"coerce": "unicode"},
-                            }
-                        },
-                        "article_statistics": {
-                            "fields": {
-                                "detection": {"coerce": "bool"},
-                                "url": {"coerce": "unicode"},
-                            }
-                        },
-                        "author_copyright": {
-                            "fields": {
-                                "copyright": {"coerce": "unicode"},
-                                "url": {"coerce": "unicode"},
-                            }
-                        },
-                        "author_publishing_rights": {
-                            "fields": {
-                                "publishing_rights": {"coerce": "unicode"},
-                                "url": {"coerce": "unicode"},
-                            }
-                        },
-                        "identifier": {
-                            "fields": {
-                                "type": {"coerce": "unicode"},
-                                "id": {"coerce": "unicode"},
-                            }
-                        },
-                        "link": {
-                            "fields": {
-                                "type": {"coerce": "unicode"},
-                                "url": {"coerce": "unicode"},
-                            }
-                        },
-                        "subject": {
-                            "fields": {
-                                "scheme": {"coerce": "unicode"},
-                                "term": {"coerce": "unicode"},
-                                "code": {"coerce": "unicode"},
-                            }
-                        },
-                        "license": {
-                            "fields": {
-                                "title": {"coerce": "unicode"},
-                                "type": {"coerce": "unicode"},
-                                "url": {"coerce": "unicode"},
-                                "version": {"coerce": "unicode"},
-                                "open_access": {"coerce": "bool"},
-                                "BY": {"coerce": "bool"},
-                                "NC": {"coerce": "bool"},
-                                "ND": {"coerce": "bool"},
-                                "SA": {"coerce": "bool"},
-                                "embedded": {"coerce": "bool"},
-                                "embedded_example_url": {"coerce": "unicode"},
-                            }
-                        },
+                        "statistics": {"coerce": "bool"},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "author_copyright": {
+                    "fields": {
+                        "copyright": {"coerce": "unicode"},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "author_publishing_rights": {
+                    "fields": {
+                        "publishing_rights": {"coerce": "unicode"},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "editorial_review": {
+                    "fields": {
+                        "process": {"coerce": "unicode", "allowed_values" : ["Editorial review", "Peer review", "Blind peer review", "Double blind peer review", "Open peer review", "None"]},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "identifier": {
+                    "fields": {
+                        "type": {"coerce": "unicode"},
+                        "id": {"coerce": "unicode"},
+                    }
+                },
+
+                "license": {
+                    "fields": {
+                        "title": {"coerce": "license"},
+                        "type": {"coerce": "license"},
+                        "url": {"coerce": "url"},
+                        "version": {"coerce": "unicode"},
+                        "open_access": {"coerce": "bool"},
+                        "BY": {"coerce": "bool"},
+                        "NC": {"coerce": "bool"},
+                        "ND": {"coerce": "bool"},
+                        "SA": {"coerce": "bool"},
+                        "embedded": {"coerce": "bool"},
+                        "embedded_example_url": {"coerce": "url"},
+                    }
+                },
+
+                "link": {
+                    "fields": {
+                        "type": {"coerce": "unicode"},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "oa_start": {
+                    "fields": {
+                        "year": {"coerce": "integer"}
+                    }
+                },
+
+                "oa_end": {
+                    "fields": {
+                        "year": {"coerce": "integer"},
+                        "volume": {"coerce": "integer"},
+                        "number": {"coerce": "integer"},
+                    }
+                },
+
+                "plagiarism_detection": {
+                    "fields": {
+                        "detection": {"coerce": "bool"},
+                        "url": {"coerce": "url"},
+                    }
+                },
+
+                "submission_charges": {
+                    "fields": {
+                        "currency": {"coerce": "currency_code"},
+                        "average_price": {"coerce": "integer"}
+                    }
+                },
+                "subject": {
+                    "fields": {
+                        "scheme": {"coerce": "unicode"},
+                        "term": {"coerce": "unicode"},
+                        "code": {"coerce": "unicode"},
                     }
                 }
             }
         }
+    }
+}
 
-        super(JournalDO, self).__init__(raw, struct=struct, construct_silent_prune=True, expose_data=True)
+
+class OutgoingJournal(OutgoingCommonJournalApplication):
+
+    def __init__(self, raw=None):
+        super(OutgoingJournal, self).__init__(raw, struct=JOURNAL_STRUCT, construct_silent_prune=True, expose_data=True)
 
     @classmethod
     def from_model(cls, jm):
         assert isinstance(jm, models.Journal)
-        return cls(jm.data)
+        return super(OutgoingJournal, cls).from_model(jm)
 
     @classmethod
     def from_model_by_id(cls, id_):

--- a/portality/lib/dataobj.py
+++ b/portality/lib/dataobj.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 from portality.lib import dates
 from portality.datasets import get_country_code, get_currency_code
 from copy import deepcopy
@@ -226,7 +228,10 @@ class DataObj(object):
         "isolang_2letter": to_isolang(output_format="alpha2"),
         "country_code": to_country_code,
         "currency_code": to_currency_code,
-        "license": string_canonicalise(["CC BY", "CC BY-NC", "CC BY-NC-ND", "CC BY-NC-SA", "CC BY-ND", "CC BY-SA", "Not CC-like"], allow_fail=True)
+        "license": string_canonicalise(["CC BY", "CC BY-NC", "CC BY-NC-ND", "CC BY-NC-SA", "CC BY-ND", "CC BY-SA", "Not CC-like"], allow_fail=True),
+        "persistent_identifier_scheme": string_canonicalise(["None", "DOI", "Handles", "ARK"], allow_fail=True),
+        "format": string_canonicalise(["PDF", "HTML", "ePUB", "XML"], allow_fail=True),
+        "deposit_policy": string_canonicalise(["None", "Sherpa/Romeo", "Dulcinea", "OAKlist", "Héloïse", "Diadorim"], allow_fail=True),
     }
 
     def __init__(self, raw=None, struct=None, construct_raw=True, expose_data=False, properties=None, coerce_map=None, construct_silent_prune=False):

--- a/portality/view/api_v1.py
+++ b/portality/view/api_v1.py
@@ -1018,3 +1018,13 @@ def update_article(aid):
 def delete_article(aid):
     ArticlesCrudApi.delete(aid, current_user)
     return no_content()
+
+
+@api_key_optional
+@blueprint.route('/journals/<jid>', methods=['GET'])
+def retrieve_journal(jid):
+    # TODO do this check on all these routes. Maybe an API decorator to check for format of IDs?
+    if not int(jid, 16):
+        return Api400Error()
+
+    return jsonify_data_object(JournalsCrudApi.retrieve(jid, current_user))


### PR DESCRIPTION
Finally! @Steven-Eardley @richard-jones 

Important things:

1. Introduce journals, duh. Tests, api class, view func.

    EDIT: I've taken the Application struct that Richard wrote (since it has more type casts) and tacked on fields like oa_end that only journals have. Also journals and applications now expose both subjects and keywords.

2. Refactor applications a bit to use common logic with journals. Had to make a common Outgoing object since it was just the best way to share the logic I could come up with, and it allows more sharing in the future. Sorry about the name of the common object, I thought for 5 min but couldn't come up with "what's the parent of journal and application conceptually". Suggestions very welcome.

3. Introduce parity between incoming and outgoing applications with additional safeguards so people can't overwrite info they shouldn't be able to overwrite. Though they can supply that info now. Otherwise it's very annoying to update applications via the API (GET, modify what you want, delete some fields so it fits our reqs, PUT; rather than just GET, modify what you want, PUT).