### PR TITLE
shift from getFullYear to getUTCFullYear and bump app version for js …

### DIFF
--- a/portality/settings.py
+++ b/portality/settings.py
@@ -8,7 +8,7 @@ READ_ONLY_MODE = False
 # This puts the cron jobs into READ_ONLY mode
 SCRIPTS_READ_ONLY_MODE = False
 
-DOAJ_VERSION = "2.10.7_SNAPSHOT-1"
+DOAJ_VERSION = "2.10.8"
 
 OFFLINE_MODE = False
 

--- a/portality/static/doaj/js/available_facetviews/public.journalarticle.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/public.journalarticle.facetview.js
@@ -59,7 +59,7 @@ jQuery(document).ready(function($) {
             interval: "year",
             display: "Date added to DOAJ",
             value_function : function(val) {
-                return (new Date(parseInt(val))).getFullYear();
+                return (new Date(parseInt(val))).getUTCFullYear();
             },
             size: false,
             sort: "desc",
@@ -83,7 +83,7 @@ jQuery(document).ready(function($) {
             interval: "year",
             display: "Year of publication",
             value_function : function(val) {
-                return (new Date(parseInt(val))).getFullYear();
+                return (new Date(parseInt(val))).getUTCFullYear();
             },
             size: false,
             short_display: 15,


### PR DESCRIPTION
…cache busting

hotfix

Fix that we believe will resolve #952 , which is most likely due to getFullYear returning the user's local time, rather than the UTC time of the range timestamp.