### PR TITLE
Feature/iss 815 classification required

### DIFF
--- a/doajtest/unit/test_assed_app_review.py
+++ b/doajtest/unit/test_assed_app_review.py
@@ -291,10 +291,10 @@ del APPLICATION_FORM["editor_group"]
 # Main test class
 ######################################################
 
-class TestEditorAppReview(DoajTestCase):
+class TestAssedAppReview(DoajTestCase):
 
     def setUp(self):
-        super(TestEditorAppReview, self).setUp()
+        super(TestAssedAppReview, self).setUp()
 
         self.editor_group_pull = models.EditorGroup.pull_by_key
         models.EditorGroup.pull_by_key = editor_group_pull
@@ -306,7 +306,7 @@ class TestEditorAppReview(DoajTestCase):
         lcc.lookup_code = mock_lookup_code
 
     def tearDown(self):
-        super(TestEditorAppReview, self).tearDown()
+        super(TestAssedAppReview, self).tearDown()
 
         models.EditorGroup.pull_by_key = self.editor_group_pull
         lcc.lcc_choices = self.old_lcc_choices
@@ -315,14 +315,14 @@ class TestEditorAppReview(DoajTestCase):
 
 
     ###########################################################
-    # Tests on the editor's reapplication form
+    # Tests on the associate editor's reapplication form
     ###########################################################
 
     def test_01_editor_review_success(self):
         """Give the editor's reapplication form a full workout"""
 
         # we start by constructing it from source
-        fc = formcontext.ApplicationFormFactory.get_form_context(role="editor", source=models.Suggestion(**APPLICATION_SOURCE))
+        fc = formcontext.ApplicationFormFactory.get_form_context(role="associate_editor", source=models.Suggestion(**APPLICATION_SOURCE))
         assert isinstance(fc, formcontext.EditorApplicationReview)
         assert fc.form is not None
         assert fc.source is not None
@@ -345,11 +345,11 @@ class TestEditorAppReview(DoajTestCase):
 
         # now construct it from form data (with a known source)
         fc = formcontext.ApplicationFormFactory.get_form_context(
-            role="editor",
+            role="associate_editor",
             form_data=MultiDict(APPLICATION_FORM) ,
             source=models.Suggestion(**APPLICATION_SOURCE))
 
-        assert isinstance(fc, formcontext.EditorApplicationReview)
+        assert isinstance(fc, formcontext.AssEdApplicationReview)
         assert fc.form is not None
         assert fc.source is not None
         assert fc.form_data is not None
@@ -383,28 +383,28 @@ class TestEditorAppReview(DoajTestCase):
         assert True # gives us a place to drop a break point later if we need it
 
     def test_02_classification_required(self):
-        # Check we can mark an application 'ready' with a subject classification present
+        # Check we can mark an application 'completed' with a subject classification present
         in_progress_application = models.Suggestion(**ApplicationFixtureFactory.make_application_source())
         in_progress_application.set_application_status("in progress")
 
-        fc = formcontext.ApplicationFormFactory.get_form_context(role='editor', source=in_progress_application)
+        fc = formcontext.ApplicationFormFactory.get_form_context(role='associate_editor', source=in_progress_application)
 
         # Make changes to the application status via the form, check it validates
-        fc.form.application_status.data = "ready"
+        fc.form.application_status.data = "completed"
 
         assert fc.validate()
 
         # Without a subject classification, we should not be able to set the status to 'ready'
         no_class_application = models.Suggestion(**ApplicationFixtureFactory.make_application_source())
         del no_class_application.data['bibjson']['subject']
-        fc = formcontext.ApplicationFormFactory.get_form_context(role='editor', source=no_class_application)
+        fc = formcontext.ApplicationFormFactory.get_form_context(role='associate_editor', source=no_class_application)
         # Make changes to the application status via the form
         assert fc.source.bibjson().subjects() == []
-        fc.form.application_status.data = "ready"
+        fc.form.application_status.data = "completed"
 
         assert not fc.validate()
 
         # However, we should be able to set it to a different status rather than 'ready'
-        fc.form.application_status.data = "pending"
+        fc.form.application_status.data = "competed"
 
         assert fc.validate()

--- a/doajtest/unit/test_maned_app_review.py
+++ b/doajtest/unit/test_maned_app_review.py
@@ -1,5 +1,6 @@
 
 from doajtest.helpers import DoajTestCase
