### PR TITLE
[hotfix] switch to using Published rather than Updated on wordpress news items

### DIFF
--- a/portality/blog.py
+++ b/portality/blog.py
@@ -45,16 +45,21 @@ class News(DomainObject):
     def updated(self, date): self.data["updated"] = date
 
     @property
+    def published(self): return self.data.get("published")
+    @published.setter
+    def published(self, date): self.data["published"] = date
+
+    @property
     def summary(self): return self.data.get("summary")
     @summary.setter
     def summary(self, s): self.data["summary"] = s
 
-    def updated_formatted(self, format="%a, %d %b %Y at %H:%M"):
+    def published_formatted(self, format="%a, %d %b %Y at %H:%M"):
         try:
-            dt = datetime.strptime(self.updated, "%Y-%m-%dT%H:%M:%SZ")
+            dt = datetime.strptime(self.published, "%Y-%m-%dT%H:%M:%SZ")
             return dt.strftime(format)
         except:
-            return self.updated
+            return self.published
 
 class NewsQuery(object):
     _remote_term =  { "term" : { "remote_id.exact" : "<remote id>" } }
@@ -64,7 +69,7 @@ class NewsQuery(object):
         self.size = size
 
     def query(self):
-        q = {"query" : {}, "size" : self.size, "sort" : {"updated" : {"order" : "desc"}}}
+        q = {"query" : {}, "size" : self.size, "sort" : {"published" : {"order" : "desc"}}}
         if self.remote_id is not None:
             rt = deepcopy(self._remote_term)
             rt["term"]["remote_id.exact"] = self.remote_id
@@ -104,5 +109,6 @@ def save_entry(entry):
     news.title = entry.title
     news.updated = entry.updated
     news.summary = entry.summary
+    news.published = entry.published
 
     news.save()

--- a/portality/templates/doaj/index.html
+++ b/portality/templates/doaj/index.html
@@ -44,7 +44,7 @@
                 <div style="border-bottom: 1px dotted #cccccc; padding: 15px">
                     <strong><a href="{{n.url}}" target="_blank">{% autoescape off%}{{n.title}}{% endautoescape %}</a></strong><br>
                     <p>{% autoescape off%}{{n.summary}}{% endautoescape %}&nbsp;<a href="{{n.url}}" target="_blank">Read More...</a></p>
-                    <em>{{n.updated_formatted()}}</em>
+                    <em>Published {{n.published_formatted()}}</em>
                 </div>
 
             {% endfor %}

--- a/portality/templates/doaj/news.html
+++ b/portality/templates/doaj/news.html
@@ -11,7 +11,7 @@
                 <div style="border-bottom: 1px dotted #cccccc; padding: 15px">
                     <strong><a href="{{n.url}}" target="_blank">{% autoescape off%}{{n.title}}{% endautoescape %}</a></strong><br>
                     <p>{% autoescape off%}{{n.summary}}{% endautoescape %}&nbsp;<a href="{{n.url}}" target="_blank">Read More...</a></p>
-                    <em>{{n.updated_formatted()}}</em>
+                    <em>Published {{n.published_formatted()}}</em>
                 </div>
 
             {% endfor %}


### PR DESCRIPTION
Fulfil #1341 

Before:

![image](https://user-images.githubusercontent.com/1190172/28080874-59dea932-6665-11e7-9d06-9bdcb51d2984.png)


After:

![image](https://user-images.githubusercontent.com/1190172/28080880-5ee3eb68-6665-11e7-8948-0e9b5822a3e9.png)

