### PR TITLE
[hotfix] order S3FS directory creation after ensuring S3FS is mounted

### DIFF
--- a/deploy/deploy-apps.sh
+++ b/deploy/deploy-apps.sh
@@ -9,13 +9,6 @@ mkdir -p /home/cloo/appdata/doaj
 mkdir -p /home/cloo/appdata/doaj/history
 mkdir -p /home/cloo/appdata/doaj/history/article
 mkdir -p /home/cloo/appdata/doaj/history/journal
-mkdir -p /home/cloo/appdata/doaj/s3fs
-mkdir -p /home/cloo/appdata/doaj/s3fs/cache
-mkdir -p /home/cloo/appdata/doaj/s3fs/cache/csv
-mkdir -p /home/cloo/appdata/doaj/s3fs/cache/sitemap
-mkdir -p /home/cloo/appdata/doaj/s3fs/upload
-mkdir -p /home/cloo/appdata/doaj/s3fs/upload_reapplication
-mkdir -p /home/cloo/appdata/doaj/s3fs/reapp_csvs
 
 sudo apt-get update -q -y
 sudo apt-get install -q -y redis-tools
@@ -51,3 +44,11 @@ if [ $? -eq 0 ]; then
     echo
     DOAJENV=$1 python deploy/mount_s3fs.py
 fi
+
+mkdir -p /home/cloo/appdata/doaj/s3fs
+mkdir -p /home/cloo/appdata/doaj/s3fs/cache
+mkdir -p /home/cloo/appdata/doaj/s3fs/cache/csv
+mkdir -p /home/cloo/appdata/doaj/s3fs/cache/sitemap
+mkdir -p /home/cloo/appdata/doaj/s3fs/upload
+mkdir -p /home/cloo/appdata/doaj/s3fs/upload_reapplication
+mkdir -p /home/cloo/appdata/doaj/s3fs/reapp_csvs

--- a/deploy/deploy-background-apps.sh
+++ b/deploy/deploy-background-apps.sh
@@ -9,13 +9,6 @@ mkdir -p /home/cloo/appdata/doaj
 mkdir -p /home/cloo/appdata/doaj/history
 mkdir -p /home/cloo/appdata/doaj/history/article
 mkdir -p /home/cloo/appdata/doaj/history/journal
-mkdir -p /home/cloo/appdata/doaj/s3fs
-mkdir -p /home/cloo/appdata/doaj/s3fs/cache
-mkdir -p /home/cloo/appdata/doaj/s3fs/cache/csv
-mkdir -p /home/cloo/appdata/doaj/s3fs/cache/sitemap
-mkdir -p /home/cloo/appdata/doaj/s3fs/upload
-mkdir -p /home/cloo/appdata/doaj/s3fs/upload_reapplication
-mkdir -p /home/cloo/appdata/doaj/s3fs/reapp_csvs
 
 sudo apt-get update -q -y
 sudo apt-get install -q -y redis-tools
@@ -41,6 +34,14 @@ if [ $? -eq 0 ]; then
     echo
     DOAJENV=$1 python deploy/mount_s3fs.py
 fi
+
+mkdir -p /home/cloo/appdata/doaj/s3fs
+mkdir -p /home/cloo/appdata/doaj/s3fs/cache
+mkdir -p /home/cloo/appdata/doaj/s3fs/cache/csv
+mkdir -p /home/cloo/appdata/doaj/s3fs/cache/sitemap
+mkdir -p /home/cloo/appdata/doaj/s3fs/upload
+mkdir -p /home/cloo/appdata/doaj/s3fs/upload_reapplication
+mkdir -p /home/cloo/appdata/doaj/s3fs/reapp_csvs
 
 sudo supervisorctl reread huey-main-$ENV
 sudo supervisorctl reread huey-long-running-$ENV


### PR DESCRIPTION
Yep, what the title says. Created the directories before S3FS was mounted. Doesn't work very well running on a vanilla machine that doesn't have S3FS set up, since the S3FS directory will be occupied by a bunch of empty folders when the mount is attempted.