### PR TITLE
bulk article delete; no UI yet

### DIFF
--- a/doajtest/unit/test_task_article_bulk_delete.py
+++ b/doajtest/unit/test_task_article_bulk_delete.py
@@ -1,0 +1,55 @@
+from time import sleep
+import json
+
+from doajtest.helpers import DoajTestCase
+
+from portality import models
+from portality.tasks.article_bulk_delete import article_bulk_delete_manage
+
+from doajtest.fixtures import JournalFixtureFactory, AccountFixtureFactory, ArticleFixtureFactory
+
+TEST_JOURNAL_COUNT = 2
+TEST_ARTICLES_PER_JOURNAL = 25
+
+class TestTaskJournalBulkDelete(DoajTestCase):
+
+    def setUp(self):
+        super(TestTaskJournalBulkDelete, self).setUp()
+
+        self.journals = []
+        self.articles = []
+        for j_src in JournalFixtureFactory.make_many_journal_sources(count=TEST_JOURNAL_COUNT):
+            j = models.Journal(**j_src)
+            self.journals.append(j)
+            j.save()
+            for i in range(0, TEST_ARTICLES_PER_JOURNAL):
+                a = models.Article(**ArticleFixtureFactory.make_article_source(with_id=False, eissn=j.bibjson().first_eissn, pissn=j.bibjson().first_pissn))
+                a.save()
+                self.articles.append(a)
+
+        sleep(2)
+
+        self._make_and_push_test_context(acc=models.Account(**AccountFixtureFactory.make_managing_editor_source()))
+
+    def tearDown(self):
+        super(TestTaskJournalBulkDelete, self).tearDown()
+
+    def test_01_bulk_delete(self):
+        """Bulk delete journals as an admin, but leave some around to test queries in bulk delete job"""
+        # test dry run
+
+        # all articles with the last journal's ISSN. The articles for the other journal should remain intact.
+        del_q_should_terms = {"query": {"bool": {"must": [{"match_all": {}}, {"terms": {"index.issn.exact": [self.journals[-1].bibjson().first_pissn]}}]}}}
+
+        r = article_bulk_delete_manage(del_q_should_terms, dry_run=True)
+        assert r == 1 * TEST_ARTICLES_PER_JOURNAL, r
+
+        r = article_bulk_delete_manage(del_q_should_terms, dry_run=False)
+        assert r is True, r
+
+        sleep(3)
+
+        job = models.BackgroundJob.all()[0]
+
+        assert len(models.Journal.all()) == TEST_JOURNAL_COUNT, "{}\n\n{}".format(len(models.Journal.all()), json.dumps(job.audit, indent=2))  # json.dumps([j.data for j in models.Journal.all()], indent=2)
+        assert len(models.Article.all()) == 1 * TEST_ARTICLES_PER_JOURNAL, "{}\n\n{}".format(len(models.Article.all()), json.dumps(job.audit, indent=2))  # json.dumps([a.data for a in models.Article.all()], indent=2)

--- a/doajtest/unit/test_util.py
+++ b/doajtest/unit/test_util.py
@@ -1,0 +1,37 @@
+import types
+
+from doajtest.helpers import DoajTestCase
+from portality import util
+
+
+class TestUtil(DoajTestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_01_batch_up(self):
+        """ Test and document how the batching up function works """
+        long_list = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]  # len(long_list) is 22
+
+        lazy_batches = util.batch_up(long_list, batch_size=5)
+        assert isinstance(lazy_batches, types.GeneratorType), type(lazy_batches)
+
+        batches = []
+        for batch in lazy_batches:
+            batches.append(batch)
+        assert isinstance(batches, list), type(batches)
+        assert len(batches) == 5, len(batches)
+
+        assert isinstance(batches[0], list), "wrong type {} for batch {} of {}".format(type(batches[0]), 0, len(batches))
+        assert batches[0] == [10, 11, 12, 13, 14], batches[0]
+        assert isinstance(batches[1], list), "wrong type {} for batch {} of {}".format(type(batches[1]), 1, len(batches))
+        assert batches[1] == [15, 16, 17, 18, 19], batches[1]
+        assert isinstance(batches[2], list), "wrong type {} for batch {} of {}".format(type(batches[2]), 2, len(batches))
+        assert batches[2] == [20, 21, 22, 23, 24], batches[2]
+        assert isinstance(batches[3], list), "wrong type {} for batch {} of {}".format(type(batches[3]), 3, len(batches))
+        assert batches[3] == [25, 26, 27, 28, 29], batches[3]
+        assert isinstance(batches[4], list), "wrong type {} for batch {} of {}".format(type(batches[4]), 4, len(batches))
+        assert batches[4] == [30, 31], batches[4]

