### PR TITLE
Feature/autocomplete

### DIFF
--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -874,15 +874,15 @@ class TestClient(DoajTestCase):
 
         time.sleep(2)
 
-        res = models.Journal.autocomplete("bibjson.publisher", "Bio")
+        res = models.Journal.advanced_autocomplete("index.publisher_ac", "bibjson.publisher", "Bio")
         assert len(res) == 2
 
-        res = models.Journal.autocomplete("bibjson.publisher", "BioMed")
+        res = models.Journal.advanced_autocomplete("index.publisher_ac", "bibjson.publisher", "BioMed")
         assert len(res) == 2
 
-        res = models.Journal.autocomplete("bibjson.publisher", "De ")
+        res = models.Journal.advanced_autocomplete("index.publisher_ac", "bibjson.publisher", "De ")
         assert len(res) == 1
 
-        res = models.Journal.autocomplete("bibjson.publisher", "BioMed C")
+        res = models.Journal.advanced_autocomplete("index.publisher_ac", "bibjson.publisher", "BioMed C")
         assert len(res) == 1
 

--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -851,3 +851,38 @@ class TestClient(DoajTestCase):
         j.prep()
         assert j.data.get("index", {}).get("has_apc") == "Yes"
 
+    def test_25_autocomplete(self):
+        j = models.Journal()
+        bj = j.bibjson()
+        bj.publisher = "BioMed Central"
+        j.save()
+
+        j = models.Journal()
+        bj = j.bibjson()
+        bj.publisher = "BioMedical Publisher"
+        j.save()
+
+        j = models.Journal()
+        bj = j.bibjson()
+        bj.publisher = "De Gruyter"
+        j.save()
+
+        j = models.Journal()
+        bj = j.bibjson()
+        bj.publisher = "Deep Mind"
+        j.save()
+
+        time.sleep(2)
+
+        res = models.Journal.autocomplete("bibjson.publisher", "Bio")
+        assert len(res) == 2
+
+        res = models.Journal.autocomplete("bibjson.publisher", "BioMed")
+        assert len(res) == 2
+
+        res = models.Journal.autocomplete("bibjson.publisher", "De ")
+        assert len(res) == 1
+
+        res = models.Journal.autocomplete("bibjson.publisher", "BioMed C")
+        assert len(res) == 1
+

--- a/portality/dao.py
+++ b/portality/dao.py
@@ -407,7 +407,7 @@ class DomainObject(UserDict.IterableUserDict, object):
         return cls.iterate(deepcopy(all_query), page_size, limit)
 
     @classmethod
-    def prefix_query(cls, field, prefix, size=5):
+    def prefix_query(cls, field, prefix, size=5, facet_field=None, analyzed_field=True):
         # example of a prefix query
         # {
         #     "query": {"prefix" : { "bibjson.publisher" : "ope" } },
@@ -416,15 +416,23 @@ class DomainObject(UserDict.IterableUserDict, object):
         #       "publisher" : { "terms" : {"field" : "bibjson.publisher.exact", "size": 5} }
         #     }
         # }
-        if field.endswith(app.config['FACET_FIELD']):
-            # strip .exact (or whatever it's configured as) off the end
-            query_field = field[:field.rfind(app.config['FACET_FIELD'])]
+
+        suffix = app.config['FACET_FIELD']
+        query_field = field
+        if analyzed_field:
+            if field.endswith(suffix):
+                # strip .exact (or whatever it's configured as) off the end
+                query_field = field[:field.rfind(suffix)]
         else:
-            query_field = field
+            if not field.endswith(suffix):
+                query_field = field + suffix
 
         # the actual terms should come from the .exact version of the
         # field - we are suggesting whole values, not fragments
