### PR TITLE
Feature/1220 bulk ui feedback

### DIFF
--- a/doajtest/unit/test_task_article_bulk_delete.py
+++ b/doajtest/unit/test_task_article_bulk_delete.py
@@ -42,11 +42,11 @@ class TestTaskJournalBulkDelete(DoajTestCase):
         # all articles with the last journal's ISSN. The articles for the other journal should remain intact.
         del_q_should_terms = {"query": {"bool": {"must": [{"match_all": {}}, {"terms": {"index.issn.exact": [self.journals[-1].bibjson().first_pissn]}}]}}}
 
-        r = article_bulk_delete_manage(del_q_should_terms, dry_run=True)
-        assert r == 1 * TEST_ARTICLES_PER_JOURNAL, r
+        summary = article_bulk_delete_manage(del_q_should_terms, dry_run=True)
+        assert summary.as_dict().get("affected", {}).get("articles") == 1 * TEST_ARTICLES_PER_JOURNAL, summary.as_dict()
 
-        r = article_bulk_delete_manage(del_q_should_terms, dry_run=False)
-        assert r == TEST_ARTICLES_PER_JOURNAL
+        summary = article_bulk_delete_manage(del_q_should_terms, dry_run=False)
+        assert summary.as_dict().get("affected", {}).get("articles") == TEST_ARTICLES_PER_JOURNAL
 
         sleep(3)
 

--- a/doajtest/unit/test_task_journal_bulk_delete.py
+++ b/doajtest/unit/test_task_journal_bulk_delete.py
@@ -53,11 +53,13 @@ class TestTaskJournalBulkDelete(DoajTestCase):
             ids_to_delete.append(self.journals[i].id)
         del_q_should_terms = {"query": {"bool": {"must": [{"match_all": {}}, {"terms": {"_id": ids_to_delete}}]}}}
 
-        r = journal_bulk_delete_manage(del_q_should_terms, dry_run=True)
-        assert r == {'journals-to-be-deleted': TEST_JOURNAL_COUNT - SPARE_JOURNALS_NUM, 'articles-to-be-deleted': (TEST_JOURNAL_COUNT - SPARE_JOURNALS_NUM) * TEST_ARTICLES_PER_JOURNAL}, r
+        summary = journal_bulk_delete_manage(del_q_should_terms, dry_run=True)
+        assert summary.as_dict().get("affected", {}).get("journals") == TEST_JOURNAL_COUNT - SPARE_JOURNALS_NUM
+        assert summary.as_dict().get("affected", {}).get("articles") == (TEST_JOURNAL_COUNT - SPARE_JOURNALS_NUM) * TEST_ARTICLES_PER_JOURNAL
 
-        r = journal_bulk_delete_manage(del_q_should_terms, dry_run=False)
-        assert r == {'journals-to-be-deleted': TEST_JOURNAL_COUNT - SPARE_JOURNALS_NUM, 'articles-to-be-deleted': (TEST_JOURNAL_COUNT - SPARE_JOURNALS_NUM) * TEST_ARTICLES_PER_JOURNAL}, r
+        summary = journal_bulk_delete_manage(del_q_should_terms, dry_run=False)
+        assert summary.as_dict().get("affected", {}).get("journals") == TEST_JOURNAL_COUNT - SPARE_JOURNALS_NUM
+        assert summary.as_dict().get("affected", {}).get("articles") == (TEST_JOURNAL_COUNT - SPARE_JOURNALS_NUM) * TEST_ARTICLES_PER_JOURNAL
 
         sleep(3)
 

--- a/doajtest/unit/test_task_journal_bulkedit.py
+++ b/doajtest/unit/test_task_journal_bulkedit.py
@@ -42,11 +42,11 @@ class TestTaskJournalBulkEdit(DoajTestCase):
         new_eg = EditorGroupFixtureFactory.setup_editor_group_with_editors(group_name='Test Editor Group')
 
         # test dry run
-        r = journal_manage({"query": {"terms": {"_id": [j.id for j in self.journals]}}}, editor_group=new_eg.name, dry_run=True)
-        assert r == TEST_JOURNAL_COUNT, r
+        summary = journal_manage({"query": {"terms": {"_id": [j.id for j in self.journals]}}}, editor_group=new_eg.name, dry_run=True)
+        assert summary.as_dict().get("affected", {}).get("journals") == TEST_JOURNAL_COUNT, summary.as_dict()
 
-        r = journal_manage({"query": {"terms": {"_id": [j.id for j in self.journals]}}}, editor_group=new_eg.name, dry_run=False)
-        assert r == TEST_JOURNAL_COUNT, r
+        summary = journal_manage({"query": {"terms": {"_id": [j.id for j in self.journals]}}}, editor_group=new_eg.name, dry_run=False)
+        assert summary.as_dict().get("affected", {}).get("journals") == TEST_JOURNAL_COUNT, summary.as_dict()
 
         sleep(1)
 
@@ -62,11 +62,11 @@ class TestTaskJournalBulkEdit(DoajTestCase):
 
     def test_02_note_successful_add(self):
         # test dry run
-        r = journal_manage({"query": {"terms": {"_id": [j.id for j in self.journals]}}}, note="Test note", dry_run=True)
-        assert r == TEST_JOURNAL_COUNT, r
+        summary = journal_manage({"query": {"terms": {"_id": [j.id for j in self.journals]}}}, note="Test note", dry_run=True)
+        assert summary.as_dict().get("affected", {}).get("journals") == TEST_JOURNAL_COUNT, summary.as_dict()
 
-        r = journal_manage({"query": {"terms": {"_id": [j.id for j in self.journals]}}}, note="Test note", dry_run=False)
-        assert r == TEST_JOURNAL_COUNT, r
+        summary = journal_manage({"query": {"terms": {"_id": [j.id for j in self.journals]}}}, note="Test note", dry_run=False)
+        assert summary.as_dict().get("affected", {}).get("journals") == TEST_JOURNAL_COUNT, summary.as_dict()
 
         sleep(1)
 

--- a/doajtest/unit/test_task_suggestion_bulkedit.py
+++ b/doajtest/unit/test_task_suggestion_bulkedit.py
@@ -45,11 +45,11 @@ class TestTaskSuggestionBulkEdit(DoajTestCase):
         new_eg = EditorGroupFixtureFactory.setup_editor_group_with_editors(group_name='Test Editor Group')
 
         # test dry run
