### PR TITLE
add new requirements of live code into deploy scripts, not clear why …

### DIFF
--- a/deploy/deploy-gateway.sh
+++ b/deploy/deploy-gateway.sh
@@ -43,6 +43,8 @@ pip install flask-cors==2.1.2 # for some reason this is not being picked up from
 # something's wrong with the virtualenv
 pip install LinkHeader==0.4.3
 pip install universal-analytics-python==0.2.4
+pip install huey==1.2.2
+pip install redis==2.10.5
 
 # prep sym links for the app server
 ln -sf $DIR/supervisor/doaj-$ENV.conf /home/cloo/repl/$ENV/supervisor/conf.d/doaj-$ENV.conf


### PR DESCRIPTION
…requirements.txt is not picking them up. It has been an issue for a while. A cleaner virtualenv deployment (where we don't recreate it every single time?) might help. I'd have thought recreating it would ensure 100% all requirements are installed, but alas, it doesn't actually install everything in setup.py.