### PR TITLE
Feature/api inout parity

### DIFF
--- a/doajtest/fixtures/article.py
+++ b/doajtest/fixtures/article.py
@@ -36,6 +36,15 @@ class ArticleFixtureFactory(object):
     @staticmethod
     def make_article_source():
         return deepcopy(ARTICLE_SOURCE)
+    
+    @staticmethod
+    def make_incoming_api_article():
+        template = deepcopy(ARTICLE_SOURCE)
+        template['bibjson']['journal']['start_page'] = template['bibjson']['start_page']
+        template['bibjson']['journal']['end_page'] = template['bibjson']['end_page']
+        del template['bibjson']['start_page']
+        del template['bibjson']['end_page']
+        return deepcopy(template)
 
     @staticmethod
     def make_article_apido_struct():

--- a/doajtest/unit/test_api_crud_article.py
+++ b/doajtest/unit/test_api_crud_article.py
@@ -77,6 +77,9 @@ class TestCrudArticle(DoajTestCase):
         assert a.created_date != "2000-01-01T00:00:00Z"
         assert a.last_updated != "2000-01-01T00:00:00Z"
 
+        # TODO add test that journal info is created as allowed (number, volume, start_page, end_page)
+        # but not overwritten by the user where not allowed - journal title, country, license, etc.
+
         time.sleep(1)
 
         am = models.Article.pull(a.id)
@@ -179,6 +182,7 @@ class TestCrudArticle(DoajTestCase):
         # check that we got back the object we expected
         assert isinstance(a, OutgoingArticleDO)
         assert a.id == ap.id
+        # TODO write test to check article's journal portion is correct
 
     def test_07_retrieve_article_fail(self):
         # set up all the bits we need
@@ -254,6 +258,8 @@ class TestCrudArticle(DoajTestCase):
         assert updated.created_date == created.created_date
         assert updated.last_updated != created.last_updated
         assert updated.data['admin']['upload_id'] == created.data['admin']['upload_id']
+        # TODO add test that journal info is updated where allowed (number, volume, start_page, end_page)
+        # but not updated where not allowed - journal title, country, license, etc.
 
     def test_09_update_article_fail(self):
         # set up all the bits we need

--- a/portality/api/v1/crud/applications.py
+++ b/portality/api/v1/crud/applications.py
@@ -44,8 +44,7 @@ class ApplicationsCrudApi(CrudApi):
         ap.set_owner(account.id)
 
         # they are not allowed to set "subject"
-        bj = ap.bibjson()
-        bj.remove_subjects()
+        ap.bibjson().remove_subjects()
 
         # finally save the new application, and return to the caller
         ap.save()

--- a/portality/api/v1/crud/articles.py
+++ b/portality/api/v1/crud/articles.py
@@ -32,6 +32,10 @@ class ArticlesCrudApi(CrudApi):
         am.set_id()
         am.set_created()
 
+        # not allowed to set subjects
+        am.bibjson().remove_subjects()
+        am.bibjson().journal_title
+
         # finally save the new article, and return to the caller
         am.save()
         return am
@@ -86,6 +90,7 @@ class ArticlesCrudApi(CrudApi):
         # are copied over
         new_ar.set_id(id)
         new_ar.set_created(ar.created_date)
+        new_ar.bibjson().set_subjects(ar.bibjson().subjects())
 
         # finally save the new article, and return to the caller
         new_ar.save()