-        r = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, editor_group=new_eg.name, dry_run=True)
-        assert r == TEST_SUGGESTION_COUNT, r
+        summary = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, editor_group=new_eg.name, dry_run=True)
+        assert summary.as_dict().get("affected", {}).get("applications") == TEST_SUGGESTION_COUNT, summary.as_dict()
 
-        r = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, editor_group=new_eg.name, dry_run=False)
-        assert r == TEST_SUGGESTION_COUNT, r
+        summary = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, editor_group=new_eg.name, dry_run=False)
+        assert summary.as_dict().get("affected", {}).get("applications") == TEST_SUGGESTION_COUNT, summary.as_dict()
 
         sleep(1)
 
@@ -66,11 +66,11 @@ class TestTaskSuggestionBulkEdit(DoajTestCase):
 
     def test_02_note_successful_add(self):
         # test dry run
-        r = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, note="Test note", dry_run=True)
-        assert r == TEST_SUGGESTION_COUNT, r
+        summary = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, note="Test note", dry_run=True)
+        assert summary.as_dict().get("affected", {}).get("applications") == TEST_SUGGESTION_COUNT, summary.as_dict()
 
-        r = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, note="Test note", dry_run=False)
-        assert r == TEST_SUGGESTION_COUNT, r
+        summary = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, note="Test note", dry_run=False)
+        assert summary.as_dict().get("affected", {}).get("applications") == TEST_SUGGESTION_COUNT, summary.as_dict()
 
         sleep(1)
 
@@ -153,11 +153,11 @@ class TestTaskSuggestionBulkEdit(DoajTestCase):
         """Bulk set an application status on a bunch of suggestions using a background task"""
         expected_app_status = 'on hold'
         # test dry run
-        r = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=True)
-        assert r == TEST_SUGGESTION_COUNT, r
+        summary = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=True)
+        assert summary.as_dict().get("affected", {}).get("applications") == TEST_SUGGESTION_COUNT, summary.as_dict()
 
-        r = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=False)
-        assert r == TEST_SUGGESTION_COUNT, r
+        summary = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=False)
+        assert summary.as_dict().get("affected", {}).get("applications") == TEST_SUGGESTION_COUNT, summary.as_dict()
 
         sleep(1)
 
@@ -176,11 +176,11 @@ class TestTaskSuggestionBulkEdit(DoajTestCase):
         """Bulk set an application status on a bunch of suggestions using a background task"""
         expected_app_status = 'lalala'
         # test dry run
-        r = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=True)
-        assert r == TEST_SUGGESTION_COUNT, r
+        summary = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=True)
+        assert summary.as_dict().get("affected", {}).get("applications") == TEST_SUGGESTION_COUNT, summary.as_dict()
 
-        r = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=False)
-        assert r == TEST_SUGGESTION_COUNT, r
+        summary = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=False)
+        assert summary.as_dict().get("affected", {}).get("applications") == TEST_SUGGESTION_COUNT, summary.as_dict()
 
         sleep(1)
 
@@ -213,11 +213,11 @@ class TestTaskSuggestionBulkEdit(DoajTestCase):
         self.suggestions[-1].save(blocking=True)
 
         # test dry run
-        r = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=True)
-        assert r == TEST_SUGGESTION_COUNT, r
+        summary = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=True)
+        assert summary.as_dict().get("affected", {}).get("applications") == TEST_SUGGESTION_COUNT, summary.as_dict()
 
-        r = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=False)
-        assert r == TEST_SUGGESTION_COUNT, r
+        summary = suggestion_manage({"query": {"terms": {"_id": [s.id for s in self.suggestions]}}}, application_status=expected_app_status, dry_run=False)
+        assert summary.as_dict().get("affected", {}).get("applications") == TEST_SUGGESTION_COUNT, summary.as_dict()
 
         sleep(1)
 

--- a/portality/authorise.py
+++ b/portality/authorise.py
@@ -3,8 +3,12 @@ from portality.core import app
 class Authorise(object):
     @classmethod
     def has_role(cls, role, reference):
+        ultra = False
+        if role.startswith("ultra_"):
+            ultra = True
+
         # if we are the super user we can do anything
-        if app.config["SUPER_USER_ROLE"] in reference:
+        if app.config["SUPER_USER_ROLE"] in reference and not ultra:
             return True
         
         # if the user's role list contains the role explicitly then do it

--- a/portality/background.py
+++ b/portality/background.py
@@ -12,6 +12,17 @@ class BackgroundException(Exception):
 class RetryException(Exception):
     pass
 
+class BackgroundSummary(object):
+    def __init__(self, job_id, affected=None):
+        self.job_id = job_id
+        self.affected = affected if affected is not None else {}
+
+    def as_dict(self):
+        return {
+            "job_id" : self.job_id,
+            "affected" : self.affected
+        }
+
 class BackgroundApi(object):
 
     @classmethod

--- a/portality/background.py
+++ b/portality/background.py
@@ -1,7 +1,8 @@
 from flask_login import login_user
 
 from portality.core import app
-from portality import models
+from portality import models, app_email
+from portality.dao import Facetview2
 
 import traceback
 
@@ -29,6 +30,7 @@ class BackgroundApi(object):
     def execute(self, background_task):
         job = background_task.background_job
         ctx = None
+        acc = None
         if job.user is not None:
             ctx = app.test_request_context("/")
             ctx.push()
@@ -67,6 +69,28 @@ class BackgroundApi(object):
         if not job.is_failed():
             job.success()
         job.save()
+
+        # send a confirmation email to the user if the account exists
+        if acc is not None:
+            if acc.email is not None:
+                template = "email/admin_background_job_finished.txt"
+                subject = app.config.get("SERVICE_NAME", "") + " - background job finished"
+
+                url_root = app.config.get("BASE_URL")
+                to = [acc.email]
+                fro = app.config.get('SYSTEM_EMAIL_FROM', 'feedback@doaj.org')
+                query = Facetview2.make_query(job.id)
+                url = url_root + "admin/background_jobs?source=" + Facetview2.url_encode_query(query)
+
+                app_email.send_mail(to=to,
+                                    fro=fro,
+                                    subject=subject,
+                                    template_name=template,
+                                    job_id=job.id,
+                                    action=job.action,
+                                    status=job.status,
+                                    background_job_url=url
+                                    )
 
         if ctx is not None:
             ctx.pop()

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -145,7 +145,7 @@ TICK_THRESHOLD = '2014-03-19T00:00:00Z'
 SUPER_USER_ROLE = "admin"
 
 #"api" top-level role is added to all acounts on creation; it can be revoked per account by removal of the role.
