### PR TITLE
replace journal activate/deactivate tasks with huey tasks + necessary refactors

### DIFF
--- a/portality/decorators.py
+++ b/portality/decorators.py
@@ -80,15 +80,23 @@ def restrict_to_role(role):
         return redirect(url_for('doaj.home'))
 
 
-def write_required(fn):
-    @wraps(fn)
-    def decorated_view(*args, **kwargs):
-        if app.config.get("READ_ONLY_MODE", False):
-            return render_template("doaj/readonly.html")
+def write_required(script=False):
+    def decorator(fn):
+        @wraps(fn)
+        def decorated_view(*args, **kwargs):
+            if app.config.get("READ_ONLY_MODE", False):
+                # TODO remove "script" argument from decorator.
+                # Should be possible to detect if this is run in a web context or not.
+                if script:
+                    raise RuntimeError('This task cannot run since the system is in read-only mode.')
+                else:
+                    return render_template("doaj/readonly.html")
 
-        return fn(*args, **kwargs)
+            return fn(*args, **kwargs)
 
-    return decorated_view
+        return decorated_view
+    return decorator
+
 
 def track_analytics(event_category, event_action, event_label='',
                     event_value=0, record_value_of_which_arg=''):

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -66,6 +66,10 @@ ELASTIC_SEARCH_VERSION = "1.7.5"
 
 ES_TERMS_LIMIT = 1024
 
+# redis settings
+HUEY_REDIS_HOST = '127.0.0.1'
+HUEY_REDIS_PORT = 6379
+
 # PyCharm debug settings
 DEBUG_PYCHARM = False  # do not try to connect to the PyCharm debugger by default
 DEBUG_PYCHARM_SERVER = 'localhost'

--- a/portality/tasks/__init__.py
+++ b/portality/tasks/__init__.py
@@ -1,0 +1,1 @@
+from portality.tasks.journal_in_out_doaj import journal_activate, journal_deactivate

--- a/portality/tasks/journal_in_out_doaj.py
+++ b/portality/tasks/journal_in_out_doaj.py
@@ -1,0 +1,29 @@
+from huey import RedisHuey
+
+from portality.core import app
+from portality import models
+from portality.decorators import write_required
+
+huey = RedisHuey('doaj', host=app.config['HUEY_REDIS_HOST'], port=app.config['HUEY_REDIS_PORT'])
+
+
+def journal_manage(journal_id, in_doaj_new_val):
+    j = models.Journal.pull(journal_id)
+    if j is None:
+        raise RuntimeError("Journal with id {} does not exist".format(journal_id))
+    j.bibjson().active = in_doaj_new_val
+    j.set_in_doaj(in_doaj_new_val)
+    j.save()
+    j.propagate_in_doaj_status_to_articles()  # will save each article, could take a while
+
+
+@huey.task()
+@write_required(script=True)
+def journal_activate(journal_id):
+    return journal_manage(journal_id, True)
+
+
+@huey.task()
+@write_required(script=True)
+def journal_deactivate(journal_id):
+    return journal_manage(journal_id, False)

--- a/portality/view/account.py
+++ b/portality/view/account.py
@@ -28,7 +28,7 @@ def index():
 @blueprint.route('/<username>', methods=['GET','POST', 'DELETE'])
 @login_required
 @ssl_required
-@write_required
+@write_required()
 def username(username):
     acc = models.Account.pull(username)
 
@@ -138,7 +138,7 @@ def login():
 
 @blueprint.route('/forgot', methods=['GET', 'POST'])
 @ssl_required
-@write_required
+@write_required()
 def forgot():
     CONTACT_INSTR = ' Please <a href="{url}">contact us.</a>'.format(url=url_for('doaj.contact'))
     if request.method == 'POST':
@@ -193,7 +193,7 @@ def forgot():
 
 @blueprint.route("/reset/<reset_token>", methods=["GET", "POST"])
 @ssl_required
-@write_required
+@write_required()
 def reset(reset_token):
     account = models.Account.get_by_reset_token(reset_token)
     if account is None:
@@ -252,7 +252,7 @@ class RegisterForm(Form):
 @blueprint.route('/register', methods=['GET', 'POST'])
 @login_required
 @ssl_required
-@write_required
+@write_required()
 def register():
     if not app.config.get('PUBLIC_REGISTER', False) and not current_user.has_role("create_user"):
         abort(401)

--- a/portality/view/admin.py
+++ b/portality/view/admin.py
@@ -175,7 +175,7 @@ JOURNAL_OP_MSG = 'Journal {} has been queued for processing. Refresh this page i
 @blueprint.route("/journal/<journal_id>/activate", methods=["GET", "POST"])
 @login_required
 @ssl_required
-# @write_required()
+@write_required()
 def journal_activate(journal_id):
     tasks.journal_activate(journal_id)
     flash(JOURNAL_OP_MSG.format('activation'), 'success')
