### PR TITLE
fix language crosswalk for oai_doaj articles

### DIFF
--- a/portality/datasets.py
+++ b/portality/datasets.py
@@ -542,6 +542,7 @@ languages_iso639_2 = [
 # ok, but we don't care about the Aramaic Empire ... we only want the ISO639-1 subset of those (the ones with 2-char codes)
 languages = {}
 languages_fullname_to_3char_code = {}
+languages_3char_code_index = []
 for l in languages_iso639_2:
     if l[2]:
         twochar_code = l[2].upper()
@@ -552,6 +553,7 @@ for l in languages_iso639_2:
             "name": l[3]
         }
         languages[twochar_code] = lobj
+        languages_3char_code_index.append(l[0].upper())
 
     if l[3] and l[0]:  # if a name and a 3-char code exist for this lang
         languages_fullname_to_3char_code[l[3]] = l[0]

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -1210,11 +1210,14 @@ class OAI_DOAJ_Article(OAI_Crosswalk):
         if jlangs:
             if isinstance(jlangs, list):
                 jlangs = jlangs[0]
-            char3 = datasets.languages_fullname_to_3char_code.get(jlangs)
-            if char3 is None:
-                char3 = datasets.languages_dict.get(jlangs, {}).get("iso639-3_code")
-            if char3 is not None:
-                language = char3.lower()
+            if jlangs in datasets.languages_3char_code_index:
+                language = jlangs.lower()
+            else:
+                char3 = datasets.languages_fullname_to_3char_code.get(jlangs)
+                if char3 is None:
+                    char3 = datasets.languages_dict.get(jlangs, {}).get("iso639-3_code")
+                if char3 is not None:
+                    language = char3.lower()
 
         # if the language code lookup was successful, add it to the
         # result

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -1209,7 +1209,7 @@ class OAI_DOAJ_Article(OAI_Crosswalk):
         if jlangs:
             if isinstance(jlangs, list):
                 jlangs = jlangs[0]
-            jlangs = datasets.languages_fullname_to_3char_code.get(jlangs)
+            jlangs = datasets.languages_fullname_to_3char_code.get(jlangs, jlangs)
 
         # if the language code lookup was successful, add it to the
         # result

--- a/portality/view/oaipmh.py
+++ b/portality/view/oaipmh.py
@@ -1206,16 +1206,21 @@ class OAI_DOAJ_Article(OAI_Crosswalk):
         jlangs = bibjson.journal_language
         # first, if there are any languages recorded, get the 3-char code
         # corresponding to the first language
+        language = None
         if jlangs:
             if isinstance(jlangs, list):
                 jlangs = jlangs[0]
-            jlangs = datasets.languages_fullname_to_3char_code.get(jlangs, jlangs)
+            char3 = datasets.languages_fullname_to_3char_code.get(jlangs)
+            if char3 is None:
+                char3 = datasets.languages_dict.get(jlangs, {}).get("iso639-3_code")
+            if char3 is not None:
+                language = char3.lower()
 
         # if the language code lookup was successful, add it to the
         # result
-        if jlangs:
+        if language:
             langel = etree.SubElement(oai_doaj_article, self.OAI_DOAJ + "language")
-            set_text(langel, jlangs)
+            set_text(langel, language)
 
         if bibjson.publisher:
             publel = etree.SubElement(oai_doaj_article, self.OAI_DOAJ + "publisher")


### PR DESCRIPTION
HOTFIX

Attempt to convert the language code to a 3 letter code if it isn't one already (it won't be, we use 2 letter codes internally) and expose via oai_doaj metadata format.