--- a/portality/api/v1/data_objects/article.py
+++ b/portality/api/v1/data_objects/article.py
@@ -26,8 +26,6 @@ BASE_ARTICLE_STRUCT = {
                 "title": {"coerce": "unicode"},
                 "year": {"coerce": "unicode"},
                 "month": {"coerce": "unicode"},
-                "start_page": {"coerce": "unicode"},
-                "end_page": {"coerce": "unicode"},
                 "abstract": {"coerce": "unicode"}
             },
             "lists": {
@@ -67,6 +65,8 @@ BASE_ARTICLE_STRUCT = {
 
                 "journal": {
                     "fields": {
+                        "start_page": {"coerce": "unicode"},
+                        "end_page": {"coerce": "unicode"},
                         "volume": {"coerce": "unicode"},
                         "number": {"coerce": "unicode"},
                         "publisher": {"coerce": "unicode"},

--- a/portality/api/v1/data_objects/article.py
+++ b/portality/api/v1/data_objects/article.py
@@ -35,6 +35,7 @@ BASE_ARTICLE_STRUCT = {
                 "link": {"contains": "object"},
                 "author": {"contains": "object"},
                 "keywords": {"coerce": "unicode", "contains": "field"},
+                "subject": {"contains": "object"},
             },
             "objects": [
                 "journal",
@@ -67,9 +68,36 @@ BASE_ARTICLE_STRUCT = {
                 "journal": {
                     "fields": {
                         "volume": {"coerce": "unicode"},
-                        "number": {"coerce": "unicode"}
+                        "number": {"coerce": "unicode"},
+                        "publisher": {"coerce": "unicode"},
+                        "title": {"coerce": "unicode"},
+                        "country": {"coerce": "unicode"}
                     },
-                }
+                    "lists": {
+                        "license": {"contains": "object"},
+                        "language": {"coerce": "unicode", "contains": "field"}
+                    },
+                    "structs": {
+
+                        "license": {
+                            "fields": {
+                                "title": {"coerce": "license"},
+                                "type": {"coerce": "license"},
+                                "url": {"coerce": "unicode"},
+                                "version": {"coerce": "unicode"},
+                                "open_access": {"coerce": "bool"},
+                            }
+                        }
+                    }
+                },
+
+                "subject": {
+                    "fields": {
+                        "scheme": {"coerce": "unicode"},
+                        "term": {"coerce": "unicode"},
+                        "code": {"coerce": "unicode"}
+                    }
+                },
             }
         }
     }
@@ -98,56 +126,6 @@ INCOMING_ARTICLE_REQUIRED = {
                 "author": {
                     "required": ["name"]
                 },
-            }
-        }
-    }
-}
-
-OUTGOING_ARTICLE_EXTRAS = {
-    "objects": ["bibjson"],
-
-    "structs": {
-
-        "bibjson": {
-            "lists": {
-                "subject": {"contains": "object"}
-            },
-            "structs": {
-                "subject": {
-                    "fields": {
-                        "scheme": {"coerce": "unicode"},
-                        "term": {"coerce": "unicode"},
-                        "code": {"coerce": "unicode"}
-                    }
-                },
-                "link": {
-                    "fields": {
-                        "type": {"coerce": "link_type_optional"}
-                    }
-                },
-                "journal": {
-                    "fields": {
-                        "publisher": {"coerce": "unicode"},
-                        "title": {"coerce": "unicode"},
-                        "country": {"coerce": "unicode"}
-                    },
-                    "lists": {
-                        "license": {"contains": "object"},
-                        "language": {"coerce": "unicode", "contains": "field"}
-                    },
-                    "structs": {
-
-                        "license": {
-                            "fields": {
-                                "title": {"coerce": "license"},
-                                "type": {"coerce": "license"},
-                                "url": {"coerce": "unicode"},
-                                "version": {"coerce": "unicode"},
-                                "open_access": {"coerce": "bool"},
-                            }
-                        }
-                    }
-                }
             }
         }
     }
@@ -221,7 +199,6 @@ class IncomingArticleDO(dataobj.DataObj):
 class OutgoingArticleDO(dataobj.DataObj):
     def __init__(self, raw=None):
         self._add_struct(BASE_ARTICLE_STRUCT)
-        self._add_struct(OUTGOING_ARTICLE_EXTRAS)
         super(OutgoingArticleDO, self).__init__(raw, construct_silent_prune=True, expose_data=True, coerce_map=BASE_ARTICLE_COERCE)
 
     @classmethod

--- a/portality/api/v1/data_objects/article.py
+++ b/portality/api/v1/data_objects/article.py
@@ -212,7 +212,7 @@ class OutgoingArticleDO(dataobj.DataObj):
         if "end_page" in dat["bibjson"]:
             dat["bibjson"].get("journal", {})["end_page"] = dat["bibjson"]["end_page"]
             del dat["bibjson"]["end_page"]
-        return cls(am.data)
+        return cls(dat)
     
     @classmethod
     def from_model_by_id(cls, id_):

--- a/portality/article.py
+++ b/portality/article.py
@@ -13,54 +13,8 @@ from datetime import datetime
 import json
 
 class XWalk(object):
-    def add_journal_info(self, article):
-        """
-        this function takes an article and makes sure that it is populated
-        with all the relevant info from its owning parent object
-        """
-        bibjson = article.bibjson()
-        
-        # first, get the ISSNs associated with the record
-        pissns = bibjson.get_identifiers(bibjson.P_ISSN)
-        eissns = bibjson.get_identifiers(bibjson.E_ISSN)
-        allissns = list(set(pissns + eissns))
-        
-        # find a matching journal record from the index
-        journal = None
-        for issn in allissns:
-            journals = models.Journal.find_by_issn(issn)
-            if len(journals) > 0:
-                # there should only ever be one, so take the first one
-                journal = journals[0]
-                break
-        
-        # we were unable to find a journal
-        if journal is None:
-            return False
-        
-        # FIXME: use the journal model API
-        # if we get to here, we have a journal record we want to pull data from
-        jbib = journal.bibjson()
-        
-        for s in jbib.subjects():
-            bibjson.add_subject(s.get("scheme"), s.get("term"), code=s.get("code"))
-        
-        if jbib.title is not None:
-            bibjson.journal_title = jbib.title
-        
-        if jbib.get_license() is not None:
-            lic = jbib.get_license()
-            bibjson.set_journal_license(lic.get("title"), lic.get("type"), lic.get("url"), lic.get("version"), lic.get("open_access"))
-        
-        if jbib.language is not None:
-            bibjson.journal_language = jbib.language
-        
-        if jbib.country is not None:
-            bibjson.journal_country = jbib.country
-        
-        indoaj = journal.is_in_doaj()
-        article.set_in_doaj(indoaj)
-        return True
+    @staticmethod
+
 
     @staticmethod
     def is_legitimate_owner(article, owner):
@@ -303,7 +257,7 @@ class FormXWalk(XWalk):
         
         # add the journal info if requested
         if add_journal_info:
-            self.add_journal_info(article)
+            article.add_journal_metadata()
         
         # before finalising, we need to determine whether this is a new article
         # or an update
@@ -538,7 +492,7 @@ class DOAJXWalk(XWalk):
         
         # add the journal info if requested
         if add_journal_info:
-            self.add_journal_info(article)
+            article.add_journal_metadata()
             
         return article
 

--- a/portality/article.py
+++ b/portality/article.py
@@ -14,9 +14,6 @@ import json
 
 class XWalk(object):
     @staticmethod
-
-
-    @staticmethod
     def is_legitimate_owner(article, owner):
         # get all the issns for the article
         b = article.bibjson()

--- a/portality/models/article.py
+++ b/portality/models/article.py
@@ -202,6 +202,9 @@ class Article(DomainObject):
         if jbib.country is not None:
             bibjson.journal_country = jbib.country
 
+        if jbib.publisher:
+            bibjson.publisher = jbib.publisher
+
         indoaj = journal.is_in_doaj()
         self.set_in_doaj(indoaj)
         return True

--- a/portality/models/article.py
+++ b/portality/models/article.py
@@ -1,5 +1,5 @@
 from portality.dao import DomainObject
-from portality.models import GenericBibJSON
+from portality.models import GenericBibJSON, Journal
 from copy import deepcopy
 from datetime import datetime
 from portality import xwalk
@@ -156,6 +156,55 @@ class Article(DomainObject):
         if "admin" not in self.data:
             self.data["admin"] = {}
         self.data["admin"]["upload_id"] = uid
+
+    def add_journal_metadata(self):
+        """
+        this function makes sure the article is populated
+        with all the relevant info from its owning parent object
+        """
+        bibjson = self.bibjson()
+
+        # first, get the ISSNs associated with the record
+        pissns = bibjson.get_identifiers(bibjson.P_ISSN)
+        eissns = bibjson.get_identifiers(bibjson.E_ISSN)
+        allissns = list(set(pissns + eissns))
+
+        # find a matching journal record from the index
+        journal = None
+        for issn in allissns:
+            journals = Journal.find_by_issn(issn)
+            if len(journals) > 0:
+                # there should only ever be one, so take the first one
+                journal = journals[0]
+                break
+
+        # we were unable to find a journal
+        if journal is None:
+            return False
+
+        # FIXME: use the journal model API
+        # if we get to here, we have a journal record we want to pull data from
+        jbib = journal.bibjson()
+
+        for s in jbib.subjects():
+            bibjson.add_subject(s.get("scheme"), s.get("term"), code=s.get("code"))
+
+        if jbib.title is not None:
+            bibjson.journal_title = jbib.title
+
+        if jbib.get_license() is not None:
+            lic = jbib.get_license()
+            bibjson.set_journal_license(lic.get("title"), lic.get("type"), lic.get("url"), lic.get("version"), lic.get("open_access"))
+
+        if jbib.language is not None:
+            bibjson.journal_language = jbib.language
+
+        if jbib.country is not None:
+            bibjson.journal_country = jbib.country
+
+        indoaj = journal.is_in_doaj()
+        self.set_in_doaj(indoaj)
+        return True
 
     def merge(self, old, take_id=True):
         # this takes an old version of the article and brings

--- a/portality/scripts/articleload.py
+++ b/portality/scripts/articleload.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     for data in j:
         a = models.Article(**data)
         a.bibjson().remove_subjects()
-        article.XWalk().add_journal_info(a)
+        a.add_journal_metadata()
         a.save()
 
 

--- a/portality/scripts/journalinfo.py
+++ b/portality/scripts/journalinfo.py
@@ -16,7 +16,7 @@ total=0
 article_iterator = models.Article.iterall(page_size=5000)
 batch = []
 for a in article_iterator:
-    xwalk.add_journal_info(a)
+    a.add_journal_metadata()
     a.prep()
     batch.append(a.data)
     


### PR DESCRIPTION
@Steven-Eardley @richard-jones Ahoy! Possibly final code PR for CRUD API. A bit more in docs coming, and should be done!

We already have parity in applications (in/out) and journals are only out atm. So this adds parity to articles. This was a bit tricky because of journal info. Unfortunately it seemed quite difficult to go with the proper solution of supplying a journal identifier to people (e.g. for journal info see X) because some mutable properties like start page, end page, volume and issue make a bit more sense in the journal part of the article **and** more importantly people would've been able to specify journal_id on the way in. Which we could ignore, but it could get quite confusing (how do you assign an article to a journal then?).

So I've avoided that can of worms by keeping the data object quite close to the internal data structure for this iteration of the API. People just have properties they can set, and properties we will ignore. Journal-intrinsic properties like title, license, country etc. will be ignored on article create/update. start_page, end_page, volume and number (issue) are allowed to change.

Also fixes a little boo-boo in portality/api/v1/data_objects/article.py:215 as well, which meant start and end pages were never retrieved for an article. Hooray tests.