### PR TITLE
fixes to article ingest pipeline to defend against es-refresh race-co…

### DIFF
--- a/doajtest/unit/resources/article_uploads.xml
+++ b/doajtest/unit/resources/article_uploads.xml
@@ -28,7 +28,7 @@
         <affiliationsList>
             <affiliationName affiliationId="1"/>
         </affiliationsList>
-        <fullTextUrl/>
+        <fullTextUrl>http://doaj.org/testing/url.pdf</fullTextUrl>
         <keywords>
             <keyword>Introduction</keyword>
             <keyword>Littérature amérindienne</keyword>

--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -298,3 +298,10 @@ class TestClient(DoajTestCase):
         acc2.generate_api_key()
         acc2.save()
         assert acc2.api_key is not None
+
+    def test_10_block(self):
+        a = models.Article()
+        a.save()
+        models.Article.block(a.id, a.last_updated)
+        a = models.Article.pull(a.id)
+        assert a is not None

--- a/portality/article.py
+++ b/portality/article.py
@@ -298,6 +298,7 @@ class DOAJXWalk(XWalk):
         new = 0
         
         # go through the records in the doc and crosswalk each one individually
+        last_success = None
         root = doc.getroot()
         for record in root.findall("record"):
             article = self.crosswalk_article(record, add_journal_info=add_journal_info)
@@ -329,8 +330,13 @@ class DOAJXWalk(XWalk):
             # (which can do something like save)
             if article_callback is not None:
                 article_callback(article)
+                last_success = article
             success += 1
-        
+
+        # run the block so we are sure the records have saved
+        if last_success is not None:
+            models.Article.block(last_success.id, last_success.last_updated)
+
         # return some stats on the import
         return {"success" : success, "fail" : fail, "update" : update, "new" : new}
     
@@ -534,11 +540,11 @@ xwalk_map = {DOAJXWalk.format_name : DOAJXWalk}
 def article_upload_closure(upload_id):
     def article_callback(article):
         article.set_upload_id(upload_id)
-        article.save()
+        article.save(differentiate=True)
     return article_callback
 
 def article_save_callback(article):
-    article.save()
+    article.save(differentiate=True)
     
 def ingest_file(handle, format_name=None, owner=None, upload_id=None, article_fail_callback=None):
     try:

--- a/portality/models/article.py
+++ b/portality/models/article.py
@@ -373,9 +373,9 @@ class Article(DomainObject):
         self._generate_index()
         self.data['last_updated'] = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    def save(self):
+    def save(self, *args, **kwargs):
         self._generate_index()
-        super(Article, self).save()
+        super(Article, self).save(*args, **kwargs)
 
 class ArticleBibJSON(GenericBibJSON):
 

--- a/portality/models/uploads.py
+++ b/portality/models/uploads.py
@@ -6,6 +6,10 @@ class FileUpload(DomainObject):
     __type__ = "upload"
 
     @property
+    def status(self):
+        return self.data.get("status")
+
+    @property
     def local_filename(self):
         return self.id + ".xml"
 

--- a/portality/scripts/ingestarticles.py
+++ b/portality/scripts/ingestarticles.py
@@ -139,9 +139,10 @@ if upload_dir is None:
 
 # our first task is to dereference and validate any remote files
 to_download = models.FileUpload.list_remote()
-do_sleep = False
+# do_sleep = False
+last_valid = None
 for remote in to_download:
-    do_sleep = True
+    # do_sleep = True
     path = os.path.join(upload_dir, remote.local_filename)
     remote_filename = remote.filename
     if isinstance(remote_filename, unicode):
@@ -185,12 +186,18 @@ for remote in to_download:
     # document, so we can write it to the index
     remote.validated(actual_schema)
     remote.save()
+    last_valid = remote
     print "...success"
-    
+
+# block until the last upload has been surfaced
+if last_valid is not None:
+    models.FileUpload.block(last_valid.id, last_valid.last_updated)
+
+
 # in between, issue a refresh request and wait for the index to sort itself out
-if do_sleep:
-    models.FileUpload.refresh()
-    time.sleep(5)
+#if do_sleep:
+    # models.FileUpload.refresh()
+#    time.sleep(5)
 
 to_process = models.FileUpload.list_valid() # returns an iterator
 for upload in to_process:
@@ -233,5 +240,5 @@ for upload in to_process:
             pass
     
     # always refresh before moving on to the next file
-    models.Article.refresh()
-    time.sleep(5)
+    # models.Article.refresh()
+    #time.sleep(5)


### PR DESCRIPTION
…ndition bugs in rapid re-import of matching articles.  Plus tests.

This works by adding the following:

* a "differentiate" keyword on the DAO save() method which forces last_updated to be modified such that it is different to any previous version of the record if necessary.  Basically this means that if a record is saved twice in a second, it will block until the next second ticks over before saving.
* a block() method on the DAO which monitors an id for a last_updated time that can be /searched/ for (not pulled) which is equal to or greater than the desired time.
* calling save(differentiate=True) on articles when an XML doc is processed (and nowhere else in the codebase)
* calling block() after large loops over documents/result sets

The reasons for doing it this way, and not in the esprit style blocking save is that we don't want to do this for every save, only on the last save of many, and since the records are often pulled out of iterators, it's difficult to know when that is.  So instead, we separate the save from the block, and then just block the thread itself, based on the id/last_updated of the last saved object.

I realise, also, that we could do this with version numbers, and that would get rid of the need to differentiate on save, but I already had experience with this above approach, and know it works well, and I don't think the difference of approach really makes much difference, especially in this use case.