### PR TITLE
[hotfix] article deduplication hotfix

### DIFF
--- a/doajtest/unit/test_article_match.py
+++ b/doajtest/unit/test_article_match.py
@@ -155,8 +155,63 @@ class TestArticleMatch(DoajTestCase):
         expected = sorted([a, a2])
         xwalk = article.XWalk()
         l = xwalk.get_duplicate(z, all_duplicates=True)
+        assert isinstance(l, list), l
+        assert l
+        l.sort()
+        assert expected == l
+
+    def test_05_with_doi_instead(self):
+        # make ourselves a couple of example articles
+        a = models.Article()
+        b = a.bibjson()
+        b.title = "Example A article with a fulltext url"
+        b.add_identifier('doi', "10.doi")
+        a.save()
+
+        # wait for a bit to create good separation between last_updated times
+        time.sleep(2)
+
+        a2 = models.Article()
+        b2 = a2.bibjson()
+        b2.title = "Example B article with a fulltext url"
+        b2.add_identifier('doi', "10.doi")
+        a2.save()
+
+        # wait for a bit to create good separation between last_updated times
+        time.sleep(2)
+
+        # create an article which should not be caught by the duplicate detection
+        not_duplicate = models.Article()
+        not_duplicate_bibjson = not_duplicate.bibjson()
+        not_duplicate_bibjson.title = "Example C article with a fulltext url"
+        not_duplicate_bibjson.add_identifier('doi', "10.doi.DIFFERENT")
+        not_duplicate.save()
+
+        # pause to allow the index time to catch up
+        time.sleep(2)
+
+        # create a replacement article
+        z = models.Article()
+        y = z.bibjson()
+        y.title = "Replacement article for fulltext url"
+        y.add_identifier('doi', "10.doi")
+
+        # get the xwalk to determine if there is a duplicate
+        xwalk = article.XWalk()
+        d = xwalk.get_duplicate(z)
+
+        assert d is not None
+        assert d.bibjson().title == "Example B article with a fulltext url", d.bibjson().title
+
+        # get the xwalk to determine all duplicates
+        # sort both results and expectations here to avoid false alarm
+        # we don't care about the order of duplicates
+        expected = sorted([a, a2])
+        xwalk = article.XWalk()
+        l = xwalk.get_duplicate(z, all_duplicates=True)
         assert isinstance(l, list)
         assert l
+        assert len(l) == 2
         l.sort()
         assert expected == l
     
@@ -206,3 +261,40 @@ class TestArticleMatch(DoajTestCase):
         assert a2.bibjson().title == "Example B article with a fulltext url"
         assert a2.bibjson().abstract is None
         
+    def test_08(self):
+        # make ourselves a couple of example articles
+        a = models.Article()
+        b = a.bibjson()
+        b.title = "Example A article with a fulltext url"
+        b.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
+        a.save()
+
+        # create an article which should not be caught by the duplicate detection
+        not_duplicate = models.Article()
+        not_duplicate_bibjson = not_duplicate.bibjson()
+        not_duplicate_bibjson.title = "Example C article with a fulltext url"
+        not_duplicate_bibjson.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf_DIFFERENT", urltype="fulltext")
+        not_duplicate.save()
+
+        # pause to allow the index time to catch up
+        time.sleep(2)
+
+        # get the xwalk to determine if there is a duplicate
+        xwalk = article.XWalk()
+        d = xwalk.get_duplicate(a)
+
+        # TODO: This is complete nonsense, we must refactor get_duplicate
+        # so it doesn't return the article that is being passed in when
+        # requesting a single duplicate!
+        # This may have implications for XML upload ingestion and could be non-trivial.
+        # If you request multiple duplicates with all_duplicates=True it
+        # will act intuitively and not return the article you asked for.
+        assert d is not None  # current behaviour, but should be changed!
+        assert d.id == a.id  # current behaviour, but should be changed!
+
+        # get the xwalk to determine all duplicates - they do not include
+        # the original
+        xwalk = article.XWalk()
+        l = xwalk.get_duplicate(a, all_duplicates=True)
+        assert isinstance(l, list)
+        assert l == []

--- a/portality/article.py
+++ b/portality/article.py
@@ -61,6 +61,7 @@ class XWalk(object):
         # (this isn't as bad as it sounds - the identifiers are pretty reliable, this catches
         # issues like where there are already duplicates in the data, and not matching one
         # of them propagates the issue)
