### PR TITLE
[hotfix] add pagination and a total count HTTP headers to API

### DIFF
--- a/doajtest/unit/test_api_discovery.py
+++ b/doajtest/unit/test_api_discovery.py
@@ -1,4 +1,5 @@
 from doajtest.helpers import DoajTestCase
+from portality.app import app
 from portality import models
 from portality.api.v1 import DiscoveryApi, DiscoveryException
 from portality.api.v1.common import generate_link_headers
@@ -40,89 +41,89 @@ class TestArticleMatch(DoajTestCase):
         time.sleep(1)
 
         # now run some queries
+        with app.test_request_context():
+            # 1. a general query that should hit everything (except number 6)
+            res = DiscoveryApi.search_journals("Test", 1, 2)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 2
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 2
+            assert res.data.get("query") == "Test"
 
-        # 1. a general query that should hit everything (except number 6)
-        res = DiscoveryApi.search_journals("Test", 1, 2)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 2
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 2
-        assert res.data.get("query") == "Test"
+            # 2. a specific field query that should hit just one
+            res = DiscoveryApi.search_journals("title:\"Test Journal 2\"", 1, 5)
+            assert res.data.get("total") == 1
+            assert len(res.data.get("results")) == 1
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 5
+            assert res.data.get("query") == "title:\"Test Journal 2\""
 
-        # 2. a specific field query that should hit just one
-        res = DiscoveryApi.search_journals("title:\"Test Journal 2\"", 1, 5)
-        assert res.data.get("total") == 1
-        assert len(res.data.get("results")) == 1
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 5
-        assert res.data.get("query") == "title:\"Test Journal 2\""
+            # 3.paging out of range of results
+            res = DiscoveryApi.search_journals("Test", 2, 10)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 0
+            assert res.data.get("page") == 2
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
 
-        # 3.paging out of range of results
-        res = DiscoveryApi.search_journals("Test", 2, 10)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 0
-        assert res.data.get("page") == 2
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
+            # 4. paging outside the allowed bounds (lower)
+            res = DiscoveryApi.search_journals("Test", 0, 0)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
 
-        # 4. paging outside the allowed bounds (lower)
-        res = DiscoveryApi.search_journals("Test", 0, 0)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
+            # 5. page size above upper limit
+            res = DiscoveryApi.search_journals("Test", 1, 100000)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 100
+            assert res.data.get("query") == "Test"
 
-        # 5. page size above upper limit
-        res = DiscoveryApi.search_journals("Test", 1, 100000)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 100
-        assert res.data.get("query") == "Test"
+            # 6. Failed attempt at wildcard search
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_journals("Te*t", 1, 10)
 
-        # 6. Failed attempt at wildcard search
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_journals("Te*t", 1, 10)
+            # 7. Failed attempt at fuzzy search
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_journals("title:Test~0.8", 1, 10)
 
-        # 7. Failed attempt at fuzzy search
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_journals("title:Test~0.8", 1, 10)
+            # 8. sort on a specific field, expect a default to "asc"
+            res = DiscoveryApi.search_journals("Test", 1, 10, "created_date")
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
+            assert res.data.get("results")[0].get("created_date") < res.data.get("results")[1].get("created_date")
+            assert res.data.get("sort") == "created_date"
 
-        # 8. sort on a specific field, expect a default to "asc"
-        res = DiscoveryApi.search_journals("Test", 1, 10, "created_date")
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
-        assert res.data.get("results")[0].get("created_date") < res.data.get("results")[1].get("created_date")
-        assert res.data.get("sort") == "created_date"
+            # 9. sort on a specific field in a specified direction
+            res = DiscoveryApi.search_journals("Test", 1, 10, "created_date:desc")
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
+            assert res.data.get("results")[0].get("created_date") > res.data.get("results")[1].get("created_date")
+            assert res.data.get("sort") == "created_date:desc"
 
-        # 9. sort on a specific field in a specified direction
-        res = DiscoveryApi.search_journals("Test", 1, 10, "created_date:desc")
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
-        assert res.data.get("results")[0].get("created_date") > res.data.get("results")[1].get("created_date")
-        assert res.data.get("sort") == "created_date:desc"
+            # 10. Malformed sort direction
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_journals("Test", 1, 10, "created_date:whatever")
 
-        # 10. Malformed sort direction
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_journals("Test", 1, 10, "created_date:whatever")
+            # 11. non-existant sort field
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_journals("Test", 1, 10, "some.missing.field:asc")
 
