### PR TITLE
Hotfix/2017 06 10 iss1293 associate privileges

### DIFF
--- a/doajtest/unit/test_editor_app_review.py
+++ b/doajtest/unit/test_editor_app_review.py
@@ -140,7 +140,7 @@ APPLICATION_SOURCE = {
         "article_metadata" : True
     },
     "admin" : {
-        "application_status" : "reapplication",
+        "application_status" : "pending",
         "notes" : [
             {"note" : "First Note", "date" : "2014-05-21T14:02:45Z"},
             {"note" : "Second Note", "date" : "2014-05-22T00:00:00Z"}
@@ -514,6 +514,22 @@ class TestEditorAppReview(DoajTestCase):
         assert fc.form_data is not None
 
         # Finalise the formcontext. This should raise an exception because the application status is out of bounds.
+        assert_raises(formcontext.FormContextException, fc.finalise)
+
+        # Check that an application status can't be brought backwards in the review process
+        pending_source = APPLICATION_SOURCE.copy()
+
+        progressing_form = APPLICATION_FORM.copy()
+        progressing_form['application_status'] = 'in progress'
+
+        # Construct the formcontext from form data (with a known source)
+        fc = formcontext.ApplicationFormFactory.get_form_context(
+            role="associate_editor",
+            form_data=MultiDict(progressing_form),
+            source=models.Suggestion(**pending_source)
+        )
+
+        # Finalise the formcontext. This should raise an exception because the application status can't go backwards.
         assert_raises(formcontext.FormContextException, fc.finalise)
 
         ctx.pop()

--- a/doajtest/unit/test_editor_app_review.py
+++ b/doajtest/unit/test_editor_app_review.py
@@ -9,6 +9,7 @@ from portality.formcontext import formcontext
 from portality import lcc
 
 from werkzeug.datastructures import MultiDict
+from nose.tools import assert_raises
 
 #####################################################################
 # Mocks required to make some of the lookups work
@@ -459,5 +460,60 @@ class TestEditorAppReview(DoajTestCase):
             if prov.action == "status:ready":
                 count += 10
         assert count == 11
+
+        ctx.pop()
+
+    def test_04_editor_review_disallowed_statuses(self):
+        """ Check that editors can't access applications beyond their review process """
+
+        acc = models.Account()
+        acc.set_id("contextuser")
+        acc.add_role("editor")
+        ctx = self._make_and_push_test_context(acc=acc)
+
+        # Check that an accepted application can't be regressed by an editor
+        accepted_source = APPLICATION_SOURCE.copy()
+        accepted_source['admin']['application_status'] = 'accepted'
+
+        ready_form = APPLICATION_FORM.copy()
+        ready_form['application_status'] = 'ready'
+
+        # Construct the formcontext from form data (with a known source)
+        fc = formcontext.ApplicationFormFactory.get_form_context(
+            role="editor",
+            form_data=MultiDict(ready_form),
+            source=models.Suggestion(**accepted_source)
+        )
+
+        assert isinstance(fc, formcontext.EditorApplicationReview)
+        assert fc.form is not None
+        assert fc.source is not None
+        assert fc.form_data is not None
+
+        # Finalise the formcontext. This should raise an exception because the application has already been accepted.
+        assert_raises(formcontext.FormContextException, fc.finalise)
+
+        # Check that an application status can't be edited by editors when on hold,
+        # since this status must have been set by a managing editor.
+        held_source = APPLICATION_SOURCE.copy()
+        held_source['admin']['application_status'] = 'on hold'
+
+        progressing_form = APPLICATION_FORM.copy()
+        progressing_form['application_status'] = 'in progress'
+
+        # Construct the formcontext from form data (with a known source)
+        fc = formcontext.ApplicationFormFactory.get_form_context(
+            role="editor",
+            form_data=MultiDict(progressing_form),
+            source=models.Suggestion(**held_source)
+        )
+
+        assert isinstance(fc, formcontext.EditorApplicationReview)
+        assert fc.form is not None
+        assert fc.source is not None
+        assert fc.form_data is not None
+
+        # Finalise the formcontext. This should raise an exception because the application status is out of bounds.
+        assert_raises(formcontext.FormContextException, fc.finalise)
 
         ctx.pop()

--- a/portality/formcontext/formcontext.py
+++ b/portality/formcontext/formcontext.py
@@ -758,12 +758,20 @@ class EditorApplicationReview(ApplicationContext):
         # can be carried over from the old implementation
         if self.source is None:
             raise FormContextException("You cannot edit a not-existent application")
+        
+        src_status = self.source.application_status
 
-        if self.source.application_status == "accepted":
+        if src_status == "accepted":
             raise FormContextException("You cannot edit applications which have been accepted into DOAJ.")
 
         # if we are allowed to finalise, kick this up to the superclass
         super(EditorApplicationReview, self).finalise()
+
+        # Don't allow status change when source application status is beyond this editor's permissions in the pipeline
+        if self.target.application_status != src_status and src_status not in choices.Choices.application_status(
+                'editor'):
+            raise FormContextException(
+                "You don't have permission to change the status of applications which are {0}.".format(src_status))
 
         # FIXME: may want to factor this out of the suggestionformxwalk
         new_associate_assigned = xwalk.SuggestionFormXWalk.is_new_editor(self.form, self.source)
@@ -887,11 +895,18 @@ class AssEdApplicationReview(ApplicationContext):
         if self.source is None:
             raise FormContextException("You cannot edit a not-existent application")
 
-        if self.source.application_status == "accepted":
+        src_status = self.source.application_status
+
+        if src_status == "accepted":
             raise FormContextException("You cannot edit applications which have been accepted into DOAJ.")
 
         # if we are allowed to finalise, kick this up to the superclass
         super(AssEdApplicationReview, self).finalise()
+
+        # Don't allow status change when source application status is beyond this editor's permissions in the pipeline
+        if self.target.application_status != src_status and src_status not in choices.Choices.application_status():
+            raise FormContextException(
+                "You don't have permission to change the status of applications which are {0}.".format(src_status))
 
         # Save the target
         self.target.set_last_manual_update()

--- a/portality/formcontext/formcontext.py
+++ b/portality/formcontext/formcontext.py
@@ -767,11 +767,18 @@ class EditorApplicationReview(ApplicationContext):
         # if we are allowed to finalise, kick this up to the superclass
         super(EditorApplicationReview, self).finalise()
 
+        editor_choices = list(sum(choices.Choices.application_status('editor'), ()))       # flattens the list of tuples
+        target_status = self.target.application_status
+
         # Don't allow status change when source application status is beyond this editor's permissions in the pipeline
-        if self.target.application_status != src_status and src_status not in choices.Choices.application_status(
-                'editor'):
-            raise FormContextException(
-                "You don't have permission to change the status of applications which are {0}.".format(src_status))
+        if target_status != src_status:
+            if src_status not in editor_choices:
+                raise FormContextException(
+                    "You don't have permission to change the status of applications which are {0}.".format(src_status))
+            elif editor_choices.index(target_status) < editor_choices.index(src_status):
+                raise FormContextException(
+                    "You don't have permission to change the status of applications from {0} to {1}.".format(src_status,
+                                                                                                             target_status))
 
         # FIXME: may want to factor this out of the suggestionformxwalk
         new_associate_assigned = xwalk.SuggestionFormXWalk.is_new_editor(self.form, self.source)
@@ -903,10 +910,18 @@ class AssEdApplicationReview(ApplicationContext):
         # if we are allowed to finalise, kick this up to the superclass
         super(AssEdApplicationReview, self).finalise()
 
+        associate_editor_choices = list(sum(choices.Choices.application_status(), ()))     # flattens the list of tuples
+        target_status = self.target.application_status
+
         # Don't allow status change when source application status is beyond this editor's permissions in the pipeline
-        if self.target.application_status != src_status and src_status not in choices.Choices.application_status():
-            raise FormContextException(
-                "You don't have permission to change the status of applications which are {0}.".format(src_status))
+        if target_status != src_status:
+            if src_status not in associate_editor_choices:
+                raise FormContextException(
+                    "You don't have permission to change the status of applications which are {0}.".format(src_status))
+            elif associate_editor_choices.index(target_status) < associate_editor_choices.index(src_status):
+                raise FormContextException(
+                    "You don't have permission to change the status of applications from {0} to {1}.".format(src_status,
+                                                                                                             target_status))
 
         # Save the target
         self.target.set_last_manual_update()

--- a/portality/formcontext/render.py
+++ b/portality/formcontext/render.py
@@ -260,6 +260,7 @@ class BasicJournalInformationRenderer(Renderer):
             if found:
                 break
 
+
 class ApplicationRenderer(BasicJournalInformationRenderer):
     def __init__(self):
         super(ApplicationRenderer, self).__init__()
@@ -359,6 +360,7 @@ class ManEdApplicationReviewRenderer(ApplicationRenderer):
 
         self.check_field_groups()
 
+
 class EditorApplicationReviewRenderer(ApplicationRenderer):
     def __init__(self):
         super(EditorApplicationReviewRenderer, self).__init__()
@@ -390,6 +392,7 @@ class EditorApplicationReviewRenderer(ApplicationRenderer):
         self.number_questions()
 
         self.check_field_groups()
+
 
 class AssEdApplicationReviewRenderer(ApplicationRenderer):
     def __init__(self):

--- a/portality/templates/formcontext/_lockable_header.html
+++ b/portality/templates/formcontext/_lockable_header.html
@@ -20,6 +20,6 @@
 
 {% if form_context.info != '' %}
     {% autoescape off %}
-        <h4 class="form-status">{{ form_context.info }}</h4>
+        <h4 id="info_header" class="form-status">{{ form_context.info }}</h4>
     {% endautoescape %}
 {% endif %}

--- a/portality/templates/formcontext/_lockable_header.html
+++ b/portality/templates/formcontext/_lockable_header.html
@@ -17,3 +17,9 @@
         </div>
     </div>
 </div>
+
+{% if form_context.info != '' %}
+    {% autoescape off %}
+        <h4 class="form-status">{{ form_context.info }}</h4>
+    {% endautoescape %}
+{% endif %}

--- a/portality/templates/formcontext/assed_application_review.html
+++ b/portality/templates/formcontext/assed_application_review.html
@@ -13,12 +13,6 @@
     <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
 
-    {# FIXME: would be best if this was something more formal on the formcontext level #}
-    {% if form_context.source.application_status == 'accepted' %}
-    <h4 class="form-status">Please note you <span class="red">cannot edit</span> this application as it has been accepted into the DOAJ.</h4>
-    {% endif %}
-
-
     <fieldset>
 
         <div class="row-fluid">

--- a/portality/templates/formcontext/assed_application_review.html
+++ b/portality/templates/formcontext/assed_application_review.html
@@ -104,5 +104,10 @@
 {% block extra_js_bottom %}
 <script type="text/javascript">
     var notes_deletable = false;
+
+    // When the header says the form can't be edited, disable the save buttons.
+    if ($("#info_header").text()) {
+        $(".btn-success").prop('disabled', true);
+    }
 </script>
 {% endblock extra_js_bottom %}

--- a/portality/templates/formcontext/editor_application_review.html
+++ b/portality/templates/formcontext/editor_application_review.html
@@ -112,5 +112,10 @@
 {% block extra_js_bottom %}
 <script type="text/javascript">
     var notes_deletable = false;
+
+    // When the header says the form can't be edited, disable the save buttons.
+    if ($("#info_header").text()) {
+        $(".btn-success").prop('disabled', true);
+    }
 </script>
 {% endblock extra_js_bottom %}

--- a/portality/templates/formcontext/editor_application_review.html
+++ b/portality/templates/formcontext/editor_application_review.html
@@ -13,12 +13,6 @@
     <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
 
-    {# FIXME: would be best if this was something more formal on the formcontext level #}
-    {% if form_context.source.application_status == 'accepted' %}
-    <h4 class="form-status">Please note you <span class="red">cannot edit</span> this application as it has been accepted into the DOAJ.</h4>
-    {% endif %}
-
-
     <fieldset>
 
         <div class="row-fluid">

--- a/portality/templates/formcontext/maned_application_review.html
+++ b/portality/templates/formcontext/maned_application_review.html
@@ -134,6 +134,11 @@
 
     // When the editor group field is changed, refresh the options for editor
     var ed_query_url = "{{url_for('admin.eg_associates_dropdown')}}";
-    $("#editor_group").change(function() {load_eds_in_group(ed_query_url);})
+    $("#editor_group").change(function() {load_eds_in_group(ed_query_url);});
+
+    // When the header says the form can't be edited, disable the save buttons.
+    if ($("#info_header").text()) {
+        $(".btn-success").prop('disabled', true);
+    }
 </script>
 {% endblock extra_js_bottom %}

--- a/portality/templates/formcontext/maned_application_review.html
+++ b/portality/templates/formcontext/maned_application_review.html
@@ -13,12 +13,6 @@
     <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
 
-    {# FIXME: would be best if this was something more formal on the formcontext level #}
-    {% if form_context.source.application_status == 'accepted' %}
-    <h4 class="form-status">Please note you <span class="red">cannot edit</span> this application as it has been accepted into the DOAJ.</h4>
-    {% endif %}
-
-
     <fieldset>
 
         <div class="row-fluid">


### PR DESCRIPTION
* Editor and associate editor forms throw errors when application is trying to be saved in a status outwith their editorial permissions, or backwards in the editorial pipeline.
* Editors and associate editors only see statuses that they can change to on the application edit form. Statuses beyond their permitted are visible but greyed out.

In light of the second point, the FormContextExceptions are a little redundant, because users don't get access to the statuses for the UI, but this is more complete (since the UI can be bypassed). The tests reflect this.

This may need to go on the test server so I can prove that some of my weirder code works as intended.
#1293 