### PR TITLE
The article toc template no longer assumes articles have titles in th…

### DIFF
--- a/portality/templates/doaj/article.html
+++ b/portality/templates/doaj/article.html
@@ -2,8 +2,11 @@
 
 {% block page_title %}
     {% set bibjson = article.bibjson() %}
-    {% set metatitle = bibjson.title %}
-    {% set metatitle = metatitle + ' | ' + app.config['SERVICE_NAME'] %}
+    {%  if bibjson.title %}
+        {% set metatitle = bibjson.title + ' | ' + app.config['SERVICE_NAME'] %}
+    {% else %}
+        {% set metatitle = app.config['SERVICE_NAME'] %}
+    {% endif %}
     <title>{{ metatitle }}</title>
 {% endblock %}
 
@@ -68,7 +71,11 @@ hosted on DOAJ.org) #}
 
 <div class="row-fluid">
     <div class="span12">
-        <h1>{{bibjson.title}}</h1>
+        {%  if bibjson.title %}
+            <h1>{{bibjson.title}}</h1>
+        {% else %}
+            <h1>&lt; Article title missing &gt;</h1>
+        {% endif %}
 
         <p>
         {# citation #}


### PR DESCRIPTION
…eir bibjson. Articles should have titles, though. They really should and it's sad that some don't. #1095 

We should still consider whether those articles should be deleted at some point.
## HOTFIX