+from doajtest.fixtures import JournalFixtureFactory
 # from flask.ext.testing import TestCase
 
 import re, time
@@ -8,7 +9,7 @@ from copy import deepcopy
 from portality import models
 from portality.formcontext import formcontext
 from portality import lcc
-from portality.core import app
+from portality.app import app
 
 from werkzeug.datastructures import MultiDict
 
@@ -156,6 +157,8 @@ APPLICATION_SOURCE = {
         "editor" : "associate",
     }
 }
+
+JOURNAL_SOURCE = JournalFixtureFactory.make_journal_source(in_doaj=True)
 
 ######################################################################
 # Complete, populated, form components
@@ -362,15 +365,23 @@ class TestManEdAppReview(DoajTestCase):
         fc.finalise()
         assert True # gives us a place to drop a break point later if we need it
 
-    """
-    FIXME: this test won't run because we need the flask application context, but you can enable
-    it and step through with a debugger if you want.  That confirms that the test is working, at least,
-    up until the flask context kills it.
-
     def test_02_reapplication(self):
+
+        # There needs to be an existing journal in the index for this test to work
+        extant_j = models.Journal(**JOURNAL_SOURCE)
+        assert extant_j.last_reapplication is None
+        extant_j_created_date = extant_j.created_date
+        extant_j.save()
+        time.sleep(1)
+
+        # We've added one journal, so there'll be one snapshot already
+        assert models.Journal.count() == 1
+        h = models.JournalHistory.get_history_for("abcdefghijk_journal")
+        assert len(h) == 1
+
         # set up an application which is a reapp on an existing journal
         s = models.Suggestion(**APPLICATION_SOURCE)
-        s.set_current_journal("1234567")
+        s.set_current_journal("abcdefghijk_journal")
         s.set_application_status("submitted")
 
         # set up the form which "accepts" this reapplication
@@ -380,18 +391,19 @@ class TestManEdAppReview(DoajTestCase):
 
         # create and finalise the form context
         fc = formcontext.ApplicationFormFactory.get_form_context(role="admin", form_data=fd, source=s)
+
         with app.test_request_context():
             fc.finalise()
 
         # let the index catch up
-        time.sleep(2)
+        time.sleep(1)
 
-        j = models.Journal.pull("1234567")
+        j = models.Journal.pull("abcdefghijk_journal")
         assert j is not None
+        assert j.created_date == extant_j_created_date
         assert j.last_reapplication is not None
+        assert models.Journal.count() == 1
 
-        h = models.JournalHistory.get_history_for("1234567")
+        h = models.JournalHistory.get_history_for("abcdefghijk_journal")
         assert h is not None
-        assert len(h) == 1
-    """
-
+        assert len(h) == 2

--- a/portality/formcontext/choices.py
+++ b/portality/formcontext/choices.py
@@ -378,9 +378,9 @@ class Choices(object):
 
     @classmethod
     def application_status_optional(cls):
-        all = [v[0] for v in cls._application_status_admin]
-        all.remove("accepted")
-        return all
+        all_s = [v[0] for v in cls._application_status_admin]
+        all_s.remove("accepted")
+        return all_s
 
     @classmethod
     def application_status(cls, context=None):
@@ -392,3 +392,10 @@ class Choices(object):
             return [('accepted', 'Accepted')] # just the one status - Accepted
         else:
             return cls._application_status_base
+
+    @classmethod
+    def application_status_subject_optional(cls):
+        """ The set of permitted statuses we can save an application without a subject classification """
+        all_s = [v[0] for v in cls._application_status_admin]
+        disallowed_statuses = {'accepted', 'ready', 'completed'}
+        return list(set(all_s).difference(disallowed_statuses))

--- a/portality/formcontext/forms.py
+++ b/portality/formcontext/forms.py
@@ -314,10 +314,16 @@ class Notes(Form):
     """ Multiple notes form for inclusion into admin forms """
     notes = FieldList(FormField(Note))
 
-class Subject(Form):
-    """ Subject classification entry """
+class ApplicationSubject(Form):
+    """ Subject classification entry - with workflow validation"""
+
+    subject = SelectMultipleField('Subjects', [OptionalIf('application_status', optvals=Choices.application_status_subject_optional())], choices=Choices.subjects())
+
+class JournalSubject(Form):
+    """ Subject classification entry - optional"""
 
     subject = SelectMultipleField('Subjects', [validators.Optional()], choices=Choices.subjects())
