### PR TITLE
Hotfix/2016 05 21 1040 apc facet

### DIFF
--- a/doajtest/clonelive.py
+++ b/doajtest/clonelive.py
@@ -1,0 +1,14 @@
+import esprit, requests
+from portality.core import app
+
+ELASTIC_SEARCH_HOST = "http://localhost:9200"
+ELASTIC_SEARCH_DB = "doaj_old"
+
+live = esprit.raw.Connection(app.config.get("DOAJGATE_URL"), "doaj", auth=requests.auth.HTTPBasicAuth(app.config.get("DOAJGATE_UN"), app.config.get("DOAJGATE_PW")), verify_ssl=False, port=app.config.get("DOAJGATE_PORT"))
+local = esprit.raw.Connection(app.config.get("ELASTIC_SEARCH_HOST"), app.config.get("ELASTIC_SEARCH_DB"))
+
+esprit.tasks.copy(live, "account", local, "account", method="GET")
+esprit.tasks.copy(live, "journal", local, "journal", method="GET")
+esprit.tasks.copy(live, "suggestion", local, "suggestion", method="GET")
+esprit.tasks.copy(live, "article", local, "article", limit=100000, method="GET")
+esprit.tasks.copy(live, "editor_group", local, "editor_group", method="GET")

--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -306,3 +306,30 @@ class TestClient(DoajTestCase):
         models.Article.block(a.id, a.last_updated)
         a = models.Article.pull(a.id)
         assert a is not None
+
+    def test_13_index_has_apc(self):
+        # no apc record, not ticked
+        j = models.Journal()
+        j.set_created("1970-01-01T00:00:00Z")   # so it's before the tick
+        j.prep()
+        assert j.data.get("index", {}).get("has_apc") == "No Information"
+
+        # no apc record, ticked
+        j = models.Journal()
+        j.prep()
+        assert j.data.get("index", {}).get("has_apc") == "No"
+
+        # apc record, not ticked
+        j = models.Journal()
+        j.set_created("1970-01-01T00:00:00Z")   # so it's before the tick
+        b = j.bibjson()
+        b.set_apc("GBP", 100)
+        j.prep()
+        assert j.data.get("index", {}).get("has_apc") == "Yes"
+
+        # apc record, ticked
+        j = models.Journal()
+        b = j.bibjson()
+        b.set_apc("GBP", 100)
+        j.prep()
+        assert j.data.get("index", {}).get("has_apc") == "Yes"

--- a/portality/migrate/apc_facet/README.md
+++ b/portality/migrate/apc_facet/README.md
@@ -1,0 +1,8 @@
+# Migrate the Has APC Facet
+
+This changes the index.has_apc field during prep() so that it shows "No Information" for records
+where there is no APC and the record is not ticked
+
+    python portality/upgrade.py -u portality/migrate/apc_facet/apc_facet.json
+    
+    

--- a/portality/migrate/apc_facet/apc_facet.json
+++ b/portality/migrate/apc_facet/apc_facet.json
@@ -1,0 +1,8 @@
+{
+	"types": [
+		{
+			"type": "journal",
+			"keepalive": "1m"
+		}
+	]
+}

--- a/portality/models/journal.py
+++ b/portality/models/journal.py
@@ -646,7 +646,12 @@ class Journal(DomainObject):
         schema_codes = list(set(schema_codes))
 
         # work out of the journal has an apc
-        has_apc = "Yes" if len(self.bibjson().apc.keys()) > 0 else "No"
+        has_apc = "No Information"
+        apc_field_present = len(self.bibjson().apc.keys()) > 0
+        if apc_field_present:
+            has_apc = "Yes"
+        elif self.is_ticked():
+            has_apc = "No"
 
         # determine if the seal is applied
         has_seal = "Yes" if self.has_seal() else "No"
@@ -750,8 +755,8 @@ class Journal(DomainObject):
 
     def prep(self):
         self._ensure_in_doaj()
-        self._generate_index()
         self.calculate_tick()
+        self._generate_index()
         self.data['last_updated'] = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
 
     def _sync_owner_to_application(self):


### PR DESCRIPTION
hoftix

modifies the journal's prep method to provide the new calculation of the has_apc field for the public search facets.

Once deployed, the migration needs to be run to update all the journal records:

python portality/upgrade.py -u portality/migrate/apc_facet/apc_facet.json