+        # additionally if all_duplicates has been set to True we will return them all to the caller
         possible_articles = []
         
         # first test is the most definitive - does the publisher's record id match
@@ -85,8 +86,12 @@ class XWalk(object):
             # there should only be the one
             doi = dois[0]
             articles = models.Article.duplicates(issns=issns, doi=doi)
-            if len(articles) == 1 and not all_duplicates:
-                return articles[0]
+            if len(articles) == 1:
+                if all_duplicates:
+                    if articles[0] not in possible_articles:
+                        possible_articles.append(articles[0])
+                else:
+                    return articles[0]
             if len(articles) > 1:
                 possible_articles += articles
                 use_doi = True # we don't have a definitive answer, but we do have options
@@ -96,13 +101,26 @@ class XWalk(object):
         if len(urls) > 0:
             # there should be only one, but let's allow for multiple
             articles = models.Article.duplicates(issns=issns, fulltexts=urls)
-            if len(articles) == 1 and not all_duplicates:
-                return articles[0]
+            if len(articles) == 1:
+                if all_duplicates:
+                    if articles[0] not in possible_articles:
+                        possible_articles.append(articles[0])
+                else:
+                    return articles[0]
             if len(articles) > 1:
                 possible_articles += articles
                 use_fulltext = True # we don't have a definitive answer, but we do have options
 
         if all_duplicates:
+            if article in possible_articles:
+                possible_articles.remove(article)  # if the Elasticsearch ID is the same then
+                    # this is the actual record we are trying to get duplicates for - don't return it
+                    # note that when called with a single article, it will return the article itself
+                    # that seems to have been the behaviour from the beginning
+                    # TODO this needs refactoring.
+                    # It makes 0 sense that XWalk().get_duplicate(article) returns article if no
+                    # duplicates are found. Especially now with XWalk().get_duplicate(article, all_duplicates=True)
+                    # returning [] if there are no duplicates.
             return possible_articles
 
         # now we need to try to do something about multiple hits one one or more of the above if needed