-        # 11. non-existant sort field
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_journals("Test", 1, 10, "some.missing.field:asc")
+            # 12. with a forward slash, with and without escaping (note that we have to escape the : as it has meaning for lucene)
+            res = DiscoveryApi.search_journals('"http\://homepage.com/1"', 1, 10)
+            assert res.data.get("total") == 1
 
-        # 12. with a forward slash, with and without escaping (note that we have to escape the : as it has meaning for lucene)
-        res = DiscoveryApi.search_journals('"http\://homepage.com/1"', 1, 10)
-        assert res.data.get("total") == 1
-
-        res = DiscoveryApi.search_journals('"http\:\/\/homepage.com\/1"', 1, 10)
-        assert res.data.get("total") == 1
+            res = DiscoveryApi.search_journals('"http\:\/\/homepage.com\/1"', 1, 10)
+            assert res.data.get("total") == 1
 
     def test_02_articles(self):
         # populate the index with some articles
@@ -143,88 +144,89 @@ class TestArticleMatch(DoajTestCase):
 
         # now run some queries
 
-        # 1. a general query that should hit everything
-        res = DiscoveryApi.search_articles("Test", 1, 2)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 2
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 2
-        assert res.data.get("query") == "Test"
+        with app.test_request_context():
+            # 1. a general query that should hit everything
+            res = DiscoveryApi.search_articles("Test", 1, 2)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 2
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 2
+            assert res.data.get("query") == "Test"
 
-        # 2. a specific field query that should hit just one
-        res = DiscoveryApi.search_articles("title:\"Test Article 2\"", 1, 5)
-        assert res.data.get("total") == 1
-        assert len(res.data.get("results")) == 1
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 5
-        assert res.data.get("query") == "title:\"Test Article 2\""
+            # 2. a specific field query that should hit just one
+            res = DiscoveryApi.search_articles("title:\"Test Article 2\"", 1, 5)
+            assert res.data.get("total") == 1
+            assert len(res.data.get("results")) == 1
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 5
+            assert res.data.get("query") == "title:\"Test Article 2\""
 
-        # 3.paging out of range of results
-        res = DiscoveryApi.search_articles("Test", 2, 10)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 0
-        assert res.data.get("page") == 2
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
+            # 3.paging out of range of results
+            res = DiscoveryApi.search_articles("Test", 2, 10)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 0
+            assert res.data.get("page") == 2
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
 
-        # 4. paging outside the allowed bounds (lower)
-        res = DiscoveryApi.search_articles("Test", 0, 0)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
+            # 4. paging outside the allowed bounds (lower)
+            res = DiscoveryApi.search_articles("Test", 0, 0)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
 
-        # 5. page size above upper limit
-        res = DiscoveryApi.search_articles("Test", 1, 100000)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 100
-        assert res.data.get("query") == "Test"
+            # 5. page size above upper limit
+            res = DiscoveryApi.search_articles("Test", 1, 100000)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 100
+            assert res.data.get("query") == "Test"
 
-        # 6. Failed attempt at wildcard search
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_articles("Te*t", 1, 10)
+            # 6. Failed attempt at wildcard search
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_articles("Te*t", 1, 10)
 
-        # 7. Failed attempt at fuzzy search
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_articles("title:Test~0.8", 1, 10)
+            # 7. Failed attempt at fuzzy search
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_articles("title:Test~0.8", 1, 10)
 
-        # 8. sort on a specific field, expect a default to "asc"
-        res = DiscoveryApi.search_articles("Test", 1, 10, "created_date")
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
-        assert res.data.get("results")[0].get("created_date") < res.data.get("results")[1].get("created_date")
-        assert res.data.get("sort") == "created_date"
+            # 8. sort on a specific field, expect a default to "asc"
+            res = DiscoveryApi.search_articles("Test", 1, 10, "created_date")
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
+            assert res.data.get("results")[0].get("created_date") < res.data.get("results")[1].get("created_date")
+            assert res.data.get("sort") == "created_date"
 
-        # 9. sort on a specific field in a specified direction
-        res = DiscoveryApi.search_articles("Test", 1, 10, "created_date:desc")
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
-        assert res.data.get("results")[0].get("created_date") > res.data.get("results")[1].get("created_date")
-        assert res.data.get("sort") == "created_date:desc"
+            # 9. sort on a specific field in a specified direction
+            res = DiscoveryApi.search_articles("Test", 1, 10, "created_date:desc")
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
+            assert res.data.get("results")[0].get("created_date") > res.data.get("results")[1].get("created_date")
+            assert res.data.get("sort") == "created_date:desc"
 
-        # 10. Malformed sort direction
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_articles("Test", 1, 10, "created_date:whatever")
+            # 10. Malformed sort direction
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_articles("Test", 1, 10, "created_date:whatever")
 
