### PR TITLE
[hotfix] Do not rerun article creation twice. Use the results of the dry run.

### DIFF
--- a/portality/api/v1/bulk/articles.py
+++ b/portality/api/v1/bulk/articles.py
@@ -29,8 +29,10 @@ class ArticlesBulkApi(Api):
 
     @classmethod
     def create(cls, articles, account):
-        # we run through create twice, once as a dry-run and the second time
-        # as the real deal
+        # We run through the articles once, validating in dry-run mode
+        # and deduplicating as we go. Then we .save() everything once
+        # we know all incoming articles are valid.
+
         new_articles = []
 
         ids = []

--- a/portality/api/v1/bulk/articles.py
+++ b/portality/api/v1/bulk/articles.py
@@ -31,9 +31,7 @@ class ArticlesBulkApi(Api):
     def create(cls, articles, account):
         # we run through create twice, once as a dry-run and the second time
         # as the real deal
-        for a in articles:
-            ArticlesCrudApi.create(a, account, dry_run=True)
-        # no formatting issues, the JSON of each article complies with required format at this point
+        new_articles = []
 
         ids = []
         dois_seen = set()
@@ -41,28 +39,34 @@ class ArticlesBulkApi(Api):
         for a in articles:
             duplicate = False  # skip articles if their fulltext URL or DOI is the same
 
-            for i in a['bibjson']['identifier']:
-                if i['type'] == 'doi':
-                    if i['id'] in dois_seen:
-                        duplicate = True
-                        break
-                    dois_seen.add(i['id'])
+            for i in a.get('bibjson', {}).get('identifier', []):
+                if i.get('type', '') == 'doi':
+                    if 'id' in i:
+                        if i['id'] in dois_seen:
+                            duplicate = True
+                            break
+                        dois_seen.add(i['id'])
 
             if duplicate:
                 continue
 
-            for l in a['bibjson']['link']:
-                if l['type'] == 'fulltext':
-                    if l['url'] in fulltext_urls_seen:
-                        duplicate = True
-                        break
-                    fulltext_urls_seen.add(l['url'])
+            for l in a.get('bibjson', {}).get('link', []):
+                if l.get('type', '') == 'fulltext':
+                    if 'url' in l:
+                        if l['url'] in fulltext_urls_seen:
+                            duplicate = True
+                            break
+                        fulltext_urls_seen.add(l['url'])
 
             if duplicate:
                 continue
 
-            n = ArticlesCrudApi.create(a, account)
+            n = ArticlesCrudApi.create(a, account, dry_run=True)
+            new_articles.append(n)
             ids.append(n.id)
+
+        for na in new_articles:
+            na.save()
 
         return ids
 


### PR DESCRIPTION
For #1313 

We used to do a dry run, then redo the entire article creation process. We thought a 1000 x2 would not be a big problem at the time.

We also only avoided processing duplicates during the real run.

Now:

1. we avoid duplicates immediately. The code has been refactored to be more defensive. This might well need tests to prove it is more defensive against bad data and you should ask for such tests if they are not there.

2. we accumulate the results of the dry run as we go, so we still don't save anything until 100% of the articles have passed validation

3. we save the results of the dry run. This is based on the fact that the dry run currently only consists of:

```python
# ArticlesCrudApi.create , portality/api/v1/crud/articles.py:97
        if not dry_run:
            am.save()
```

There are no other uses of `dry_run` in this method.

Of course, this may change in the future without notice to the Bulk API classes and the new dependency I'm introducing is not obvious. We can leave a comment that there is a dependency, or make the dry run functionality more explicit. For example, create a method on ArticlesCrudApi like `create_not_dry_run` and call that inside `create` as well as outside of it (as I'm doing in this PR). That's quite ugly, but you get the ultimate goal - express the dependency in code and make sure it's easily (or 0 effort) to maintain.

