### PR TITLE
[hotfix] add reapplication filter to admin appl fv

### DIFF
--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -155,11 +155,18 @@ class TestClient(DoajTestCase):
         assert s.suggester.get("name") == "test"
         assert s.suggester.get("email") == "test@test.com"
 
-        s.remove_current_journal()
-
-        assert s.current_journal is None
-
         s.prep()
+        assert 'index' in s, s
+        assert 'application_type' in s['index'], s['index']
+        assert s['index']['application_type'] == 'reapplication'
+
+        s.remove_current_journal()
+        assert s.current_journal is None
+        s.prep()
+        assert 'index' in s, s
+        assert 'application_type' in s['index'], s['index']
+        assert s['index']['application_type'] == 'new application'
+
         s.save()
 
     def test_05_bulk_reapplication_rw(self):

--- a/portality/migrate/reapplication_admin_facet/README.md
+++ b/portality/migrate/reapplication_admin_facet/README.md
@@ -1,0 +1,5 @@
+# Add an Application type facet
+
+This adds an index.application_type field during prep() so that it shows "reapplication" for records which have a `current_journal` set, and "new application" otherwise.
+
+    python portality/upgrade.py -u portality/migrate/reapplication_admin_facet/reapplication_admin_facet.json

--- a/portality/migrate/reapplication_admin_facet/reapplication_admin_facet.json
+++ b/portality/migrate/reapplication_admin_facet/reapplication_admin_facet.json
@@ -1,0 +1,8 @@
+{
+	"types": [
+		{
+			"type": "suggestion",
+			"keepalive": "1m"
+		}
+	]
+}

--- a/portality/models/suggestion.py
+++ b/portality/models/suggestion.py
@@ -124,6 +124,13 @@ class Suggestion(JournalLikeObject):
             cj.set_owner(self.owner)
             cj.save(sync_owner=False)
 
+    def _generate_index(self):
+        super(Suggestion, self)._generate_index()
+        if self.current_journal:
+            self.data["index"]['application_type'] = 'reapplication'
+        else:
+            self.data["index"]['application_type'] = 'new application'
+
     def prep(self):
         self._generate_index()
         self.set_last_updated()
