### PR TITLE
enable querying suggestions by status, and producing a csv report on …

### DIFF
--- a/portality/models/suggestion.py
+++ b/portality/models/suggestion.py
@@ -27,6 +27,11 @@ class Suggestion(JournalLikeObject):
         q = SuggestionQuery(email=email, statuses=statuses)
         r = cls.delete_by_query(q.query())
 
+    @classmethod
+    def list_by_status(cls, status):
+        q = StatusQuery(status)
+        return cls.iterate(q=q.query())
+
     def make_journal(self):
         # first make a raw copy of the content into a journal
         journal_data = deepcopy(self.data)
@@ -292,4 +297,22 @@ class OwnerStatusQuery(object):
 
     def query(self):
         return self._query
+
+class StatusQuery(object):
+
+    def __init__(self, statuses):
+        if not isinstance(statuses, list):
+            statuses = [statuses]
+        self.statuses = statuses
+
+    def query(self):
+        return {
+            "query" : {
+                "bool" : {
+                    "must" : [
+                        {"terms" : {"admin.application_status.exact" : self.statuses}}
+                    ]
+                }
+            }
+        }
 

--- a/portality/scripts/rejected_applications.py
+++ b/portality/scripts/rejected_applications.py
@@ -1,0 +1,54 @@
+from portality import models, clcsv, datasets
+import codecs
+
+def do_report(out):
+    with codecs.open(out, "wb", encoding="utf-8") as f:
+        writer = clcsv.UnicodeWriter(f)
+        writer.writerow(["Title", "ISSN(s)", "Country Code", "Country", "Status", "Date Applied", "Last Manual Update", "Last Update", "Notes"])
+        gen = models.Suggestion.list_by_status("rejected")
+        for s in gen:
+            bj = s.bibjson()
+            title = bj.title
+            issns = bj.issns()
+            cc = bj.country
+            applied = s.created_date
+            last_manual = s.last_manual_update
+            last_update = s.last_updated
+            notes = s.notes()
+            status = s.application_status
+
+            if title is None:
+                title = ""
+            if issns is None:
+                issns = []
+            if cc is None:
+                cc = ""
+            if applied is None:
+                applied = ""
+            if last_manual is None:
+                last_manual = "never"
+            if last_update is None:
+                last_update = "never"
+            if notes is None:
+                notes = []
+            if status is None:
+                status = "unknown"
+
+            issns = ", ".join(issns)
+            notes = "\n\n".join(["[" + n.get("date") + "] " + n.get("note") for n in notes])
+
+            country = datasets.get_country_name(cc)
+
+            writer.writerow([title, issns, cc, country, status, applied, last_manual, last_update, notes])
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--out", help="output file path")
+    args = parser.parse_args()
+
+    if not args.out:
+        print "Please specify an output file path with -o"
+        exit()
+
+    do_report(args.out)


### PR DESCRIPTION
…that

For issue #1061 

Once this has been merged, can it be run on test just to make sure it functions there, and then deployed to live, and then run again to produce the final output to be sent to @dommitchell 

To run the script do

    python portality/scripts/rejected_reapplications.py -o <output file path>

