### PR TITLE
Feature/continuations fixes

### DIFF
--- a/portality/migrate/continuations/README.md
+++ b/portality/migrate/continuations/README.md
@@ -4,3 +4,8 @@ This migrate script removes the existing "history" portion of a record in the in
 that list into a first-class journal object
 
     python portality/upgrade.py -u portality/migrate/continuations/continuations.json -v
+    
+    
+You will also need to update the ES mappings so that the new search interface changes work:
+
+    python portality/migrate/continuations/mappings.py

--- a/portality/migrate/continuations/mappings.py
+++ b/portality/migrate/continuations/mappings.py
@@ -1,0 +1,18 @@
+from portality.core import app
+import esprit
+
+nm = {
+    "properties" : {
+        "bibjson" : {
+            "properties" : {
+                "discontinued_date" : {
+                    "type" : "date",
+                    "format" : "dateOptionalTime"
+                }
+            }
+        }
+    }
+}
+
+conn = esprit.raw.Connection(app.config.get("ELASTIC_SEARCH_HOST"), app.config.get("ELASTIC_SEARCH_DB"))
+esprit.raw.put_mapping(conn, "journal", nm, es_version=app.config.get("ELASTIC_SEARCH_VERSION", "1.7.5"))

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -61,6 +61,7 @@ ELASTIC_SEARCH_HOST = "http://localhost:9200" # remember the http:// or https://
 ELASTIC_SEARCH_DB = "doaj"
 ELASTIC_SEARCH_TEST_DB = "doajtest"
 INITIALISE_INDEX = True # whether or not to try creating the index and required index types on startup
+ELASTIC_SEARCH_VERSION = "1.7.5"
 
 # PyCharm debug settings
 DEBUG_PYCHARM = False  # do not try to connect to the PyCharm debugger by default

--- a/portality/templates/doaj/toc.html
+++ b/portality/templates/doaj/toc.html
@@ -49,8 +49,13 @@
         {% if future %}
             <p><strong>Subsequent title(s): </strong>
             {% for f in future %}
-                {% if f.issns()|length > 0 %}
-                <a href="{{ url_for('doaj.toc', identifier=f.issns()[0]) }}">{{ f.title }}</a>
+                {% set bibjson = f.bibjson() %}
+                {% if bibjson.issns()|length > 0 %}
+                    {% if f.is_in_doaj() %}
+                        <a href="{{ url_for('doaj.toc', identifier=bibjson.issns()[0]) }}">{{ bibjson.title }}</a>
+                    {% else %}
+                        {{ bibjson.title }}, ISSN: {{ bibjson.issns()[0] }} (not available in DOAJ)
+                    {% endif %}
                 {% endif %}
                 {% if not loop.last %}&nbsp;|&nbsp;{% endif %}
             {% endfor %}
@@ -60,8 +65,13 @@
         {% if past %}
             <p><strong>Previous title(s): </strong>
             {% for p in past %}
-                {% if p.issns()|length > 0 %}
-                <a href="{{ url_for('doaj.toc', identifier=p.issns()[0]) }}">{{ p.title }}</a>
+                {% set bibjson = p.bibjson() %}
+                {% if bibjson.issns()|length > 0 %}
+                    {% if p.is_in_doaj() %}
+                        <a href="{{ url_for('doaj.toc', identifier=bibjson.issns()[0]) }}">{{ bibjson.title }}</a>
+                    {% else %}
+                        {{ bibjson.title }}, ISSN: {{ bibjson.issns()[0] }} (not available in DOAJ)
+                    {% endif %}
                 {% endif %}
                 {% if not loop.last %}&nbsp;|&nbsp;{% endif %}
             {% endfor %}

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -233,12 +233,12 @@ def toc(identifier=None, volume=None, issue=None):
     future_journals = journal.get_future_continuations()
     past_journals = journal.get_past_continuations()
 
-    # extract the bibjson, which is what the template is after
-    future = [j.bibjson() for j in future_journals]
-    past = [j.bibjson() for j in past_journals]
+    # extract the bibjson, which is what the template is after, and whether the record is in doaj
+    #future = [j.bibjson() j for j in future_journals]
+    #past = [j.bibjson() for j in past_journals]
 
     # now render all that information
-    return render_template('doaj/toc.html', journal=journal, bibjson=bibjson, future=future, past=past,
+    return render_template('doaj/toc.html', journal=journal, bibjson=bibjson, future=future_journals, past=past_journals,
                            search_page=True, toc_issn=issn, facetviews=['public.journaltocarticles.facetview'])
 
 


### PR DESCRIPTION
This fixes two known issues on the develop branch for the continuations code:

1/ Admin Journal facetview not rendering  - see #838 

2/ Dud links on ToC pages when replaced/replacing journals are in_doaj=False - see #839 

Once this has been merged and deployed to test, you will need to run the following script to fix (1):

    python portality/migrate/continuations/mappings.py

This will amend the ES mappings for the Journal type, to allow faceting over discontinued_date.