-        # 11. non-existant sort field
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_articles("Test", 1, 10, "some.missing.field:asc")
+            # 11. non-existant sort field
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_articles("Test", 1, 10, "some.missing.field:asc")
 
-        # 12. with a forward slash, with and without escaping
-        res = DiscoveryApi.search_articles('"10.test/1"', 1, 10)
-        assert res.data.get("total") == 1
+            # 12. with a forward slash, with and without escaping
+            res = DiscoveryApi.search_articles('"10.test/1"', 1, 10)
+            assert res.data.get("total") == 1
 
-        res = DiscoveryApi.search_articles('"10.test\/1"', 1, 10)
-        assert res.data.get("total") == 1
+            res = DiscoveryApi.search_articles('"10.test\/1"', 1, 10)
+            assert res.data.get("total") == 1
 
     def test_03_applications(self):
         # create an account that will own the suggestions
@@ -264,95 +266,95 @@ class TestArticleMatch(DoajTestCase):
         time.sleep(1)
 
         # now run some queries
+        with app.test_request_context():
+            # 1. a general query that should hit everything
+            res = DiscoveryApi.search_applications(acc, "Test", 1, 2)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 2
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 2
+            assert res.data.get("query") == "Test"
 
-        # 1. a general query that should hit everything
-        res = DiscoveryApi.search_applications(acc, "Test", 1, 2)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 2
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 2
-        assert res.data.get("query") == "Test"
+            # 2. a specific field query that should hit just one
+            res = DiscoveryApi.search_applications(acc, "title:\"Test Suggestion 2\"", 1, 5)
+            assert res.data.get("total") == 1
+            assert len(res.data.get("results")) == 1
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 5
+            assert res.data.get("query") == "title:\"Test Suggestion 2\""
 
-        # 2. a specific field query that should hit just one
-        res = DiscoveryApi.search_applications(acc, "title:\"Test Suggestion 2\"", 1, 5)
-        assert res.data.get("total") == 1
-        assert len(res.data.get("results")) == 1
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 5
-        assert res.data.get("query") == "title:\"Test Suggestion 2\""
+            # 3.paging out of range of results
+            res = DiscoveryApi.search_applications(acc, "Test", 2, 10)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 0
+            assert res.data.get("page") == 2
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
 
-        # 3.paging out of range of results
-        res = DiscoveryApi.search_applications(acc, "Test", 2, 10)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 0
-        assert res.data.get("page") == 2
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
+            # 4. paging outside the allowed bounds (lower)
+            res = DiscoveryApi.search_applications(acc, "Test", 0, 0)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
 
-        # 4. paging outside the allowed bounds (lower)
-        res = DiscoveryApi.search_applications(acc, "Test", 0, 0)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
+            # 5. page size above upper limit
+            res = DiscoveryApi.search_applications(acc, "Test", 1, 100000)
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 100
+            assert res.data.get("query") == "Test"
 
-        # 5. page size above upper limit
-        res = DiscoveryApi.search_applications(acc, "Test", 1, 100000)
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 100
-        assert res.data.get("query") == "Test"
+            # 6. Failed attempt at wildcard search
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_applications(acc, "Te*t", 1, 10)
 
-        # 6. Failed attempt at wildcard search
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_applications(acc, "Te*t", 1, 10)
+            # 7. Failed attempt at fuzzy search
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_applications(acc, "title:Test~0.8", 1, 10)
 
-        # 7. Failed attempt at fuzzy search
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_applications(acc, "title:Test~0.8", 1, 10)
+            # 8. sort on a specific field, expect a default to "asc"
+            res = DiscoveryApi.search_applications(acc, "Test", 1, 10, "created_date")
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
+            assert res.data.get("results")[0].get("created_date") < res.data.get("results")[1].get("created_date")
+            assert res.data.get("sort") == "created_date"
 
-        # 8. sort on a specific field, expect a default to "asc"
-        res = DiscoveryApi.search_applications(acc, "Test", 1, 10, "created_date")
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
-        assert res.data.get("results")[0].get("created_date") < res.data.get("results")[1].get("created_date")
-        assert res.data.get("sort") == "created_date"
+            # 9. sort on a specific field in a specified direction
+            res = DiscoveryApi.search_applications(acc, "Test", 1, 10, "created_date:desc")
+            assert res.data.get("total") == 5
+            assert len(res.data.get("results")) == 5
+            assert res.data.get("page") == 1
+            assert res.data.get("pageSize") == 10
+            assert res.data.get("query") == "Test"
+            assert res.data.get("results")[0].get("created_date") > res.data.get("results")[1].get("created_date")
+            assert res.data.get("sort") == "created_date:desc"
 