-        facet_field = query_field + app.config['FACET_FIELD']
+        if facet_field is None:
+            facet_field = query_field + suffix
+        if not facet_field.endswith(suffix):
+            facet_field = facet_field + suffix
 
         q = {
             "query": {"prefix" : { query_field : prefix.lower() } },
@@ -437,9 +445,10 @@ class DomainObject(UserDict.IterableUserDict, object):
         return cls.send_query(q)
 
     @classmethod
-    def wildcard_autocomplete_query(cls, field, substring, before=False, after=True, facet_size=5):
+    def wildcard_autocomplete_query(cls, field, substring, before=True, after=True, facet_size=5, facet_field=None):
         """
         Example of a wildcard query
+        Works only on .exact fields
 
         {
             "query" : {
@@ -459,9 +468,9 @@ class DomainObject(UserDict.IterableUserDict, object):
         """
         # wildcard queries need to be on unanalyzed fields
         suffix = app.config['FACET_FIELD']
-        query_field = field
-        if not query_field.endswith("."  + suffix):
-            query_field = query_field + suffix
+        filter_field = field
+        if not filter_field.endswith(suffix):
+            filter_field = filter_field + suffix
 
         # add the wildcard before/after
         if before:
@@ -469,20 +478,46 @@ class DomainObject(UserDict.IterableUserDict, object):
         if after:
             substring = substring + "*"
 
+        # sort out the facet field
+        if facet_field is None:
+            facet_field = filter_field
+        if not facet_field.endswith(suffix):
+            facet_field = facet_field + suffix
+
         # build the query
         q = {
             "query" : {
-                "wildcard" : {query_field : substring}
+                "wildcard" : {filter_field : substring}
             },
             "size" : 0,
             "facets" : {
                 field : {
-                    "terms" : {"field" : query_field, "size" : facet_size}
+                    "terms" : {"field" : facet_field, "size" : facet_size}
                 }
             }
         }
 
         return cls.send_query(q)
+
+    @classmethod
+    def advanced_autocomplete(cls, filter_field, facet_field, substring, size=5, prefix_only=True):
+        analyzed = True
+        if " " in substring:
+            analyzed = False
+
+        substring = substring.lower()
+
+        if " " in substring and not prefix_only:
+            res = cls.wildcard_autocomplete_query(filter_field, substring, before=True, after=True, facet_size=size, facet_field=facet_field)
+        else:
+            res = cls.prefix_query(filter_field, substring, size=size, facet_field=facet_field, analyzed_field=analyzed)
+
+        result = []
+        for term in res['facets'][filter_field]['terms']:
+            # keep ordering - it's by count by default, so most frequent
+            # terms will now go to the front of the result list
+            result.append({"id": term['term'], "text": term['term']})
+        return result
 
     @classmethod
     def autocomplete(cls, field, prefix, size=5):

--- a/portality/migrate/autocomplete/README.md
+++ b/portality/migrate/autocomplete/README.md
@@ -1,0 +1,5 @@
+# Autocompletes
+
+This migrate script sets up autocomplete fields for publisher, institution and provider
+
+    python portality/upgrade.py -u portality/migrate/autocomplete/autocomplete.json -v

--- a/portality/migrate/autocomplete/autocomplete.json
+++ b/portality/migrate/autocomplete/autocomplete.json
@@ -1,0 +1,7 @@
+{
+	"types": [
+		{
+			"type": "journal"
+		}
+	]
+}

--- a/portality/models/journal.py
+++ b/portality/models/journal.py
@@ -648,6 +648,7 @@ class Journal(JournalLikeObject):
         self.calculate_tick()
         self._generate_index()
         self._calculate_has_apc()
+        self._generate_autocompletes()
         self.set_last_updated()
 
     def save(self, snapshot=True, sync_owner=True, **kwargs):
@@ -660,6 +661,24 @@ class Journal(JournalLikeObject):
 
     ######################################################
     ## internal utility methods
+
+    def _generate_autocompletes(self):
+        bj = self.bibjson()
+        publisher = bj.publisher
+        institution = bj.institution
+        provider = bj.provider
+
+        if "index" not in self.data:
+            self.data["index"] = {}
+
+        if publisher is not None:
+            self.data["index"]["publisher_ac"] = publisher.lower()
+
+        if institution is not None:
+            self.data["index"]["institution_ac"] = institution.lower()
+
+        if provider is not None:
+            self.data["index"]["provider_ac"] = provider.lower()
 
     def _calculate_has_apc(self):
         # work out of the journal has an apc
@@ -1183,7 +1202,10 @@ JOURNAL_STRUCT = {
                 "has_seal" : {"coerce" : "unicode"},
                 "unpunctitle" : {"coerce" : "unicode"},
                 "asciiunpunctitle" : {"coerce" : "unicode"},
-                "continued" : {"coerce" : "unicode"}
+                "continued" : {"coerce" : "unicode"},
+                "publisher_ac" : {"coerce" : "unicode"},
+                "institution_ac" : {"coerce" : "unicode"},
+                "provider_ac" : {"coerce" : "unicode"}
             },
             "lists" : {
                 "issn" : {"contains" : "field", "coerce" : "unicode"},

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -219,6 +219,12 @@ QUERY_ROUTE = {
     "publisher_reapp_query" : {"role" : "publisher", "default_filter" : False, "owner_filter" : True, "reapp_filter" : True}
 }
 
+AUTOCOMPLETE_ADVANCED_FIELD_MAPS = {
+    "bibjson.publisher" : "index.publisher_ac",
+    "bibjson.institution" : "index.institution_ac",
+    "bibjson.provider" : "index.provider_ac"
+}
+
 # ========================
 # MEDIA SETTINGS
 

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -138,7 +138,7 @@ def sitemap():
 
 @blueprint.route('/autocomplete/<doc_type>/<field_name>', methods=["GET", "POST"])
 def autocomplete(doc_type, field_name):
-    prefix = request.args.get('q', '').lower()
+    prefix = request.args.get('q', '')
     if not prefix:
         return jsonify({'suggestions': [{"id": "", "text": "No results found"}]})  # select2 does not understand 400, which is the correct code here...
 

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -147,7 +147,16 @@ def autocomplete(doc_type, field_name):
         return jsonify({'suggestions': [{"id": "", "text": "No results found"}]})  # select2 does not understand 404, which is the correct code here...
 
     size = request.args.get('size', 5)
-    return jsonify({'suggestions': m.autocomplete(field_name, prefix, size=size)})
+
+    filter_field = app.config.get("AUTOCOMPLETE_ADVANCED_FIELD_MAPS", {}).get(field_name)
+
+    suggs = []
+    if filter_field is None:
+        suggs = m.autocomplete(field_name, prefix, size=size)
+    else:
+        suggs = m.advanced_autocomplete(filter_field, field_name, prefix, size=size, prefix_only=False)
+
+    return jsonify({'suggestions': suggs})
     # you shouldn't return lists top-level in a JSON response:
     # http://flask.pocoo.org/docs/security/#json-security
 


### PR DESCRIPTION
This adds a mechanism to switch between autocomplete algorithms depending on the incoming string, and supports filtering by one field (e.g. in the index.* document space) and faceting on another, allowing us to more effectively use the prefix query, and to switch seamlessly to the wildcard query.