### PR TITLE
Fixed article ordering on TOC pages by getting the right field from t…

### DIFF
--- a/portality/models/article.py
+++ b/portality/models/article.py
@@ -836,7 +836,7 @@ def _sort_articles(articles):
     numbers = []
     imap = {}
     for art in articles:
-        sp = art.get("bibjson",{}).get("start_page",None)
+        sp = art.get("bibjson.start_page", [None])[0]
 
         # can't sort anything that doesn't have a start page
         if sp is None:


### PR DESCRIPTION
…he search results in the sort function - previously it was always getting None for the start_page, and falling back to ES ordering.

# Hotfix

For issue #877.