### PR TITLE
add username substitution to journal api, and add documentation

### DIFF
--- a/portality/settings.py
+++ b/portality/settings.py
@@ -469,7 +469,8 @@ DISCOVERY_JOURNAL_SEARCH_SUBS = {
     "title" : "index.title",
     "issn" :  "index.issn.exact",
     "publisher" : "bibjson.publisher",
-    "license" : "index.license.exact"
+    "license" : "index.license.exact",
+    "username" : "admin.owner.exact"
 }
 
 DISCOVERY_JOURNAL_SORT_SUBS = {

--- a/portality/templates/api/v1/api_docs.html
+++ b/portality/templates/api/v1/api_docs.html
@@ -59,6 +59,10 @@ doi:10.3389%5C/fpsyg.2013.00479
         </ul>
     </p>
 
+    <p>In addition, if you have a publisher account with the DOAJ, you may use the field "username" to query for your own publicly available journal records.
+        Usernames are not available in the returned journal records, and no list of usernames is available to the public;
+        you need to know your own username to use this field.  You would include "username:myusername" in your search.</p>
+
     <p>The substitutions for articles are as follows:<br>
         <ul>
             <li>title - search within the article title</li>


### PR DESCRIPTION
For the harvester project, but may be suitable to roll out along with the API anyway?  See #932 