### PR TITLE
[hotfix] add nginx reload to letsencrypt procedure

### DIFF
--- a/deploy/crontab-production-gate
+++ b/deploy/crontab-production-gate
@@ -25,5 +25,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # m     h   dom     mon     dow     command
   0     6      *       *       *       export NOW=`date +\%F_\%H\%M\%S` ; export SNAPSHOT="snapshot_"`date +\%F_\%H\%M`; echo -e "\n\nstart timestamp $NOW with snapshot name $SNAPSHOT" >> /home/cloo/cron-logs/es_backups.log && curl -s -XPUT "http://"`head -n 1 /home/cloo/repl/ips/index | tr -d '\n'`":9200/_snapshot/doaj_s3/$SNAPSHOT" >> /home/cloo/cron-logs/es_backups.log 2>&1
-  19    11,22  *       *       *       export NOW=`date +\%F_\%H\%M\%S` ; echo -e "\n\nstart timestamp $NOW" >> /home/cloo/cron-logs/letsencrypt-autorenew.log && cd /opt/letsencrypt && ./letsencrypt-auto renew >> /home/cloo/cron-logs/letsencrypt-autorenew.log 2>&1
+  19    11,22  *       *       *       export NOW=`date +\%F_\%H\%M\%S` ; echo -e "\n\nstart timestamp $NOW" >> /home/cloo/cron-logs/letsencrypt-autorenew.log && cd /opt/letsencrypt && ./letsencrypt-auto renew >> /home/cloo/cron-logs/letsencrypt-autorenew.log 2>&1 && sudo nginx -t >> /home/cloo/cron-logs/letsencrypt-autorenew.log 2>&1 && sudo nginx -s reload >> /home/cloo/cron-logs/letsencrypt-autorenew.log 2>&1
 


### PR DESCRIPTION
I've been making some hotfixes (including static pages releases and cron job modifications) without putting them through the pull request process - just because they've either been my responsibility, or "small enough".

The thing is, of course, that leads to others not knowing what the changes are or what the cron jobs are. Even static pages releases can be made a PR which is merged without any review by its author - at least then there's a log of the changes on the github UI, so even that's useful.

More long-term, it is probably useful if I make sysadmin-related PRs actual PRs with review, so I can have your thoughts on alternative approaches or more things we could do in the future. Even just seeing what I think can/should be done is also useful to you (IMO). That also means I'll try to plan sysadmin related work so it's done not-when-it's-super-urgent, but will make PRs even if it is urgent - just merge them myself, so you get alerted and can see the changes.

This PR adds an nginx reload to the letsencrypt regular job. The job automatically renewed the cert successfully today (yay!!), but it was not exposed to users, since nginx needs to reload before that happens.