### PR TITLE
make Article.duplicate break up the query into several queries if too…

### DIFF
--- a/portality/settings.py
+++ b/portality/settings.py
@@ -61,6 +61,8 @@ ELASTIC_SEARCH_DB = "doaj"
 ELASTIC_SEARCH_TEST_DB = "doajtest"
 INITIALISE_INDEX = True # whether or not to try creating the index and required index types on startup
 
+ES_TERMS_LIMIT = 1024
+
 # PyCharm debug settings
 DEBUG_PYCHARM = False  # do not try to connect to the PyCharm debugger by default
 DEBUG_PYCHARM_SERVER = 'localhost'


### PR DESCRIPTION
… many issns are provided

HOTFIX

This fixes the duplication problem seen in #1033 - the problem was that for accounts with > 1024 ISSNs associated with them, the ES query was throwing an error due to a size limit.