-        # 9. sort on a specific field in a specified direction
-        res = DiscoveryApi.search_applications(acc, "Test", 1, 10, "created_date:desc")
-        assert res.data.get("total") == 5
-        assert len(res.data.get("results")) == 5
-        assert res.data.get("page") == 1
-        assert res.data.get("pageSize") == 10
-        assert res.data.get("query") == "Test"
-        assert res.data.get("results")[0].get("created_date") > res.data.get("results")[1].get("created_date")
-        assert res.data.get("sort") == "created_date:desc"
+            # 10. Malformed sort direction
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_applications(acc, "Test", 1, 10, "created_date:whatever")
 
-        # 10. Malformed sort direction
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_applications(acc, "Test", 1, 10, "created_date:whatever")
+            # 11. non-existant sort field
+            with self.assertRaises(DiscoveryException):
+                res = DiscoveryApi.search_applications(acc, "Test", 1, 10, "some.missing.field:asc")
 
-        # 11. non-existant sort field
-        with self.assertRaises(DiscoveryException):
-            res = DiscoveryApi.search_applications(acc, "Test", 1, 10, "some.missing.field:asc")
+            # 12. A search with an account that isn't either of the ones in the dataset
+            other = models.Account()
+            other.set_id("other")
+            res = DiscoveryApi.search_applications(other, "Test", 1, 10, "created_date:desc")
+            assert res.data.get("total") == 0
 
-        # 12. A search with an account that isn't either of the ones in the dataset
-        other = models.Account()
-        other.set_id("other")
-        res = DiscoveryApi.search_applications(other, "Test", 1, 10, "created_date:desc")
-        assert res.data.get("total") == 0
+            # 13. with a forward slash, with and without escaping (note that we have to escape the : as it has meaning for lucene)
+            res = DiscoveryApi.search_applications(acc, '"http\://homepage.com/1"', 1, 10)
+            assert res.data.get("total") == 1
 
-        # 13. with a forward slash, with and without escaping (note that we have to escape the : as it has meaning for lucene)
-        res = DiscoveryApi.search_applications(acc, '"http\://homepage.com/1"', 1, 10)
-        assert res.data.get("total") == 1
-
-        res = DiscoveryApi.search_applications(acc, '"http\:\/\/homepage.com\/1"', 1, 10)
-        assert res.data.get("total") == 1
+            res = DiscoveryApi.search_applications(acc, '"http\:\/\/homepage.com\/1"', 1, 10)
+            assert res.data.get("total") == 1
 
     def test_04_paging_for_link_headers(self):
         # calc_pagination takes total, page_size, requested_page

--- a/portality/api/v1/common.py
+++ b/portality/api/v1/common.py
@@ -168,6 +168,9 @@ def respond(data, status, metadata=None):
     if link:
         headers['Link'] = link
 
+    if 'total' in metadata:
+        headers['X-Total-Count'] = metadata['total']
+
     callback = request.args.get('callback', False)
     if callback:
         content = str(callback) + '(' + str(data) + ')'

--- a/portality/api/v1/discovery.py
+++ b/portality/api/v1/discovery.py
@@ -222,13 +222,13 @@ class DiscoveryApi(Api):
         }
 
         if previous_page is not None:
-            result["prev"] = app.config['BASE_URL'] + url_for('.' + endpoint, search_query=q, page=previous_page, pageSize=page_size)
+            result["prev"] = app.config['BASE_URL'] + url_for(app.config['API_BLUEPRINT_NAME'] + '.' + endpoint, search_query=q, page=previous_page, pageSize=page_size)
 
         if next_page is not None:
-            result["next"] = app.config['BASE_URL'] + url_for('.' + endpoint, search_query=q, page=next_page, pageSize=page_size)
+            result["next"] = app.config['BASE_URL'] + url_for(app.config['API_BLUEPRINT_NAME'] + '.' + endpoint, search_query=q, page=next_page, pageSize=page_size)
 
         if last_page is not None:
-            result["last"] = app.config['BASE_URL'] + url_for('.' + endpoint, search_query=q, page=last_page, pageSize=page_size)
+            result["last"] = app.config['BASE_URL'] + url_for(app.config['API_BLUEPRINT_NAME'] + '.' + endpoint, search_query=q, page=last_page, pageSize=page_size)
 
         if sort is not None:
             result["sort"] = sort

--- a/portality/api/v1/discovery.py
+++ b/portality/api/v1/discovery.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import esprit
 import re, json, uuid, os
 from copy import deepcopy
