### PR TITLE
HOTFIX to ensure publisher index field is correctly structured

### DIFF
--- a/portality/migrate/1196_publisher_struct/README.md
+++ b/portality/migrate/1196_publisher_struct/README.md
@@ -1,0 +1,11 @@
+# 1196_publisher_struct
+
+RJ 31-01-2017
+
+Migration script to be run to convert incorrect index.publisher fields to correct form, caused
+by incorrect struct.  See issue 1196.
+
+Run
+
+    python portality/upgrade.py -u portality/migrate/1196_publisher_struct/publisher_struct.json
+

--- a/portality/migrate/1196_publisher_struct/operations.py
+++ b/portality/migrate/1196_publisher_struct/operations.py
@@ -1,0 +1,11 @@
+from portality import models
+
+def clear_journal_index_fields(record):
+    if "index" in record:
+        del record["index"]
+    return models.Journal(**record)
+
+def clear_suggestion_index_fields(record):
+    if "index" in record:
+        del record["index"]
+    return models.Suggestion(**record)

--- a/portality/migrate/1196_publisher_struct/publisher_struct.json
+++ b/portality/migrate/1196_publisher_struct/publisher_struct.json
@@ -1,0 +1,20 @@
+{
+	"types": [
+		{
+			"type" : "suggestion",
+			"init_with_model" : false,
+			"keepalive" : "1m",
+			"functions" : [
+				"portality.migrate.1196_publisher_struct.operations.clear_suggestion_index_fields"
+			]
+		},
+		{
+			"type": "journal",
+			"init_with_model": false,
+			"keepalive": "1m",
+			"functions" : [
+				"portality.migrate.1196_publisher_struct.operations.clear_journal_index_fields"
+			]
+		}
+	]
+}

--- a/portality/models/journal.py
+++ b/portality/models/journal.py
@@ -1201,7 +1201,6 @@ JOURNAL_STRUCT = {
         "index" : {
             "fields" : {
                 "country" : {"coerce" : "unicode"},
-                "publisher" : {"coerce" : "unicode"},
                 "homepage_url" : {"coerce" : "unicode"},
                 "waiver_policy_url" : {"coerce" : "unicode"},
                 "editorial_board_url" : {"coerce" : "unicode"},
@@ -1228,7 +1227,8 @@ JOURNAL_STRUCT = {
                 "language" : {"contains" : "field", "coerce" : "unicode"},
                 "license" : {"contains" : "field", "coerce" : "unicode"},
                 "classification_paths" : {"contains" : "field", "coerce" : "unicode"},
-                "schema_code" : {"contains" : "field", "coerce" : "unicode"}
+                "schema_code" : {"contains" : "field", "coerce" : "unicode"},
+                "publisher" : {"contains" : "field", "coerce" : "unicode"}
             }
         }
     }

--- a/portality/models/journal.py
+++ b/portality/models/journal.py
@@ -284,40 +284,41 @@ class JournalLikeObject(dataobj.DataObj, DomainObject):
             has_editor = "Yes"
 
         # build the index part of the object
-        self.data["index"] = {}
+        index = {}
         if len(issns) > 0:
-            self.data["index"]["issn"] = issns
+            index["issn"] = issns
         if len(titles) > 0:
-            self.data["index"]["title"] = titles
+            index["title"] = titles
         if len(subjects) > 0:
-            self.data["index"]["subject"] = subjects
+            index["subject"] = subjects
         if len(schema_subjects) > 0:
-            self.data["index"]["schema_subject"] = schema_subjects
+            index["schema_subject"] = schema_subjects
         if len(classification) > 0:
-            self.data["index"]["classification"] = classification
+            index["classification"] = classification
         if len(publisher) > 0:
-            self.data["index"]["publisher"] = publisher
+            index["publisher"] = publisher
         if len(license) > 0:
-            self.data["index"]["license"] = license
+            index["license"] = license
         if len(langs) > 0:
-            self.data["index"]["language"] = langs
+            index["language"] = langs
         if country is not None:
-            self.data["index"]["country"] = country
+            index["country"] = country
         if len(schema_codes) > 0:
-            self.data["index"]["schema_code"] = schema_codes
+            index["schema_code"] = schema_codes
         if len(urls.keys()) > 0:
-            self.data["index"].update(urls)
+            index.update(urls)
         if has_seal:
-            self.data["index"]["has_seal"] = has_seal
+            index["has_seal"] = has_seal
         if len(classification_paths) > 0:
-            self.data["index"]["classification_paths"] = classification_paths
+            index["classification_paths"] = classification_paths
         if unpunctitle is not None:
-            self.data["index"]["unpunctitle"] = unpunctitle
+            index["unpunctitle"] = unpunctitle
         if asciiunpunctitle is not None:
-            self.data["index"]["asciiunpunctitle"] = asciiunpunctitle
-        self.data["index"]["continued"] = continued
-        self.data["index"]["has_editor_group"] = has_editor_group
-        self.data["index"]["has_editor"] = has_editor
+            index["asciiunpunctitle"] = asciiunpunctitle
+        index["continued"] = continued
+        index["has_editor_group"] = has_editor_group
+        index["has_editor"] = has_editor
+        self._set_with_struct("index", index)
 
 class Journal(JournalLikeObject):
     __type__ = "journal"
@@ -678,17 +679,14 @@ class Journal(JournalLikeObject):
         institution = bj.institution
         provider = bj.provider
 
-        if "index" not in self.data:
-            self.data["index"] = {}
-
         if publisher is not None:
-            self.data["index"]["publisher_ac"] = publisher.lower()
+            self._set_with_struct("index.publisher_ac", publisher.lower())
 
         if institution is not None:
-            self.data["index"]["institution_ac"] = institution.lower()
+            self._set_with_struct("index.institution_ac", institution.lower())
 
         if provider is not None:
-            self.data["index"]["provider_ac"] = provider.lower()
+            self._set_with_struct("index.provider_ac", provider.lower())
 
     def _calculate_has_apc(self):
         # work out of the journal has an apc
@@ -699,9 +697,7 @@ class Journal(JournalLikeObject):
         elif self.is_ticked():
             has_apc = "No"
 
-        if "index" not in self.data:
-            self.data["index"] = {}
-        self.data["index"]["has_apc"] = has_apc
+        self._set_with_struct("index.has_apc", has_apc)
 
     def _ensure_in_doaj(self):
         # switching active to false takes the item out of the DOAJ

--- a/portality/models/suggestion.py
+++ b/portality/models/suggestion.py
@@ -131,10 +131,11 @@ class Suggestion(JournalLikeObject):
 
     def _generate_index(self):
         super(Suggestion, self)._generate_index()
+
         if self.current_journal:
-            self.data["index"]['application_type'] = 'reapplication'
+            self._set_with_struct("index.application_type", "reapplication")
         else:
-            self.data["index"]['application_type'] = 'new application'
+            self._set_with_struct("index.application_type", "new application")
 
     def prep(self):
         self._generate_index()


### PR DESCRIPTION
HOTFIX, see issue #1196 

This changes the struct for the journals and applications, so that the publisher index field is now a list not a unicode string.  This should line up with the index mapping.

There is a migration that should be run which will make sure that the index is updated, though it is likely that items that are incorrect will correct themselves in time anyway.