### PR TITLE
[hotfix] change default search operator to AND

### DIFF
--- a/portality/api/v1/discovery.py
+++ b/portality/api/v1/discovery.py
@@ -290,7 +290,8 @@ class ApplicationQuery(object):
                     },
                     "query" : {
                         "query_string" : {
-                            "query" : self.qs
+                            "query" : self.qs,
+                            "default_operator": "AND"
                         }
                     }
                 }

--- a/portality/api/v1/discovery.py
+++ b/portality/api/v1/discovery.py
@@ -249,7 +249,8 @@ class SearchQuery(object):
                     },
                     "query" : {
                         "query_string" : {
-                            "query" : self.qs
+                            "query" : self.qs,
+                            "default_operator": "AND"
                         }
                     }
                 }

--- a/portality/templates/doaj/api_docs.html
+++ b/portality/templates/doaj/api_docs.html
@@ -18,6 +18,12 @@
 
     <h2 id="search_api">Search API</h2>
 
+    <h3 id="query_syntax">Query string syntax</h3>
+    <p>If you'd like to do more complex queries than simple words or phrases, reading <a href="https://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-query-string-query.html#query-string-syntax" target="_blank">https://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-query-string-query.html#query-string-syntax</a> should prove very useful. The datastore that backs DOAJ is Elasticsearch and knowing more about its query syntax will let you send more advanced queries to DOAJ. <strong>This is not a prerequisite for using the DOAJ API - in the sections below, we provide instructions for the most common use cases.</strong> Please do email us if you think what you have achieved with the API would be useful to others and would like to add an example to the API documentation below.</p>
+
+    <h3 id="default_query_operator">Default handling of phrases</h3>
+    <p>When searching for e.g. "understanding shadows in 3D scenes", DOAJ's web interface will return articles and journals which have metadata that contains *all* of the words "understanding", "shadows", "in" (may be ignored), "3D" and "scenes". In technical terms, the default query operator is <strong>AND</strong>. You can override it by sending us a query such as "understanding OR shadows". We find that the results returned by AND queries are much more relevant when looking for specific topics, where OR queries are best for exploring what is available, e.g. based loosely on the interests of your users.</p>
+
     <h3 id="specific_field_search">Searching inside a specific field</h3>
 
     <p>When you are querying on a specific field you can use the json dot notation used by Elasticsearch, so for example to access the journal title of an article, you could use


### PR DESCRIPTION
# HOTFIX, DO NOT MERGE HERE

A developer has noticed that our search API uses default OR operator (the ES default) but the search page uses AND (facetview specifies it as default). He thinks AND produces much more relevant results and I agree. Also it should behave similarly to the web search. And finally you can override the operator if needed by giving us "word1 OR word2" as a query.