### PR TITLE
Feature/1183 article cleanup enhance

### DIFF
--- a/deploy/huey.sh
+++ b/deploy/huey.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-huey_consumer.py portality.tasks.consumer.main_queue

--- a/deploy/huey_long_running.sh
+++ b/deploy/huey_long_running.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+huey_consumer.py portality.tasks.consumer_long_running.long_running

--- a/deploy/huey_long_running.sh
+++ b/deploy/huey_long_running.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-huey_consumer.py portality.tasks.consumer_long_running.long_running
+huey_consumer.py portality.tasks.consumer_long_running.long_running >> ~/huey_long_running.log 2>&1

--- a/deploy/huey_main_queue.sh
+++ b/deploy/huey_main_queue.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-huey_consumer.py portality.tasks.consumer_main_queue.main_queue
+huey_consumer.py portality.tasks.consumer_main_queue.main_queue >> ~/huey_main_queue.log 2>&1

--- a/deploy/huey_main_queue.sh
+++ b/deploy/huey_main_queue.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+huey_consumer.py portality.tasks.consumer_main_queue.main_queue

--- a/doajtest/bootstrap.py
+++ b/doajtest/bootstrap.py
@@ -1,6 +1,6 @@
 import time
 from portality import core, dao
-from portality.tasks.redis_huey import main_queue
+from portality.tasks.redis_huey import main_queue, long_running
 
 import logging
 logging.getLogger("requests").setLevel(logging.WARNING)
@@ -15,6 +15,7 @@ def prepare_for_test():
     core.app.config['ENABLE_EMAIL'] = False
 
     main_queue.always_eager = True
+    long_running.always_eager = True
 
     # if a test on a previous run has totally failed and tearDown has not run, then make sure the index is gone first
     dao.DomainObject.destroy_index()

--- a/doajtest/unit/test_article_cleanup_sync.py
+++ b/doajtest/unit/test_article_cleanup_sync.py
@@ -6,6 +6,7 @@ from portality.tasks import article_cleanup_sync
 
 from datetime import datetime
 import time
+import rstr
 
 
 class TestArticleCleanupSync(DoajTestCase):
@@ -139,6 +140,92 @@ class TestArticleCleanupSync(DoajTestCase):
 
         # this one should have been deleted
         assert a3u is None
+
+    def test_04_odd_sync_situations(self):
+        # If articles contain ISSNS for >1 distinct journals, we should choose the 'best'
+
+        [jk_s, l_s, m_s] = fixtures.JournalFixtureFactory.make_many_journal_sources(3, in_doaj=False)
+
+        # a journal from which we will sync metadata
+        jk_s['admin']['in_doaj'] = True
+        j = models.Journal(**jk_s)
+        j.save()
+
+        # another journal that looks suspiciously like the first, more recently updated
+        copied_journal_title = "This is a duplicate journal"
+        jk_s['bibjson']['title'] = copied_journal_title
+        k = models.Journal(**jk_s)
+        k.set_last_manual_update()
+        k.save()
+
+        # a third journal, different to the first two and it's not in the DOAJ.
+        bad_journal_title = "This is an undesirable journal because it is not in DOAJ"
+        l_s['bibjson']['title'] = bad_journal_title
+        l = models.Journal(**l_s)
+        l.save()
+
+        # yet another journal, distinct but in the DOAJ
+        good_journal_title = "This is a good journal because it is in DOAJ"
+        m_s['bibjson']['title'] = good_journal_title
+        m_s['admin']['in_doaj'] = True
+        m = models.Journal(**m_s)
+        m.save()
+
+        # the identifiers to allow us to connect articles to the journal
+        jk_eissn = j.bibjson().get_identifiers(j.bibjson().E_ISSN)[0]
+        jk_pissn = j.bibjson().get_identifiers(j.bibjson().P_ISSN)[0]
+        l_eissn =l.bibjson().get_identifiers(l.bibjson().E_ISSN)[0]
+        l_pissn = l.bibjson().get_identifiers(l.bibjson().P_ISSN)[0]
+        m_pissn = m.bibjson().get_identifiers(m.bibjson().P_ISSN)[0]
+
+        # an article source which is already synchronised with both journals j and k
+        source = fixtures.ArticleFixtureFactory.make_article_source(eissn=jk_eissn, pissn=jk_pissn, with_journal_info=False,
+                                                                     with_id=False)
+        a1 = models.Article(**source)
+        a1.add_journal_metadata(j)
+        a1.save()
+
+        # an article without metadata, but whose ISSNs match both j and k
+        source2 = fixtures.ArticleFixtureFactory.make_article_source(eissn=jk_eissn, pissn=jk_pissn, with_journal_info=False,
+                                                                     with_id=False)
+        a2 = models.Article(**source2)
+        a2.save()
+
+        # an article that matches two different journal ISSNs
+        source3 = fixtures.ArticleFixtureFactory.make_article_source(eissn=l_eissn, pissn=m_pissn,
+                                                                     with_journal_info=False,
+                                                                     with_id=False)
+        a3 = models.Article(**source3)
+        a3.save()
+
+        # an article without metadata, but whose ISSNs match both j and k
+        source4 = fixtures.ArticleFixtureFactory.make_article_source(eissn=l_eissn, pissn=l_pissn,
+                                                                     with_journal_info=False,
+                                                                     with_id=False)
+        a4 = models.Article(**source4)
+        a4.save(blocking=True)
+
+        # run the sync/cleanup job
+        job = article_cleanup_sync.ArticleCleanupSyncBackgroundTask.prepare("testuser")
+        article_cleanup_sync.ArticleCleanupSyncBackgroundTask.submit(job)
+
+        time.sleep(2)
+
+        # retrieve any updated records
+        a1u = models.Article.pull(a1.id)
+        a2u = models.Article.pull(a2.id)
+        a3u = models.Article.pull(a3.id)
+        a4u = models.Article.pull(a4.id)
+
+        # a1 and a2 should have synced with journal k, the more recent one
+        assert a1u.bibjson().journal_title == copied_journal_title
+        assert a2u.bibjson().journal_title == copied_journal_title
+
+        # a3 should have synced with the journal that was in_doaj
+        assert a3u.bibjson().journal_title == good_journal_title
+
+        # a4 should have the journal info for journal l
+        assert a4u.bibjson().journal_title == bad_journal_title
 
     def test_05_best_journal(self):
         j1 = models.Journal()