@@ -189,7 +196,8 @@ APPLICATION_STRUCT = {
                 "has_seal" : {"coerce" : "unicode"},
                 "unpunctitle" : {"coerce" : "unicode"},
                 "asciiunpunctitle" : {"coerce" : "unicode"},
-                "continued" : {"coerce" : "unicode"}
+                "continued" : {"coerce" : "unicode"},
+                "application_type": {"coerce": "unicode"}
             },
             "lists" : {
                 "issn" : {"contains" : "field", "coerce" : "unicode"},

--- a/portality/static/doaj/js/available_facetviews/admin.applications.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.applications.facetview.js
@@ -18,6 +18,7 @@ jQuery(document).ready(function($) {
                 'display': 'Application Status',
                 'value_function': adminStatusMap
             },
+            {'field': 'index.application_type.exact', 'display': 'Application type'},
             {'field': 'suggestion.suggested_by_owner.exact', 'display': 'Application by owner?'},
             {'field': 'admin.editor_group.exact', 'display': 'Editor Group'},
             {'field': 'admin.editor.exact', 'display': 'Editor'},

--- a/portality/static/doaj/js/available_facetviews/public.journalarticle.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/public.journalarticle.facetview.js
@@ -216,7 +216,7 @@ jQuery(document).ready(function($) {
 
         // add the journal icon
         result += "<div class='pull-left' style='width: 4%'>";
-        result += "<i style='font-size: 24px' class='icon icon-book'></i>";
+        result += "<i style='font-size: 24px' class='fa fa-book'></i>";
         result += "</div>";
 
         result += "<div class='pull-left' style='width: 93%'>";
@@ -447,7 +447,7 @@ jQuery(document).ready(function($) {
 
         // add the article icon
         result += "<div class='pull-left' style='width: 4%'>";
-        result += "<i style='font-size: 24px' class='icon icon-file'></i>";
+        result += "<i style='font-size: 24px' class='fa fa-file'></i>";
         result += "</div>";
 
         result += "<div class='pull-left' style='width: 90%'>";

--- a/portality/static/doaj/js/available_facetviews/public.journaltocarticles.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/public.journaltocarticles.facetview.js
@@ -175,7 +175,7 @@ jQuery(document).ready(function($) {
 
         // add the article icon
         result += "<div class='pull-left' style='width: 4%'>";
-        result += "<i style='font-size: 24px' class='icon icon-file'></i>";
+        result += "<i style='font-size: 24px' class='fa fa-file'></i>";
         result += "</div>";
 
         result += "<div class='pull-left' style='width: 90%'>";

--- a/portality/static/doaj/js/doaj.facetview.theme.js
+++ b/portality/static/doaj/js/doaj.facetview.theme.js
@@ -164,8 +164,8 @@ function searchOptions(options) {
 
         // if there is a url_shortener available, render a link
         if (options.url_shortener) {
-            thefacetview += " <a href='#' class='facetview_shorten_url btn btn-mini' style='margin-left: 30px'><i class='icon-white icon-resize-small'></i> shorten url</a>";
-            thefacetview += " <a href='#' class='facetview_lengthen_url btn btn-mini' style='display: none; margin-left: 30px'><i class='icon-white icon-resize-full'></i> original url</a>";
+            thefacetview += " <a href='#' class='facetview_shorten_url btn btn-mini' style='margin-left: 30px'><i class='icon-black icon-resize-small'></i> shorten url</a>";
+            thefacetview += " <a href='#' class='facetview_lengthen_url btn btn-mini' style='display: none; margin-left: 30px'><i class='icon-black icon-resize-full'></i> original url</a>";
         }
 
         thefacetview += '</p> \

--- a/portality/static/doaj/js/facetview_results_render_callbacks.js
+++ b/portality/static/doaj/js/facetview_results_render_callbacks.js
@@ -187,10 +187,10 @@ fv_title_field = (function (resultobj) {
         }
         else if (resultobj.suggestion) {
             // this is a suggestion
-            field += "<i class='icon icon-signin' style=\"margin-right: 0.5em;\"></i>";
+            field += "<i class='fa fa-sign-in' style=\"margin-right: 0.5em;\"></i>";
         } else {
             // this is a journal
-            field += "<i class='icon icon-book'></i>";
+            field += "<i class='fa fa-book'></i>";
             isjournal = true;
         }
         if (resultobj.bibjson.title) {

--- a/portality/static/doaj/js/facetview_results_render_callbacks.js
+++ b/portality/static/doaj/js/facetview_results_render_callbacks.js
@@ -183,7 +183,7 @@ fv_title_field = (function (resultobj) {
         var isjournal = false;
         if (resultobj.bibjson && resultobj.bibjson.journal) {
             // this is an article
-            field += "<i class='icon icon-file'></i>";
+            field += "<i class='fa fa-file'></i>";
         }
         else if (resultobj.suggestion) {
             // this is a suggestion


### PR DESCRIPTION
# hotfix, do not merge here

#1045 

Contains:

1. migration and back-end code changes needed for new `index.application_type` field. Either "new application" or "reapplication".
2. admin applications section facet to expose the new value (tested locally, manually, 2 records with the 2 possible values - works as usual)

Also I noticed and fixed some style things, not related to #1045.

3. restore icons to admin applications facetview. The journal and application icons were gone (fontawesome related problem again - `icon-` style icons seem to work on some pages, but not all, and on those using FontAwesome's better icons with `fa-` works well).
4. made resize icon in bit.ly URL shortening black - it's hardly visible as white on light grey right now.

    ![image](https://cloud.githubusercontent.com/assets/1190172/17108727/add2ce8a-528c-11e6-9b3d-be5ece8aa20b.png)