-TOP_LEVEL_ROLES = ["admin", "publisher", "editor", "associate_editor", "api"]
+TOP_LEVEL_ROLES = ["admin", "publisher", "editor", "associate_editor", "api", "ultra_bulk_delete"]
 
 ROLE_MAP = {
     "editor": [

--- a/portality/static/doaj/js/available_facetviews/admin.applications.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.applications.facetview.js
@@ -95,8 +95,8 @@ jQuery(document).ready(function($) {
     function bulk_action_success_callback(data) {
         var msg = "Your bulk edit request has been submitted and queued for execution.<br>";
         msg += build_affected_msg(data) + " have been queued for edit.<br>";
-        msg += 'You can see your request <a href="' + bulk_job_url(data) + '" target="_blank">here</a> in the background jobs interface (opens new window).<br>';
-        msg += "You will get an email when your request has been processed; this could take anything from a few minutes to a few hours<br>";
+        msg += 'You can see your request <a href="' + bulk_job_url(data) + '" target="_blank">here</a> in the background jobs interface (opens new tab).<br>';
+        msg += "You will get an email when your request has been processed; this could take anything from a few minutes to a few hours.<br>";
         msg += '<a href="#" id="bulk-action-feedback-dismiss">dismiss</a>';
 
         $(".bulk-action-feedback").html(msg).show();

--- a/portality/static/doaj/js/available_facetviews/admin.applications.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.applications.facetview.js
@@ -1,5 +1,6 @@
 jQuery(document).ready(function($) {
 
+    /*
     function adminButtons(options, context) {
         // Disable the bulk action submit button if there is an empty query in the facetview
         if ($.isEmptyObject(options.active_filters) && options.q == "") {
@@ -8,17 +9,222 @@ jQuery(document).ready(function($) {
             $("#bulk-submit").removeAttr("disabled");
         }
     }
+    */
+
+    ////////////////////////////////////////////////////////////
+    // functions for handling the bulk form
+
+    autocomplete('#editor_group', 'name', 'editor_group', 1, false);
+
+    toggle_optional_field('bulk_action', ['#editor_group'], ['assign_editor_group']);
+    toggle_optional_field('bulk_action', ['#application_status'], ['change_status']);
+    toggle_optional_field('bulk_action', ['#note'], ['add_note']);
+
+    function disable_bulk_submit() {
+        $('#bulk-submit').attr('disabled', 'disabled').html("Submit");
+    }
+
+    function enable_bulk_submit() {
+        $('#bulk-submit').removeAttr('disabled').html("Submit");
+    }
+
+    function bulk_ui_reset() {
+        disable_bulk_submit();
+        $("#bulk_action").val("");
+        $("#editor_group-container").hide();
+        $("#note-container").hide();
+        $("#application_status-container").hide();
+    }
+
+    function bulk_action_controls(options) {
+        var action = $('#bulk_action').val();
+        if (action === "") {
+            disable_bulk_submit();
+            return;
+        }
+
+        var requiresAdditional = ["assign_editor_group", "add_note", "change_status"];
+        var additional = {
+            assign_editor_group : "#editor_group",
+            add_note : "#note",
+            change_status: "#application_status"
+        };
+
+        // work out whether we enable submit
+        var enable = true;
+
+        if ($.inArray(action, requiresAdditional) > -1) {
+            var additionalVal = $(additional[action]).val();
+            if (additionalVal === "") {
+                enable = false;
+            }
+        }
+
+        if (enable) {
+            enable_bulk_submit();
+        } else {
+            disable_bulk_submit();
+        }
+    }
+
+    function get_bulk_action() {
+        var action = $('#bulk_action').val();
+        if (!action) {
+            alert('Error: unknown bulk operation.');
+            throw 'Error: unknown bulk operation. The bulk action field was empty.'
+        }
+        return action
+    }
+
+    function bulk_action_url(options) {
+        return '/admin/applications/bulk/' + get_bulk_action()
+    }
+
+    function build_affected_msg(data) {
+        var mfrg = "";
+        if (data.affected) {
+            if ("applications" in data.affected) {
+                mfrg += data.affected.applications + " applications";
+            } else {
+                mfrg = "an unknown number of records";
+            }
+        }
+        return mfrg;
+    }
+
+    function bulk_action_success_callback(data) {
+        var msg = "Your bulk edit request has been submitted and queued for execution.<br>";
+        msg += build_affected_msg(data) + " have been queued for edit.<br>";
+        msg += 'You can see your request <a href="' + bulk_job_url(data) + '" target="_blank">here</a> in the background jobs interface (opens new window).<br>';
+        msg += "You will get an email when your request has been processed; this could take anything from a few minutes to a few hours<br>";
+        msg += '<a href="#" id="bulk-action-feedback-dismiss">dismiss</a>';
+
+        $(".bulk-action-feedback").html(msg).show();
+        $("#bulk-action-feedback-dismiss").unbind("click").bind("click", function(event) {
+            event.preventDefault();
+            $(".bulk-action-feedback").html("").hide();
+        });
+
+        bulk_ui_reset();
+    }
+
+    function bulk_action_error_callback(jqXHR, textStatus, errorThrown) {
+        alert('There was an error with your request.');
+        console.error(textStatus + ': ' + errorThrown);
+        bulk_ui_reset();
+    }
+
+    function bulk_action_confirm_closure(options, query) {
+        var bulk_action_confirm_callback = function(data) {
+            var sure = confirm('This operation will affect ' + build_affected_msg(data) + '.');
+            if (sure) {
+                var action = get_bulk_action();
+                var send = {
+                    selection_query: query,
+                    dry_run: false
+                };
+                if (action === "add_note") {
+                    send["note"] = $('#note').val();
+                } else if (action === "assign_editor_group") {
+                    send["editor_group"] = $('#editor_group').val();
+                } else if (action === "change_status") {
+                    send["application_status"] = $("#application_status").val();
+                }
+                $.ajax({
+                    type: 'POST',
+                    url: bulk_action_url(options),
+                    data: JSON.stringify(send),
+                    contentType : 'application/json',
+                    success : bulk_action_success_callback,
+                    error: bulk_action_error_callback
+                });
+            } else {
+                bulk_ui_reset();
+            }
+        };
+
+        return bulk_action_confirm_callback
+    }
+
+    function bulk_job_url(data) {
+        var url = "/admin/background_jobs?source=%7B%22query%22%3A%7B%22query_string%22%3A%7B%22query%22%3A%22" + data.job_id + "%22%2C%22default_operator%22%3A%22AND%22%7D%7D%2C%22sort%22%3A%5B%7B%22created_date%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%2C%22from%22%3A0%2C%22size%22%3A25%7D";
+        return url;
+    }
+
+    ////////////////////////////////////////////////////////
+
 
 
     function adminJAPostRender(options, context) {
         doajJAPostRender(options, context);
 
-        var query = elasticSearchQuery({
-            options: options,
-            include_facets: false,
-            include_fields: false
+        $('#bulk_action').change(function () {
+            bulk_action_controls(options);
         });
 
+        $("#editor_group").change(function() {
+            if ($(this).val() === "") {
+                disable_bulk_submit();
+            } else {
+                enable_bulk_submit();
+            }
+        });
+
+        $("#application_status").change(function() {
+            if ($(this).val() === "") {
+                disable_bulk_submit();
+            } else {
+                enable_bulk_submit();
+            }
+        });
+
+        $("#note").keyup(function() {
+            if ($(this).val() === "") {
+                disable_bulk_submit();
+            } else {
+                enable_bulk_submit();
+            }
+        });
+
+        $('#bulk-submit').unbind('click').bind('click', function(event) {
+            event.preventDefault();
+
+            $('#bulk-submit').attr('disabled', 'disabled').html("<img src='/static/doaj/images/white-transparent-loader.gif'>&nbsp;Submitting...");
+
+            var sure;
+            if ($('#bulk_action').val() == 'delete') {
+                sure = confirm('Are you sure?  This operation cannot be undone!');
+            } else {
+                sure = true;
+            }
+
+            if (sure) {
+                var query = elasticSearchQuery({
+                    options: options,
+                    include_facets: false,
+                    include_fields: false
+                });
+
+                $.ajax({
+                    type: 'POST',
+                    url: bulk_action_url(options),
+                    data: JSON.stringify({
+                        selection_query: query,
+                        editor_group: $('#editor_group').val(),
+                        note: $('#note').val(),
+                        application_status: $("#application_status").val(),
+                        dry_run: true
+                    }),
+                    contentType : 'application/json',
+                    success : bulk_action_confirm_closure(options, query),
+                    error: bulk_action_error_callback
+                });
+            } else {
+                bulk_ui_reset();
+            }
+        });
+
+        /*
         ////////////////////////////////////////////////////////////
         // functions for handling the bulk form
 
@@ -88,6 +294,7 @@ jQuery(document).ready(function($) {
                 error: application_error_callback
             });
         });
+        */
     }
 
     $('.facetview.suggestions').facetview({
@@ -96,7 +303,7 @@ jQuery(document).ready(function($) {
         render_results_metadata: doajPager,
         render_active_terms_filter: doajRenderActiveTermsFilter,
         post_render_callback: adminJAPostRender,
-        post_search_callback: adminButtons,
+        post_search_callback: bulk_action_controls,
 
         sharesave_link: false,
         freetext_submit_delay: 1000,

--- a/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
@@ -83,11 +83,13 @@ jQuery(document).ready(function($) {
             var mfrg = "";
             if (data.affected) {
                 if ("journals" in data.affected && "articles" in data.affected) {
-                    mfrg += data.affected.journals + " journals and " + data.affected.articles + " articles"
+                    mfrg += data.affected.journals + " journals and " + data.affected.articles + " articles";
                 } else if ("journals" in data.affected) {
-                    mfrg = data.affected.journals + " journals"
+                    mfrg = data.affected.journals + " journals";
+                } else if ("articles" in data.affected) {
+                    mfrg = data.affected.articles + " articles";
                 } else {
-                    mfrg = "an unknown number of records"
+                    mfrg = "an unknown number of records";
                 }
             }
             return mfrg;

--- a/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
@@ -128,8 +128,8 @@ jQuery(document).ready(function($) {
     function bulk_action_success_callback(data) {
         var msg = "Your bulk edit request has been submitted and queued for execution.<br>";
         msg += build_affected_msg(data) + " have been queued for edit.<br>";
-        msg += 'You can see your request <a href="' + bulk_job_url(data) + '" target="_blank">here</a> in the background jobs interface (opens new window).<br>';
-        msg += "You will get an email when your request has been processed; this could take anything from a few minutes to a few hours<br>";
+        msg += 'You can see your request <a href="' + bulk_job_url(data) + '" target="_blank">here</a> in the background jobs interface (opens new tab).<br>';
+        msg += "You will get an email when your request has been processed; this could take anything from a few minutes to a few hours.<br>";
         msg += '<a href="#" id="bulk-action-feedback-dismiss">dismiss</a>';
 
         $(".bulk-action-feedback").html(msg).show();

--- a/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
@@ -1,166 +1,211 @@
 jQuery(document).ready(function($) {
 
+    ////////////////////////////////////////////////////////////
+    // functions for handling the bulk form
+
+    autocomplete('#editor_group', 'name', 'editor_group', 1, false);
+
+    toggle_optional_field('bulk_action', ['#editor_group'], ['assign_editor_group']);
+    toggle_optional_field('bulk_action', ['#note'], ['add_note']);
+
     function disable_bulk_submit() {
-        $('#bulk-submit').attr('disabled', 'disabled');
-        $('#bulk_delete_note-container').show();
+        $('#bulk-submit').attr('disabled', 'disabled').html("Submit");
     }
 
     function enable_bulk_submit() {
-        $('#bulk-submit').removeAttr('disabled');
-        $('#bulk_delete_note-container').hide();
+        $('#bulk-submit').removeAttr('disabled').html("Submit");
+    }
+
+    function bulk_ui_reset() {
+        disable_bulk_submit();
+        $("#bulk_action").val("");
+        $("#editor_group-container").hide();
+        $("#note-container").hide();
+        $("#journal_type_note").hide();
+        $("#any_type_note").hide();
     }
 
     function bulk_action_controls(options) {
-        // When deleting, enable/disable the bulk action submit button
-        // To enable: the _type facet must be selected AND
-        // - EITHER another facet must be selected as well
-        // - OR a free text query must have been entered
-        // Otherwise, disable.
-        if ($('#bulk_action').val() === 'delete') {
-            if ($.isEmptyObject(options.active_filters._type)) {
-                disable_bulk_submit();
-            } else {
-                if (options.q == '') {
-                    disable_bulk_submit();
-                } else {
-                    enable_bulk_submit();
-                }
-            }
-        } else {
-            enable_bulk_submit();
+        var action = $('#bulk_action').val();
+        if (action === "") {
+            $("#journal_type_note").hide();
+            $("#any_type_note").hide();
+            disable_bulk_submit();
+            return;
+        }
+        var type = options.active_filters._type;
+        if (type && type.length > 0) {
+            type = type[0];
         }
 
-        // todo selecting _type and another facet does not enable the button, you HAVE to type in a query. Should I actually keep this behaviour? (if so clarify the code)
+        // all the things we need to know to validate and determine whether to allow submit
+        var requireJournalType = ["withdraw", "reinstate", "assign_editor_group", "add_note"];
+        var requireAnyType = ["delete"];
+        var requiresAdditional = ["assign_editor_group", "add_note"];
+        var additional = {
+            assign_editor_group : "#editor_group",
+            add_note : "#note"
+        };
+
+        // work out whether we enable submit
+        var enable = true;
+
+        if ($.inArray(action, requireJournalType) > -1) {
+            if (type !== "journal") {
+                $("#journal_type_note").show();
+                enable = false;
+            } else {
+                $("#journal_type_note").hide();
+            }
+        }
+
+        if ($.inArray(action, requireAnyType) > -1) {
+            if (type && type !== "") {
+                $("#any_type_note").hide();
+            } else {
+                $("#any_type_note").show();
+                enable = false;
+            }
+        }
+
+        if ($.inArray(action, requiresAdditional) > -1) {
+            var additionalVal = $(additional[action]).val();
+            if (additionalVal === "") {
+                enable = false;
+            }
+        }
+
+        if (enable) {
+            enable_bulk_submit();
+        } else {
+            disable_bulk_submit();
+        }
     }
 
-    function adminJAPostRender(options, context) {
-        doajJAPostRender(options, context);
+    function get_bulk_action() {
+        var action = $('#bulk_action').val();
+        if (!action) {
+            alert('Error: unknown bulk operation.');
+            throw 'Error: unknown bulk operation. The bulk action field was empty.'
+        }
+        return action
+    }
 
-        var query = elasticSearchQuery({
-            options: options,
-            include_facets: false,
-            include_fields: false
+    function bulk_action_type(options) {
+        if (get_bulk_action() == 'delete') {
+            if (! $.isEmptyObject(options.active_filters._type)) {
+                if (options.active_filters._type.length != 1) {
+                    alert('Error: type facet has multiple options selected.');
+                    throw 'Error: type facet has multiple options selected.'
+                }
+                if (options.active_filters._type[0] === 'journal') { return 'journals'; }
+                if (options.active_filters._type[0] === 'article') { return 'articles'; }
+            }
+        }
+        return 'journals';
+    }
+
+    function bulk_action_url(options) {
+        return '/admin/' + bulk_action_type(options) + '/bulk/' + get_bulk_action()
+    }
+
+    function build_affected_msg(data) {
+        var mfrg = "";
+        if (data.affected) {
+            if ("journals" in data.affected && "articles" in data.affected) {
+                mfrg += data.affected.journals + " journals and " + data.affected.articles + " articles";
+            } else if ("journals" in data.affected) {
+                mfrg = data.affected.journals + " journals";
+            } else if ("articles" in data.affected) {
+                mfrg = data.affected.articles + " articles";
+            } else {
+                mfrg = "an unknown number of records";
+            }
+        }
+        return mfrg;
+    }
+
+    function bulk_action_success_callback(data) {
+        var msg = "Your bulk edit request has been submitted and queued for execution.<br>";
+        msg += build_affected_msg(data) + " have been queued for edit.<br>";
+        msg += 'You can see your request <a href="' + bulk_job_url(data) + '" target="_blank">here</a> in the background jobs interface (opens new window).<br>';
+        msg += "You will get an email when your request has been processed; this could take anything from a few minutes to a few hours<br>";
+        msg += '<a href="#" id="bulk-action-feedback-dismiss">dismiss</a>';
+
+        $(".bulk-action-feedback").html(msg).show();
+        $("#bulk-action-feedback-dismiss").unbind("click").bind("click", function(event) {
+            event.preventDefault();
+            $(".bulk-action-feedback").html("").hide();
         });
 
-        ////////////////////////////////////////////////////////////
-        // functions for handling the bulk form
+        bulk_ui_reset();
+    }
 
-        function bulk_action_selected_handler() {
-            $('#bulk_action').change(function () {
-                bulk_action_controls(options);
-            });
-        }
-        bulk_action_selected_handler();
+    function bulk_action_error_callback(jqXHR, textStatus, errorThrown) {
+        alert('There was an error with your request.');
+        console.error(textStatus + ': ' + errorThrown);
+        bulk_ui_reset();
+    }
 
-        function get_bulk_action() {
-            var action = $('#bulk_action').val();
-            if (!action) {
-                alert('Error: unknown bulk operation.');
-                throw 'Error: unknown bulk operation. The bulk action field was empty.'
-            }
-            return action
-        }
-
-        function bulk_action_type() {
-            if (get_bulk_action() == 'delete') {
-                if (! $.isEmptyObject(options.active_filters._type)) {
-                    if (options.active_filters._type.length != 1) {
-                        alert('Error: type facet has multiple options selected.');
-                        throw 'Error: type facet has multiple options selected.'
-                    }
-                    if (options.active_filters._type[0] === 'journal') { return 'journals'; }
-                    if (options.active_filters._type[0] === 'article') { return 'articles'; }
-                }
-            }
-            return 'journals';
-        }
-
-        function bulk_action_url() {
-            return '/admin/' + bulk_action_type() + '/bulk/' + get_bulk_action()
-        }
-
-        function build_affected_msg(data) {
-            var mfrg = "";
-            if (data.affected) {
-                if ("journals" in data.affected && "articles" in data.affected) {
-                    mfrg += data.affected.journals + " journals and " + data.affected.articles + " articles";
-                } else if ("journals" in data.affected) {
-                    mfrg = data.affected.journals + " journals";
-                } else if ("articles" in data.affected) {
-                    mfrg = data.affected.articles + " articles";
-                } else {
-                    mfrg = "an unknown number of records";
-                }
-            }
-            return mfrg;
-            /*
-            var mfrg = undefined;
-            if (data.affected_journals && data.affected_articles) {
-                mfrg = data.affected_journals + " journals and " + data.affected_articles + " articles"
-            }
-            else if (data.affected_journals) {
-                mfrg = data.affected_journals + " journals"
-            }
-            else if (data.affected_articles) {
-                mfrg = data.affected_articles + " articles"
-            }
-            else {
-                mfrg = "an unknown number of records"
-            }
-            return mfrg
-            */
-        }
-
-        function bulk_action_success_callback(data) {
-            var msg = "Your bulk edit request has been submitted and queued for execution.<br>";
-            msg += build_affected_msg(data) + " have been queued for edit.<br>";
-            msg += 'You can see your request <a href="' + bulk_job_url(data) + '" target="_blank">here</a> in the background jobs interface (opens new window).<br>';
-            msg += "You will get an email when your request has been processed; this could take anything from a few minutes to a few hours<br>";
-            msg += '<a href="#" id="bulk-action-feedback-dismiss">dismiss</a>';
-
-            $(".bulk-action-feedback").html(msg).show();
-            $('#bulk-submit').removeAttr('disabled').html('Submit');
-            $("#bulk-action-feedback-dismiss").unbind("click").bind("click", function(event) {
-                event.preventDefault();
-                $(".bulk-action-feedback").html("").hide();
-            });
-
-            $("#bulk_action").val("");
-        }
-
-        function bulk_action_error_callback(jqXHR, textStatus, errorThrown) {
-            alert('There was an error with your request.');
-            console.error(textStatus + ': ' + errorThrown);
-            $('#bulk-submit').removeAttr('disabled').html('Submit');
-            $("#bulk_action").val("");
-        }
-
-        function bulk_action_confirm_callback(data) {
+    function bulk_action_confirm_closure(options, query) {
+        var bulk_action_confirm_callback = function(data) {
             var sure = confirm('This operation will affect ' + build_affected_msg(data) + '.');
             if (sure) {
+                var action = get_bulk_action();
+                var send = {
+                    selection_query: query,
+                    dry_run: false
+                };
+                if (action === "add_note") {
+                    send["note"] = $('#note').val();
+                } else if (action === "assign_editor_group") {
+                    send["editor_group"] = $('#editor_group').val();
+                }
                 $.ajax({
                     type: 'POST',
-                    url: bulk_action_url(),
-                    data: JSON.stringify({
-                        selection_query: query,
-                        editor_group: $('#editor_group').val(),
-                        note: $('#note').val(),
-                        dry_run: false
-                    }),
+                    url: bulk_action_url(options),
+                    data: JSON.stringify(send),
                     contentType : 'application/json',
                     success : bulk_action_success_callback,
                     error: bulk_action_error_callback
                 });
             } else {
-                $('#bulk-submit').removeAttr('disabled').html('Submit');
-                $("#bulk_action").val("");
+                bulk_ui_reset();
             }
-        }
+        };
 
-        function bulk_job_url(data) {
-            var url = "/admin/background_jobs?source=%7B%22query%22%3A%7B%22query_string%22%3A%7B%22query%22%3A%22" + data.job_id + "%22%2C%22default_operator%22%3A%22AND%22%7D%7D%2C%22sort%22%3A%5B%7B%22created_date%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%2C%22from%22%3A0%2C%22size%22%3A25%7D";
-            return url;
-        }
+        return bulk_action_confirm_callback
+    }
+    
+    function bulk_job_url(data) {
+        var url = "/admin/background_jobs?source=%7B%22query%22%3A%7B%22query_string%22%3A%7B%22query%22%3A%22" + data.job_id + "%22%2C%22default_operator%22%3A%22AND%22%7D%7D%2C%22sort%22%3A%5B%7B%22created_date%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%2C%22from%22%3A0%2C%22size%22%3A25%7D";
+        return url;
+    }
+
+    ////////////////////////////////////////////////////////
+
+    function adminJAPostRender(options, context) {
+        doajJAPostRender(options, context);
+
+        $('#bulk_action').change(function () {
+            bulk_action_controls(options);
+        });
+
+        $("#editor_group").change(function() {
+            if ($(this).val() === "") {
+                disable_bulk_submit();
+            } else {
+                enable_bulk_submit();
+            }
+        });
+
+        $("#note").keyup(function() {
+            if ($(this).val() === "") {
+                disable_bulk_submit();
+            } else {
+                enable_bulk_submit();
+            }
+        });
 
         $('#bulk-submit').unbind('click').bind('click', function(event) {
             event.preventDefault();
@@ -175,9 +220,15 @@ jQuery(document).ready(function($) {
             }
 
             if (sure) {
+                var query = elasticSearchQuery({
+                    options: options,
+                    include_facets: false,
+                    include_fields: false
+                });
+
                 $.ajax({
                     type: 'POST',
-                    url: bulk_action_url(),
+                    url: bulk_action_url(options),
                     data: JSON.stringify({
                         selection_query: query,
                         editor_group: $('#editor_group').val(),
@@ -185,11 +236,11 @@ jQuery(document).ready(function($) {
                         dry_run: true
                     }),
                     contentType : 'application/json',
-                    success : bulk_action_confirm_callback,
+                    success : bulk_action_confirm_closure(options, query),
                     error: bulk_action_error_callback
                 });
             } else {
-                $('#bulk-submit').removeAttr('disabled').html('Submit');
+                bulk_ui_reset();
             }
         });
     }

--- a/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
+++ b/portality/static/doaj/js/available_facetviews/admin.journalarticle.facetview.js
@@ -176,7 +176,7 @@ jQuery(document).ready(function($) {
 
         return bulk_action_confirm_callback
     }
-    
+
     function bulk_job_url(data) {
         var url = "/admin/background_jobs?source=%7B%22query%22%3A%7B%22query_string%22%3A%7B%22query%22%3A%22" + data.job_id + "%22%2C%22default_operator%22%3A%22AND%22%7D%7D%2C%22sort%22%3A%5B%7B%22created_date%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%2C%22from%22%3A0%2C%22size%22%3A25%7D";
         return url;

--- a/portality/tasks/journal_bulk_edit.py
+++ b/portality/tasks/journal_bulk_edit.py
@@ -11,7 +11,7 @@ from portality.formcontext import formcontext
 from portality.tasks.redis_huey import main_queue
 from portality.decorators import write_required
 
-from portality.background import AdminBackgroundTask, BackgroundApi, BackgroundException
+from portality.background import AdminBackgroundTask, BackgroundApi, BackgroundException, BackgroundSummary
 
 
 def journal_manage(selection_query, dry_run=True, editor_group='', note=''):
@@ -19,7 +19,7 @@ def journal_manage(selection_query, dry_run=True, editor_group='', note=''):
     ids = JournalBulkEditBackgroundTask.resolve_selection_query(selection_query)
     if dry_run:
         JournalBulkEditBackgroundTask.check_admin_privilege(current_user.id)
-        return len(ids)
+        return BackgroundSummary(None, affected={"journals" : len(ids)})
 
     job = JournalBulkEditBackgroundTask.prepare(
         current_user.id,
@@ -30,7 +30,11 @@ def journal_manage(selection_query, dry_run=True, editor_group='', note=''):
     )
     JournalBulkEditBackgroundTask.submit(job)
 
-    return len(ids)
+    affected = len(ids)
+    job_id = None
+    if job is not None:
+        job_id = job.id
+    return BackgroundSummary(job_id, affected={"journals" : affected})
 
 
 class JournalBulkEditBackgroundTask(AdminBackgroundTask):

--- a/portality/templates/admin/admin_site_search.html
+++ b/portality/templates/admin/admin_site_search.html
@@ -1,6 +1,9 @@
 {% extends "admin/admin_base.html" %}
 
 {% block admin_content %}
+
+<div class="bulk-action-feedback alert alert-success" style="display: none"></div>
+
 <div style="padding-bottom: 20px">
     <div class="row-fluid">
         <div class="span12">

--- a/portality/templates/admin/admin_site_search.html
+++ b/portality/templates/admin/admin_site_search.html
@@ -17,9 +17,12 @@
                                     <option selected value="">Select action...</option>
                                     <option value="withdraw">Withdraw from DOAJ</option>
                                     <option value="reinstate">Reinstate into DOAJ</option>
-                                    <option value="delete">Delete records</option>
                                     <option value="assign_editor_group">Journal: Assign to editor group...</option>
                                     <option value="add_note">Journal: Add a note...</option>
+
+                                    {%  if current_user.has_role("ultra_bulk_delete") %}
+                                    <option value="delete">Delete records</option>
+                                    {%  endif %}
                                 </select>
                             </div>
                         </div>

--- a/portality/templates/admin/admin_site_search.html
+++ b/portality/templates/admin/admin_site_search.html
@@ -39,9 +39,10 @@
                                 </button>
                             </div>
                         </div>
-                        <div class="control-group" style="display: none; max-width: 18em;" id="bulk_delete_note-container">
+                        <div class="control-group" style="max-width: 18em;" id="bulk_help-container">
                             <div class="controls">
-                                <p id="bulk_delete_note" class="red">You need to select an option in the "Journals vs. Articles facet" <strong>and also</strong> enter a search term to filter the journals or articles for deletion.</p>
+                                <p id="any_type_note" class="red" style="display: none">You need to select an option in the "Journals vs. Articles facet" to use this option</p>
+                                <p id="journal_type_note" class="red" style="display:none">You need to select "Journal" from the "Journals vs. Articles facet" to use this option</p>
                             </div>
                         </div>
                     </fieldset>
@@ -59,11 +60,6 @@
 
 <script type="text/javascript">
     var journal_edit_url = "{{ url_for('admin.journal_page', journal_id='') }}";
-    autocomplete('#editor_group', 'name', 'editor_group', 1, false);
-
-    toggle_optional_field('bulk_action', ['#editor_group'], ['assign_editor_group']);
-    toggle_optional_field('bulk_action', ['#bulk_delete_note'], ['delete']);
-    toggle_optional_field('bulk_action', ['#note'], ['add_note']);
 </script>
 
 {% endblock %}

--- a/portality/templates/admin/suggestions.html
+++ b/portality/templates/admin/suggestions.html
@@ -2,6 +2,8 @@
 
 {% block admin_content %}
 
+<div class="bulk-action-feedback alert alert-success" style="display: none"></div>
+
 <div style="padding-bottom: 20px">
     <div class="row-fluid">
         <div class="span12">
@@ -11,8 +13,8 @@
                     <fieldset>
                         <div class="control-group" id="bulk_action-container">
                             <div class="controls ">
-                                <select class="" id="bulk_action" name="bulk_action" style="width: 250px;">
-                                    <option selected="" value="">Select action...</option>
+                                <select id="bulk_action" name="bulk_action" style="width: 250px;">
+                                    <option selected value="">Select action...</option>
                                     <option value="change_status">Change status...</option>
                                     <option value="assign_editor_group">Assign to editor group...</option>
                                     <option value="add_note">Add a note...</option>
@@ -36,12 +38,12 @@
                             </div>
                         </div>
                         <div class="control-group" style="display: none" id="editor_group-container">
-                            <div class="controls ">
-                                <input id="editor_group" name="editor_group" style="width: 250px" type="text" value="">
+                            <div class="controls">
+                                <input id="editor_group" name="editor_group" style="width: 250px;" type="text" value="">
                             </div>
                         </div>
                         <div class="control-group" style="display: none" id="note-container">
-                            <div class="controls ">
+                            <div class="controls">
                                 <textarea id="note" name="note" style="width: 240px;" placeholder="Type note here..."></textarea>
                             </div>
                         </div>
@@ -64,10 +66,5 @@
 {% block extra_js_bottom %}
 <script type="text/javascript">
     var suggestion_edit_url = "{{ url_for('admin.suggestion_page', suggestion_id="") }}";
-    autocomplete('#editor_group', 'name', 'editor_group', 1, false);
-
-    toggle_optional_field('bulk_action', ['#editor_group'], ['assign_editor_group']);
-    toggle_optional_field('bulk_action', ['#application_status'], ['change_status']);
-    toggle_optional_field('bulk_action', ['#note'], ['add_note']);
 </script>
 {% endblock %}

--- a/portality/templates/email/admin_background_job_finished.txt
+++ b/portality/templates/email/admin_background_job_finished.txt
@@ -1,0 +1,6 @@
+Your background job {{job_id}} for "{{action}}" has completed with status "{{status}}"
+
+You can see the record of your job and its status in the background jobs interface here:
+
+{{background_job_url}}
+

--- a/portality/templates/formcontext/maned_journal_review.html
+++ b/portality/templates/formcontext/maned_journal_review.html
@@ -12,8 +12,8 @@
     <div class="span12">
         <div class="alert alert-success">
             Your edit request has been submitted and queued for execution.<br>
-            You can see your request <a href="{{ job_url }}" target="_blank">here</a> in the background jobs interface (opens new window).<br>
-            You will get an email when your request has been processed; this could take anything from a few minutes to a few hours<br>
+            You can see your request <a href="{{ job_url }}" target="_blank">here</a> in the background jobs interface (opens new tab).<br>
+            You will get an email when your request has been processed; this could take anything from a few minutes to a few hours.<br>
         </div>
     </div>
 </div>

--- a/portality/templates/formcontext/maned_journal_review.html
+++ b/portality/templates/formcontext/maned_journal_review.html
@@ -6,20 +6,37 @@
 {% set heading_object_type = 'Journal' %}
 {% include 'formcontext/_lockable_header.html' %}
 
+{%  if job %}
+    {%  set job_url = "/admin/background_jobs?source=%7B%22query%22%3A%7B%22query_string%22%3A%7B%22query%22%3A%22" + job.id + "%22%2C%22default_operator%22%3A%22AND%22%7D%7D%2C%22sort%22%3A%5B%7B%22created_date%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%2C%22from%22%3A0%2C%22size%22%3A25%7D" %}
+<div class="row-fluid">
+    <div class="span12">
+        <div class="alert alert-success">
+            Your edit request has been submitted and queued for execution.<br>
+            You can see your request <a href="{{ job_url }}" target="_blank">here</a> in the background jobs interface (opens new window).<br>
+            You will get an email when your request has been processed; this could take anything from a few minutes to a few hours<br>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <div class="row-fluid">
   <div class="span12 with-borders form-section centre-text-container" style="margin-left: 0; padding: 0.5em 1.5em;">
 
     <div class="row-fluid">
         <div class="span12">
-            <p class="centre-text-container">This button will not save any other changes on this page!</p>
-            {% if form_context.source.is_in_doaj() %}
-              <form method="post" action="{{ url_for('admin.journal_deactivate', journal_id=form_context.source.id) }}" class="form-horizontal" id="journal_deactivate_form">
-                <fieldset><button class="btn btn-danger" type="submit">Take journal out of the DOAJ</button></fieldset>
-              </form>
+            {% if not job %}
+                <p class="centre-text-container">This button will not save any other changes on this page!</p>
+                {% if form_context.source.is_in_doaj() %}
+                  <form method="post" action="{{ url_for('admin.journal_deactivate', journal_id=form_context.source.id) }}" class="form-horizontal" id="journal_deactivate_form">
+                    <fieldset><button class="btn btn-danger" type="submit">Take journal out of the DOAJ</button></fieldset>
+                  </form>
+                {% else %}
+                  <form method="post" action="{{ url_for('admin.journal_activate', journal_id=form_context.source.id) }}" class="form-horizontal" id="journal_activate_form">
+                    <fieldset><button class="btn btn-success" type="submit">Put journal in the DOAJ</button></fieldset>
+                  </form>
+                {% endif %}
             {% else %}
-              <form method="post" action="{{ url_for('admin.journal_activate', journal_id=form_context.source.id) }}" class="form-horizontal" id="journal_activate_form">
-                <fieldset><button class="btn btn-success" type="submit">Put journal in the DOAJ</button></fieldset>
-              </form>
+                You cannot currently withdraw or reinstate the journal, as a background job to do this is currently active
             {% endif %}
         </div>
     </div>

--- a/portality/view/admin.py
+++ b/portality/view/admin.py
@@ -511,19 +511,17 @@ def bulk_add_note(doaj_type):
 @login_required
 @ssl_required
 def applications_bulk_change_status():
-    r = {}
     payload = get_web_json_payload()
     validate_json(payload, fields_must_be_present=['selection_query', 'application_status'], error_to_raise=BulkAdminEndpointException)
 
     q = get_query_from_request(payload)
-
-    r['affected_applications'] = get_bulk_edit_background_task_manager('applications')(
+    summary = get_bulk_edit_background_task_manager('applications')(
         selection_query=q,
         application_status=payload['application_status'],
         dry_run=payload.get('dry_run', True)
     )
 
-    return make_json_resp(r, status_code=200)
+    return make_json_resp(summary.as_dict(), status_code=200)
 
 
 @blueprint.route("/journals/bulk/delete", methods=['POST'])
@@ -545,7 +543,6 @@ def bulk_articles_delete():
     validate_json(payload, fields_must_be_present=['selection_query'], error_to_raise=BulkAdminEndpointException)
 
     q = get_query_from_request(payload)
-
     summary = article_bulk_delete.article_bulk_delete_manage(
         selection_query=q,
         dry_run=payload.get('dry_run', True)

--- a/portality/view/admin.py
+++ b/portality/view/admin.py
@@ -526,6 +526,8 @@ def applications_bulk_change_status():
 
 @blueprint.route("/journals/bulk/delete", methods=['POST'])
 def bulk_journals_delete():
+    if not current_user.has_role("ultra_bulk_delete"):
+        abort(403)
     payload = get_web_json_payload()
     validate_json(payload, fields_must_be_present=['selection_query'], error_to_raise=BulkAdminEndpointException)
 
@@ -539,6 +541,8 @@ def bulk_journals_delete():
 
 @blueprint.route("/articles/bulk/delete", methods=['POST'])
 def bulk_articles_delete():
+    if not current_user.has_role("ultra_bulk_delete"):
+        abort(403)
     payload = get_web_json_payload()
     validate_json(payload, fields_must_be_present=['selection_query'], error_to_raise=BulkAdminEndpointException)
 

--- a/portality/view/admin.py
+++ b/portality/view/admin.py
@@ -208,14 +208,15 @@ def journal_deactivate(journal_id):
 @login_required
 @ssl_required
 def journals_bulk_withdraw():
-    r = {}
     payload = get_web_json_payload()
     validate_json(payload, fields_must_be_present=['selection_query'], error_to_raise=BulkAdminEndpointException)
 
     q = get_query_from_request(payload)
-    r["affected_journals"] = journal_in_out_doaj.change_by_query(q, False, dry_run=payload.get("dry_run", True))
+    summary = journal_in_out_doaj.change_by_query(q, False, dry_run=payload.get("dry_run", True))
+    return make_json_resp(summary.as_dict(), status_code=200)
 
-    return make_json_resp(r, status_code=200)
+    # r["affected_journals"] = journal_in_out_doaj.change_by_query(q, False, dry_run=payload.get("dry_run", True))
+    # return make_json_resp(r, status_code=200)
 
 @blueprint.route("/journals/bulk/reinstate", methods=["POST"])
 @login_required


### PR DESCRIPTION
This PR introduced improved feedback on the request for bulk jobs:

* an html (as opposed to alert box) confirmation, with more text and a link to the background jobs page for the job created
* an email notification to the requesting user, when their job completes

It also refactors the javascript on the bulk edit pages for better stability and input validation.

It also introduces the concept of an "ultra" role, which is a user role that not even admins have unless it is explicitly declared (of course, admins can give themselves this roll at any time, it is just a safety mechanism).  This is then applied to the bulk delete code.  This pertains to #1221 