@@ -176,8 +194,8 @@ class XWalk(object):
         if len(articles) == 1:
             return articles[0]
         """
-        # else, we have failed to locate or have located too many matches
-        return None
+        # else, we have failed to locate
+        return [] if all_duplicates else None
 
 class FormXWalk(XWalk):
     format_name = "form"

--- a/portality/scripts/remove_duplicate_articles.py
+++ b/portality/scripts/remove_duplicate_articles.py
@@ -1,0 +1,46 @@
+"""
+This script will run through the entire catalogue, detecting duplicates
+of articles and removing them. It could take a long time and you should
+take great care running it - at minimum double check there is a recent
+backup available, there should always be one anyway.
+"""
+
+from portality import models
+from portality.article import XWalk
+import json
+from portality.core import app
+from datetime import datetime
+import time
+
+if __name__ == "__main__":
+    if app.config.get("SCRIPTS_READ_ONLY_MODE", False):
+        print "System is in READ-ONLY mode, script cannot run"
+        exit()
+
+    import argparse
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("-g", "--ghost", help="specify if you want the articles being deleted not to be snapshot", action="store_true")
+
+    args = parser.parse_args()
+
+    snapshot = not args.ghost
+    snapshot_report = "with snapshotting" if snapshot else "without snapshotting"
+
+    start = datetime.now()
+    count = 0
+    print 'Starting {0} {snapshot} in 5 seconds, Ctrl+C to exit.'.format(start.isoformat(), snapshot=snapshot_report)
+    time.sleep(5)
+
+    article_iterator = models.Article.iterall(page_size=5000)
+    for a in article_iterator:
+        duplicates = XWalk().get_duplicate(a, all_duplicates=True)
+        for d in duplicates:
+            if snapshot:
+                d.snapshot()
+            d.delete()
+            count += 1
+
+    end = datetime.now()
+    length = end - start
+    print "Ended {0}. {1} articles deleted. Took {2}.".format(end.isoformat(), count, str(length))

--- a/portality/scripts/remove_duplicate_articles.py
+++ b/portality/scripts/remove_duplicate_articles.py
@@ -7,7 +7,6 @@ backup available, there should always be one anyway.
 
 from portality import models
 from portality.article import XWalk
-import json
 from portality.core import app
 from datetime import datetime
 import time
@@ -21,8 +20,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-g", "--ghost", help="specify if you want the articles being deleted not to be snapshot", action="store_true")
+    parser.add_argument("-y", "--yes", help="are you running this script with output redirection e.g. DOAJENV=production python portality/scripts/remove_duplicate_articles.py >> ~/dedupe_`date +\%%F_\%%H\%%M\%%S`.log 2>&1 ? You really should.", action="store_true")
 
     args = parser.parse_args()
+
+    if not args.yes:
+        raise Exception('Please run this script with output redirection, see --help if needed, and also confirm you are running it with output redirection by passing -y on run.')
 
     snapshot = not args.ghost
     snapshot_report = "with snapshotting" if snapshot else "without snapshotting"
@@ -32,14 +35,25 @@ if __name__ == "__main__":
     print 'Starting {0} {snapshot} in 5 seconds, Ctrl+C to exit.'.format(start.isoformat(), snapshot=snapshot_report)
     time.sleep(5)
 
-    article_iterator = models.Article.iterall(page_size=5000)  # FIXME this doesn't do a scroll search, just normal queries, so we're deleting from a list we're modifying! Currently either because of this or what get_duplicate does, this deletes the original article AND the duplicates when an article with duplicates is found.
+    originals = []  # make sure we only delete FORWARD. So, if articles
+    # A, B and C are duplicates, we stumble upon A first, and delete B and C.
+    # We must then ensure we do not delete A if we chance upon B or C
+    # (because they are still in Python memory even though they are not in ES).
+    article_iterator = models.Article.iterall(page_size=5000)
     for a in article_iterator:
+        originals.append(a.id)
         duplicates = XWalk().get_duplicate(a, all_duplicates=True)
-        for d in duplicates:
-            if snapshot:
-                d.snapshot()
-            d.delete()
-            count += 1
+        if duplicates:
+            print '{0}:'.format(a.id),  # original: ...
+            for d in duplicates:
+                if not d.id in originals:
+                    if snapshot:
+                        d.snapshot()
+                    d.delete()
+                    count += 1
+                    print '{0},'.format(d.id)  # ... duplicate_deleted1, duplicate_deleted2, etc.
+                    time.sleep(1)
+            print
 
     end = datetime.now()
     length = end - start

--- a/portality/scripts/remove_duplicate_articles.py
+++ b/portality/scripts/remove_duplicate_articles.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     print 'Starting {0} {snapshot} in 5 seconds, Ctrl+C to exit.'.format(start.isoformat(), snapshot=snapshot_report)
     time.sleep(5)
 
-    article_iterator = models.Article.iterall(page_size=5000)
+    article_iterator = models.Article.iterall(page_size=5000)  # FIXME this doesn't do a scroll search, just normal queries, so we're deleting from a list we're modifying! Currently either because of this or what get_duplicate does, this deletes the original article AND the duplicates when an article with duplicates is found.
     for a in article_iterator:
         duplicates = XWalk().get_duplicate(a, all_duplicates=True)
         for d in duplicates:


### PR DESCRIPTION
# HOTFIX, DO NOT MERGE HERE

This is an attempt to get multiple duplicates for an article in one go. Currently for some reason the code in production will return the article itself when asked for duplicates (?!) and thus there are some .. complications when you ask for multiple duplicates of one article.

Technically (by the tests) the duplication detection is working correctly for multiples.

1. create article A with URL lala
2. create article B with URL lala
3. create article C with URL lala

get_duplicate(A, all_duplicates=True) will return B and C.

~~However, when running the new portality/scripts/remove_duplicate_articles.py **ALL** of them get deleted - A, B and C are all gone. I'm not sure why, but obviously that needs to be figured out before this goes on live. @Steven-Eardley if you have time tomorrow a bit of pairing might be helpful if I still haven't figured it out. I think it might have to do with~~

- ~~state of the index - we are deleting from a list we are reading from (not using scroll search - so we might need to use scroll search)~~
- ~~when we delete an article that's not reflected in Python memory. So I get to A and ask for duplicates. I get B and C. I delete them. But then I get to B and ask for duplicates. I get A and C, so I delete them. Now they're all gone. This is just conjecture, I may be wrong.~~