@@ -184,7 +184,7 @@ def journal_activate(journal_id):
 @blueprint.route("/journal/<journal_id>/deactivate", methods=["GET", "POST"])
 @login_required
 @ssl_required
-# @write_required()
+@write_required()
 def journal_deactivate(journal_id):
     tasks.journal_deactivate(journal_id)
     flash(JOURNAL_OP_MSG.format('deactivation'), 'success')

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -79,7 +79,7 @@ def subjects():
 
 
 @blueprint.route("/application/new", methods=["GET", "POST"])
-@write_required
+@write_required()
 def suggestion():
     if request.method == "GET":
         fc = formcontext.ApplicationFormFactory.get_form_context()

--- a/portality/view/doajservices.py
+++ b/portality/view/doajservices.py
@@ -13,7 +13,7 @@ blueprint = Blueprint('doajservices', __name__)
 @blueprint.route("/unlock/<object_type>/<object_id>", methods=["POST"])
 @login_required
 @ssl_required
-@write_required
+@write_required()
 def unlock(object_type, object_id):
     # first figure out if we are allowed to even contemplate this action
     if object_type not in ["journal", "suggestion"]:

--- a/portality/view/editor.py
+++ b/portality/view/editor.py
@@ -53,7 +53,7 @@ def associate_suggestions():
 @blueprint.route('/journal/<journal_id>', methods=["GET", "POST"])
 @login_required
 @ssl_required
-@write_required
+@write_required()
 def journal_page(journal_id):
     # user must have the role "edit_journal"
     if not current_user.has_role("edit_journal"):
@@ -110,7 +110,7 @@ def journal_page(journal_id):
 @blueprint.route('/suggestion/<suggestion_id>', methods=["GET", "POST"])
 @login_required
 @ssl_required
-@write_required
+@write_required()
 def suggestion_page(suggestion_id):
     # user must have the role "edit_journal"
     if not current_user.has_role("edit_suggestion"):

--- a/portality/view/publisher.py
+++ b/portality/view/publisher.py
@@ -31,7 +31,7 @@ def index():
 @blueprint.route("/reapply/<reapplication_id>", methods=["GET", "POST"])
 @login_required
 @ssl_required
-@write_required
+@write_required()
 def reapplication_page(reapplication_id):
     if not app.config.get("REAPPLICATION_ACTIVE", False):
         return render_template("publisher/reapps_shutdown.html")
@@ -76,7 +76,7 @@ def updates_in_progress():
 @blueprint.route("/uploadfile", methods=["GET", "POST"])
 @login_required
 @ssl_required
-@write_required
+@write_required()
 def upload_file():
     # all responses involve getting the previous uploads
     previous = models.FileUpload.by_owner(current_user.id)
@@ -256,7 +256,7 @@ def _url_upload(url, schema, previous):
 @blueprint.route("/metadata", methods=["GET", "POST"])
 @login_required
 @ssl_required
-@write_required
+@write_required()
 def metadata():
     # if this is a get request, give the blank form - there is no edit feature
     if request.method == "GET":
@@ -321,7 +321,7 @@ def help():
 @blueprint.route("/reapply", methods=["GET", "POST"])
 @login_required
 @ssl_required
-@write_required
+@write_required()
 def bulk_reapply():
     if not app.config.get("REAPPLICATION_ACTIVE", False):
         if request.method == "GET":

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ setup(
         "flask-cors==2.1.2",
         "LinkHeader==0.4.3",
         "universal-analytics-python==0.2.4",
+        "huey==1.2.2",
+        "redis==2.10.5",
         # for deployment
         "gunicorn",
         "newrelic",


### PR DESCRIPTION
#1126 

There we are!

Code needs better organisation (like the location of the `huey` object), but this is a good example and start.

Get redis to run. Install via apt-get for now if you want then `sudo service redis-server start`. I am actually using docker, so I can use the newest version of redis, which production will also use. I think we should all do that. I'll tell you how tomorrow (but basically, 

1. install docker from its PPA repo, not ubuntu main repos - follow its tutorial online; 
2. `sudo docker run -p 127.0.0.1:6400:6379 --name doaj-redis -d redis:3.2.5` ; 
3. `sudo docker stop/start doaj-redis` and `sudo docker ps` for management; 
4. set HUEY_REDIS_PORT=6400 in your dev.cfg

).

pip install -r requirements.txt to get huey and redis-py.

Then run

    huey_consumer.py portality.tasks.journal_in_out_doaj.huey

from the root of the repo while having the virtual env activated to get the huey_consumer.py executable.

Then just go to a journal's admin page and hit Take out of DOAJ / Put in DOAJ. It's wired up and should work (does for me).

We'll talk more about it at tomorrow's tech meeting.