--- a/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
@@ -30,9 +30,13 @@ jQuery(document).ready(function($) {
         }
 
         function bulk_action_type() {
-            if (get_bulk_action() == 'delete') {
-                return 'journals,articles';
-            }
+            // TODO if the action is "delete", we want to take the value of the _type facet
+            // and return "articles" or "journals" as appropriate.
+            // We also need to make disable the bulk job submit button unless an option
+            // is selected in the _type facet.
+            // if (get_bulk_action() == 'delete') {
+            //     return 'journals,articles';
+            // }
             return 'journals'
         }
 

--- a/portality/tasks/article_bulk_delete.py
+++ b/portality/tasks/article_bulk_delete.py
@@ -1,0 +1,128 @@
+from copy import deepcopy
+import json
+
+from flask_login import current_user
+
+from portality import models
+
+from portality.tasks.redis_huey import main_queue
+from portality.decorators import write_required
+
+from portality.background import AdminBackgroundTask, BackgroundApi, BackgroundException
+
+
+def article_bulk_delete_manage(selection_query, dry_run=True):
+
+    if dry_run:
+        ArticleBulkDeleteBackgroundTask.check_admin_privilege(current_user.id)
+        return ArticleBulkDeleteBackgroundTask.estimate_delete_counts(selection_query)
+
+    ids = ArticleBulkDeleteBackgroundTask.resolve_selection_query(selection_query)
+    job = ArticleBulkDeleteBackgroundTask.prepare(
+        current_user.id,
+        selection_query=selection_query,
+        ids=ids
+    )
+    ArticleBulkDeleteBackgroundTask.submit(job)
+
+    return True
+
+
+class ArticleBulkDeleteBackgroundTask(AdminBackgroundTask):
+
+    __action__ = "article_bulk_delete"
+
+    @classmethod
+    def _job_parameter_check(cls, params):
+        # we definitely need "ids" defined
+        return bool(cls.get_param(params, 'ids'))
+
+    def run(self):
+        """
+        Execute the task as specified by the background_job
+        :return:
+        """
+        job = self.background_job
+        params = job.params
+
+        ids = self.get_param(params, 'ids')
+
+        if not self._job_parameter_check(params):
+            raise BackgroundException(u"{}.run run without sufficient parameters".format(self.__class__.__name__))
+
+        estimate = self.estimate_delete_counts(json.loads(job.reference['selection_query']))
+        job.add_audit_message(u"About to delete an estimated {} articles".format(estimate))
+
+        # TODO this could be an issue with lots of article IDs (the should_terms being so big)
+        # Break up in batches if a problem occurs during manual testing.
+        # Might need a unit or integration test to test batching up works.
+        article_delete_q_by_ids = models.Article.make_query(should_terms={'_id': ids}, consistent_order=False)
+        models.Article.delete_selected(query=article_delete_q_by_ids, snapshot=True)
+        job.add_audit_message(u"Deleted {} articles".format(len(ids)))
+
+    def cleanup(self):
+        """
+        Cleanup after a successful OR failed run of the task
+        :return:
+        """
+        pass
+
+    @classmethod
+    def estimate_delete_counts(cls, selection_query):
+        q = deepcopy(selection_query)
+        res = models.Article.query(q=q, raise_es_errors=True)
+        return res['hits']['total']
+
+    @classmethod
+    def resolve_selection_query(cls, selection_query):
+        q = deepcopy(selection_query)
+        q["_source"] = False
+        iterator = models.Article.iterate(q=q, page_size=5000, wrap=False)
+        return [j['_id'] for j in iterator]
+
+    @classmethod
+    def prepare(cls, username, **kwargs):
+        """
+        Take an arbitrary set of keyword arguments and return an instance of a BackgroundJob,
+        or fail with a suitable exception
+
+        :param kwargs: arbitrary keyword arguments pertaining to this task type
+        :return: a BackgroundJob instance representing this task
+        """
+
+        super(ArticleBulkDeleteBackgroundTask, cls).prepare(username, **kwargs)
+
+        # first prepare a job record
+        job = models.BackgroundJob()
+        job.user = username
+        job.action = cls.__action__
+        job.reference = {'selection_query': json.dumps(kwargs['selection_query'])}
+
+        params = {}
+        cls.set_param(params, 'ids', kwargs['ids'])
+
+        if not cls._job_parameter_check(params):
+            raise BackgroundException(u"{}.prepare run without sufficient parameters".format(cls.__name__))
+
+        job.params = params
+
+        return job
+
+    @classmethod
+    def submit(cls, background_job):
+        """
+        Submit the specified BackgroundJob to the background queue
+
+        :param background_job: the BackgroundJob instance
+        :return:
+        """
+        background_job.save(blocking=True)
+        article_bulk_delete.schedule(args=(background_job.id,), delay=10)
+
+
+@main_queue.task()
+@write_required(script=True)
+def article_bulk_delete(job_id):
+    job = models.BackgroundJob.pull(job_id)
+    task = ArticleBulkDeleteBackgroundTask(job)
+    BackgroundApi.execute(task)

--- a/portality/tasks/consumer.py
+++ b/portality/tasks/consumer.py
@@ -16,3 +16,5 @@ from portality.tasks.ingestarticles import ingest_articles
 from portality.tasks.journal_csv import scheduled_journal_csv, journal_csv
 #from portality.tasks.article_cleanup_sync import scheduled_article_cleanup_sync, article_cleanup_sync
 from portality.tasks.read_news import scheduled_read_news, read_news
+from portality.tasks.journal_bulk_delete import journal_bulk_delete
+from portality.tasks.article_bulk_delete import article_bulk_delete

--- a/portality/util.py
+++ b/portality/util.py
@@ -189,3 +189,10 @@ def validate_json(payload, fields_must_be_present=None, fields_must_not_be_prese
                 return False
 
     return True
+
+
+def batch_up(long_list, batch_size):
+    """Yield successive n-sized chunks from l (a list)."""
+    # http://stackoverflow.com/a/312464/1154882
+    for i in xrange(0, len(long_list), batch_size):
+        yield long_list[i:i + batch_size]

--- a/portality/view/admin.py
+++ b/portality/view/admin.py
@@ -557,7 +557,7 @@ def bulk_articles_delete():
 
     q = get_query_from_request(payload)
 
-    r = article_bulk_delete.article_bulk_delete_manage(
+    r['affected_articles'] = article_bulk_delete.article_bulk_delete_manage(
         selection_query=q,
         dry_run=payload.get('dry_run', True)
     )

--- a/portality/view/admin.py
+++ b/portality/view/admin.py
@@ -11,7 +11,7 @@ from portality import lock
 from portality.lib.es_query_http import remove_search_limits
 from portality.util import flash_with_url, jsonp, make_json_resp, get_web_json_payload, validate_json
 from portality.core import app
-from portality.tasks import journal_in_out_doaj, journal_bulk_edit, suggestion_bulk_edit, journal_bulk_delete
+from portality.tasks import journal_in_out_doaj, journal_bulk_edit, suggestion_bulk_edit, journal_bulk_delete, article_bulk_delete
 
 from portality.view.forms import EditorGroupForm, MakeContinuation
 
@@ -513,6 +513,7 @@ def bulk_add_note(doaj_type):
 
     return make_json_resp(r, status_code=200)
 
+
 @blueprint.route("/applications/bulk/change_status", methods=["POST"])
 @login_required
 @ssl_required
@@ -531,6 +532,7 @@ def applications_bulk_change_status():
 
     return make_json_resp(r, status_code=200)
 
+
 @blueprint.route("/journals/bulk/delete", methods=['POST'])
 def bulk_journals_delete():
     r = {}
@@ -540,6 +542,22 @@ def bulk_journals_delete():
     q = get_query_from_request(payload)
 
     r = journal_bulk_delete.journal_bulk_delete_manage(
+        selection_query=q,
+        dry_run=payload.get('dry_run', True)
+    )
+
+    return make_json_resp(r, status_code=200)
+
+
+@blueprint.route("/articles/bulk/delete", methods=['POST'])
+def bulk_articles_delete():
+    r = {}
+    payload = get_web_json_payload()
+    validate_json(payload, fields_must_be_present=['selection_query'], error_to_raise=BulkAdminEndpointException)
+
+    q = get_query_from_request(payload)
+
+    r = article_bulk_delete.article_bulk_delete_manage(
         selection_query=q,
         dry_run=payload.get('dry_run', True)
     )


### PR DESCRIPTION
Fully working, tested. Back-end only.

Remaining:

- on the UI, disable the bulk job Submit button if the Delete option is selected and if the user has not yet selected an option in the _type facet.
- make sure the UI takes the option selected in the _type facet into account when submitting bulk delete jobs. There are 2 URLs in admin.py, not one.