--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -1005,13 +1005,23 @@ class TestClient(DoajTestCase):
         assert len(bj.audit) == 2
 
     def test_30_article_journal_sync(self):
-        j = models.Journal(**JournalFixtureFactory.make_journal_source())
-        a = models.Article(**ArticleFixtureFactory.make_article_source())
+        j = models.Journal(**JournalFixtureFactory.make_journal_source(in_doaj=True))
+        a = models.Article(**ArticleFixtureFactory.make_article_source(in_doaj=False, with_journal_info=False))
 
         assert a.has_seal() is False
         assert a.bibjson().journal_issns != j.bibjson().issns()
 
-        a.add_journal_metadata(j)
+        reg = models.Journal()
+        changed = a.add_journal_metadata(j, reg)
 
+        assert changed is True
         assert a.has_seal() is True
+        assert a.is_in_doaj() is True
         assert a.bibjson().journal_issns == j.bibjson().issns()
+        assert a.bibjson().publisher == j.bibjson().publisher
+        assert a.bibjson().journal_country == j.bibjson().country
+        assert a.bibjson().journal_language == j.bibjson().language
+        assert a.bibjson().journal_title == j.bibjson().title
+
+        changed = a.add_journal_metadata(j)
+        assert changed is False

--- a/portality/api/v1/crud/articles.py
+++ b/portality/api/v1/crud/articles.py
@@ -34,8 +34,12 @@ class ArticlesCrudApi(CrudApi):
         start_page = am.bibjson().start_page
         end_page = am.bibjson().end_page
         am.bibjson().remove_journal_metadata()  # then destroy all journal metadata
-        if not am.add_journal_metadata():  # overwrite journal part of metadata and in_doaj setting
+
+        try:
+            am.add_journal_metadata()  # overwrite journal part of metadata and in_doaj setting
+        except models.NoJournalException as e:
             raise Api400Error("No journal found to attach article to. Each article in DOAJ must belong to a journal and the (E)ISSNs provided in the bibjson.identifiers section of this article record do not match any DOAJ journal.")
+
         # restore the user's data
         am.bibjson().number = number
         am.bibjson().volume = volume

--- a/portality/models/__init__.py
+++ b/portality/models/__init__.py
@@ -7,7 +7,7 @@ from portality.models.lock import Lock
 from portality.models.journal import Journal, JournalBibJSON, JournalQuery, IssnQuery, PublisherQuery, TitleQuery, ContinuationException
 from portality.models.suggestion import Suggestion, SuggestionQuery, OwnerStatusQuery
 from portality.models.history import ArticleHistory, JournalHistory
-from portality.models.article import Article, ArticleBibJSON, ArticleQuery, ArticleVolumesQuery, DuplicateArticleQuery
+from portality.models.article import Article, ArticleBibJSON, ArticleQuery, ArticleVolumesQuery, DuplicateArticleQuery, NoJournalException
 from portality.models.oaipmh import OAIPMHRecord, OAIPMHJournal, OAIPMHArticle
 from portality.models.atom import AtomRecord
 from portality.models.search import JournalArticle, JournalArticleQuery