+from flask import url_for
 
 class DiscoveryException(Exception):
     pass
@@ -174,9 +175,41 @@ class DiscoveryApi(Api):
 
         return query, page, page_size
 
+    @staticmethod
+    def _calc_pagination(total, page_size, requested_page):
+        """
+        Calculate pagination for API results like # of pages and the last page.
+
+        Modified from https://github.com/Pylons/paginate/blob/master/paginate/__init__.py#L260 ,
+        a pagination library. (__init__.py, Page.__init__)
+        """
+        FISRT_PAGE = 1
+
+        if total == 0:
+            return 1, None, None, 1
+
+        page_count = ((total - 1) // page_size) + 1
+        last_page = FISRT_PAGE + page_count - 1
+        
+        # Links to previous and next page
+        if requested_page > FISRT_PAGE:
+            previous_page = requested_page - 1
+        else:
+            previous_page = None
+
+        if requested_page < last_page:
+            next_page = requested_page + 1
+        else:
+            next_page = None
+
+        return page_count, previous_page, next_page, last_page
+
     @classmethod
-    def _make_response(cls, res, q, page, page_size, sort, obs):
+    def _make_response(cls, endpoint, res, q, page, page_size, sort,
+                       obs):
         total = res.get("hits", {}).get("total", 0)
+
+        page_count, previous_page, next_page, last_page = cls._calc_pagination(total, page_size, page)
 
         # build the response object
         result = {
@@ -187,6 +220,15 @@ class DiscoveryApi(Api):
             "query" : q,
             "results" : obs
         }
+
+        if previous_page is not None:
+            result["prev"] = app.config['BASE_URL'] + url_for('.' + endpoint, search_query=q, page=previous_page, pageSize=page_size)
+
+        if next_page is not None:
+            result["next"] = app.config['BASE_URL'] + url_for('.' + endpoint, search_query=q, page=next_page, pageSize=page_size)
+
+        if last_page is not None:
+            result["last"] = app.config['BASE_URL'] + url_for('.' + endpoint, search_query=q, page=last_page, pageSize=page_size)
 
         if sort is not None:
             result["sort"] = sort
@@ -209,7 +251,7 @@ class DiscoveryApi(Api):
             raise DiscoveryException("There was an error executing your query (ref: {y})".format(y=magic))
 
         obs = [models.Article(**raw) for raw in esprit.raw.unpack_json_result(res)]
-        return cls._make_response(res, q, page, page_size, sort, obs)
+        return cls._make_response('search_articles', res, q, page, page_size, sort, obs)
 
     @classmethod
     def search_journals(cls, q, page, page_size, sort=None):
@@ -227,7 +269,7 @@ class DiscoveryApi(Api):
             raise DiscoveryException("There was an error executing your query (ref: {y})".format(y=magic))
 
         obs = [models.Journal(**raw) for raw in esprit.raw.unpack_json_result(res)]
-        return cls._make_response(res, q, page, page_size, sort, obs)
+        return cls._make_response('search_journals', res, q, page, page_size, sort, obs)
 
     @classmethod
     def search_applications(cls, account, q, page, page_size, sort=None):
@@ -245,7 +287,8 @@ class DiscoveryApi(Api):
             raise DiscoveryException("There was an error executing your query (ref: {y})".format(y=magic))
 
         obs = [models.Suggestion(**raw) for raw in esprit.raw.unpack_json_result(res)]
-        return cls._make_response(res, q, page, page_size, sort, obs)
+        return cls._make_response('search_applications', res, q, page, page_size, sort, obs)
+
 
 class SearchQuery(object):
     def __init__(self, qs, fro, psize, sortby=None, sortdir=None):

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -23,6 +23,7 @@ VALID_FEATURES = ['api']
 BASE_FILE_PATH = os.path.dirname(os.path.realpath(__file__))
 
 BASE_URL = "https://doaj.org"
+API_BLUEPRINT_NAME = "api_v1"  # change if upgrading API to new version and creating new view for that
 
 # make this something secret in your overriding app.cfg
 SECRET_KEY = "default-key"

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "unidecode",
         "Flask-Swagger==0.2.8",
         "flask-cors==2.1.2",
+        "LinkHeader==0.4.3",
         # for deployment
         "gunicorn",
         "newrelic",


### PR DESCRIPTION
# hotfix, do not merge here

As part of a final push to get the API project done I'm reviewing the API for best practices (there are many resources, but I found http://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api#limiting-fields to be a good modern checklist if you're interested). This adds pagination guidance and a total count.