### PR TITLE
[hotfix] fix application supervisor link

### DIFF
--- a/deploy/deploy-gateway.sh
+++ b/deploy/deploy-gateway.sh
@@ -48,7 +48,7 @@ pip install redis==2.10.5
 pip install rstr==2.2.5
 
 # prep sym links for the app server
-ln -sf $DIR/supervisor/doaj-$ENV.conf /home/cloo/repl/$ENV/supervisor/conf.d/doaj-$ENV.conf
+ln -sf $DIR/supervisor/$ENV/doaj-$ENV.conf /home/cloo/repl/$ENV/supervisor/conf.d/doaj-$ENV.conf
 ln -sf $DIR/nginx/doaj-$ENV /home/cloo/repl/$ENV/nginx/sites-available/doaj-$ENV
 ln -sf /home/cloo/repl/$ENV/nginx/sites-available/doaj-$ENV /home/cloo/repl/$ENV/nginx/sites-enabled/doaj-$ENV
 


### PR DESCRIPTION
supervisord configs are as of very recently stored as (e.g.) `/deploy/supervisor/test/doaj-test.conf` where `/` denotes the DOAJ repo root. EDIT: currently, the script in this PR links them to `/deploy/supervisor/doaj-test.conf` which is the old location.

On the server, they are indeed placed in (e.g.) `/home/cloo/repl/test/supervisor/conf.d/` so the 2nd argument to `ln` is correct.

Looks like I used the correct subdirectory for the section below, `prep sym links for the background app server`, but forgot to change the subdir in the web app's section.