--- a/portality/scripts/article_cleanup_sync.py
+++ b/portality/scripts/article_cleanup_sync.py
@@ -36,3 +36,6 @@ if __name__ == "__main__":
 
     end = datetime.now()
     print start, "-", end
+
+    for a in job.audit:
+        print a

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -76,7 +76,7 @@ HUEY_SCHEDULE = {
     "reporting" : {"month" : "*", "day" : "1", "hour" : "0", "minute" : "0"},
     "journal_csv" : {"month" : "*", "day" : "*", "hour" : "*", "minute" : "30"},
     "read_news" : {"month" : "*", "day" : "*", "hour" : "*", "minute" : "30"},
-#    "article_cleanup_sync" : {"month" : "*", "day" : "2", "hour" : "0", "minute" : "0"}
+    "article_cleanup_sync" : {"month" : "*", "day" : "2", "hour" : "0", "minute" : "0"}
 }
 
 HUEY_TASKS = {

--- a/portality/tasks/article_cleanup_sync.py
+++ b/portality/tasks/article_cleanup_sync.py
@@ -15,6 +15,7 @@ import json
 from portality import models
 from portality.util import unicode_dict
 from portality.core import app
+from datetime import datetime
 
 class ArticleCleanupSyncBackgroundTask(BackgroundTask):
 
@@ -165,6 +166,8 @@ class ArticleCleanupSyncBackgroundTask(BackgroundTask):
             else:
                 context = result["not_in_doaj"]
 
+            if lmu is None:
+                lmu = datetime.utcfromtimestamp(0)
             if lmu not in context:
                 context[lmu] = {}
             context[lmu][lu] = j

--- a/portality/tasks/consumer_long_running.py
+++ b/portality/tasks/consumer_long_running.py
@@ -1,0 +1,12 @@
+# NOTE: this file is designed to be imported by Huey, the background job processor
+# It changes the logging configuration. If it's imported anywhere else in the app,
+# it will change the logging configuration for the entire app.
+import logging
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+# import the queues
+from portality.tasks.redis_huey import long_running
+
+# these are the ones that bind to the long_running queue
+from portality.tasks.article_cleanup_sync import scheduled_article_cleanup_sync, article_cleanup_sync

--- a/portality/tasks/consumer_main_queue.py
+++ b/portality/tasks/consumer_main_queue.py
@@ -5,8 +5,12 @@ import logging
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
+# import the queues
 from portality.tasks.redis_huey import main_queue
 
+# now import the tasks that will bind to those queues
+
+# these are the ones which mind to the main_queue
 from portality.tasks.reporting import scheduled_reports, run_reports
 from portality.tasks.journal_in_out_doaj import set_in_doaj
 from portality.tasks.sitemap import scheduled_sitemap, generate_sitemap
@@ -14,7 +18,6 @@ from portality.tasks.journal_bulk_edit import journal_bulk_edit
 from portality.tasks.suggestion_bulk_edit import suggestion_bulk_edit
 from portality.tasks.ingestarticles import ingest_articles
 from portality.tasks.journal_csv import scheduled_journal_csv, journal_csv
-#from portality.tasks.article_cleanup_sync import scheduled_article_cleanup_sync, article_cleanup_sync
 from portality.tasks.read_news import scheduled_read_news, read_news
 from portality.tasks.journal_bulk_delete import journal_bulk_delete
 from portality.tasks.article_bulk_delete import article_bulk_delete

--- a/portality/tasks/redis_huey.py
+++ b/portality/tasks/redis_huey.py
@@ -1,7 +1,9 @@
 from huey import RedisHuey, crontab
 from portality.core import app
 
-main_queue = RedisHuey('doaj', host=app.config['HUEY_REDIS_HOST'], port=app.config['HUEY_REDIS_PORT'], always_eager=app.config.get("HUEY_EAGER", False))
+main_queue = RedisHuey('doaj_main_queue', host=app.config['HUEY_REDIS_HOST'], port=app.config['HUEY_REDIS_PORT'], always_eager=app.config.get("HUEY_EAGER", False))
+
+long_running = RedisHuey('doaj_long_running', host=app.config['HUEY_REDIS_HOST'], port=app.config['HUEY_REDIS_PORT'], always_eager=app.config.get("HUEY_EAGER", False))
 
 def schedule(action):
     cfg = app.config.get("HUEY_SCHEDULE", {})


### PR DESCRIPTION
This introduces a bunch of performance enhancements and feature improvements to the article cleanup script.  While it will max the CPU as much as it is allowed, it should use less than 150Mb of memory now (possibly as little as 100Mb).  Estimated run time for the entire index is around 10 hours.

In order to allow this to run alongside shorter background tasks without interfering with them, I've also created a new queue I've called "long_running", where we could put other non-trivial tasks to be executed.  You now need to start these with

   deploy/huey_main_queue.sh
   deploy/huey_long_running.sh