+
 
 class JournalLegacy(Form):
     """ Legacy information required by some journals that are already in the DOAJ """
@@ -389,7 +395,7 @@ class PublicApplicationForm(JournalInformation, Suggestion, PublicSuggester):
     pass
 
 
-class ManEdApplicationReviewForm(Editorial, Workflow, ApplicationOwner, JournalInfoOptionalPaymentURLs, Suggestion, Subject, AdminSuggester, Notes, Seal):
+class ManEdApplicationReviewForm(Editorial, Workflow, ApplicationOwner, JournalInfoOptionalPaymentURLs, Suggestion, ApplicationSubject, AdminSuggester, Notes, Seal):
     """
     Managing Editor's Application Review form.  It consists of:
         * Editorial - ability to add editorial groups (but ability to add editors individually will be disabled)
@@ -404,7 +410,7 @@ class ManEdApplicationReviewForm(Editorial, Workflow, ApplicationOwner, JournalI
     """
     pass
 
-class EditorApplicationReviewForm(Editorial, Workflow, JournalInfoOptionalPaymentURLs, Suggestion, Subject, AdminSuggester, Notes):
+class EditorApplicationReviewForm(Editorial, Workflow, JournalInfoOptionalPaymentURLs, Suggestion, ApplicationSubject, AdminSuggester, Notes):
     """
     Editor's Application Review form.  It consists of:
         * Editorial - ability to add associate editors (but not change editorial group)
@@ -417,7 +423,7 @@ class EditorApplicationReviewForm(Editorial, Workflow, JournalInfoOptionalPaymen
     """
     pass
 
-class AssEdApplicationReviewForm(Workflow, JournalInfoOptionalPaymentURLs, Suggestion, Subject, AdminSuggester, Notes):
+class AssEdApplicationReviewForm(Workflow, JournalInfoOptionalPaymentURLs, Suggestion, ApplicationSubject, AdminSuggester, Notes):
     """
     Editor's Application Review form.  It consists of:
         * Workflow - ability to change application status
@@ -437,7 +443,7 @@ class PublisherReApplicationForm(JournalInformation, Suggestion):
     """
     pass
 
-class ManEdJournalReviewForm(Editorial, RequiredOwner, Subject, JournalLegacy, JournalInformation, Notes, OptionalValidation, Seal):
+class ManEdJournalReviewForm(Editorial, RequiredOwner, JournalSubject, JournalLegacy, JournalInformation, Notes, OptionalValidation, Seal):
     """
     Managing Editor's Journal Review form.  It consists of:
         * Editorial - ability to add editorial groups (but ability to add editors individually will be disabled)
@@ -451,7 +457,7 @@ class ManEdJournalReviewForm(Editorial, RequiredOwner, Subject, JournalLegacy, J
     """
     pass
 
-class EditorJournalReviewForm(Editorial, Subject, JournalLegacy, JournalInformation, Notes):
+class EditorJournalReviewForm(Editorial, JournalSubject, JournalLegacy, JournalInformation, Notes):
     """
     Editor's Journal Review form.  It consists of:
         * Editorial - ability to add editorial groups (but ability to add editors individually will be disabled)
@@ -462,7 +468,7 @@ class EditorJournalReviewForm(Editorial, Subject, JournalLegacy, JournalInformat
     """
     pass
 
-class AssEdJournalReviewForm(JournalInformation, Subject, JournalLegacy, Notes):
+class AssEdJournalReviewForm(JournalInformation, JournalSubject, JournalLegacy, Notes):
     """
     Associate Editor's Journal Review form.  It consists of:
         * JournalInformation - journal bibliographic data
@@ -472,7 +478,7 @@ class AssEdJournalReviewForm(JournalInformation, Subject, JournalLegacy, Notes):
     """
     pass
 
-class ReadOnlyJournalForm(JournalInformation, Subject, JournalLegacy, Notes):
+class ReadOnlyJournalForm(JournalInformation, JournalSubject, JournalLegacy, Notes):
     """
     Read-only journal form.  It consists of:
         * JournalInformation - journal bibliographic data


### PR DESCRIPTION
I've reinstated a couple of tests that weren't using the right ```app``` to build urls, and made classifications required when changing to an 'end' status.

I've had to separate the Subjects part of the forms between Journal and Application - the field must be optional for Journals but conditionally required for Applications.

#815 