### PR TITLE
Hotfix/2017 06 20 iss1296 article dedupe

### DIFF
--- a/doajtest/unit/test_article_match.py
+++ b/doajtest/unit/test_article_match.py
@@ -113,7 +113,7 @@ class TestArticleMatch(DoajTestCase):
         # we don't care about the order of duplicates
         expected = sorted([a, a2])
         xwalk = article.XWalk()
-        l = xwalk.get_duplicate(z, all_duplicates=True)
+        l = xwalk.get_duplicates(z)
         assert isinstance(l, list), l
         assert l
         l.sort()
@@ -166,7 +166,7 @@ class TestArticleMatch(DoajTestCase):
         # we don't care about the order of duplicates
         expected = sorted([a, a2])
         xwalk = article.XWalk()
-        l = xwalk.get_duplicate(z, all_duplicates=True)
+        l = xwalk.get_duplicates(z)
         assert isinstance(l, list)
         assert l
         assert len(l) == 2
@@ -215,44 +215,8 @@ class TestArticleMatch(DoajTestCase):
         assert a3.id == a2.id == a.id
         assert a3.bibjson().title == "Example C article with a fulltext url"
         assert a3.bibjson().abstract == "a newer bunch of text"
-        
-    def test_06_test_that_get_duplicates_makes_no_sense(self):
-        """Test the weird behaviour that get_duplicates has..."""
-        # make ourselves a couple of example articles
-        a = models.Article()
-        b = a.bibjson()
-        b.title = "Example A article with a fulltext url"
-        b.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
-        a.save(blocking=True)
 
-        # create an article which should not be caught by the duplicate detection
-        not_duplicate = models.Article()
-        not_duplicate_bibjson = not_duplicate.bibjson()
-        not_duplicate_bibjson.title = "Example C article with a fulltext url"
-        not_duplicate_bibjson.add_url("http://this.is/a/different/url", urltype="fulltext")
-        not_duplicate.save(blocking=True)
-
-        # get the xwalk to determine if there is a duplicate
-        xwalk = article.XWalk()
-        d = xwalk.get_duplicate(a)
-
-        # TODO: This is complete nonsense, we must refactor get_duplicate
-        # so it doesn't return the article that is being passed in when
-        # requesting a single duplicate!
-        # This may have implications for XML upload ingestion and could be non-trivial.
-        # If you request multiple duplicates with all_duplicates=True it
-        # will act intuitively and not return the article you asked for.
-        assert d is not None  # current behaviour, but should be changed!
-        assert d.id == a.id  # current behaviour, but should be changed!
-
-        # get the xwalk to determine all duplicates - they do not include
-        # the original
-        xwalk = article.XWalk()
-        l = xwalk.get_duplicate(a, all_duplicates=True)
-        assert isinstance(l, list)
-        assert l == []
-
-    def test_07_many_issns(self):
+    def test_06_many_issns(self):
         """Test that a query with a LOT of ISSNs is still successful."""
         a = models.Article()
         b = a.bibjson()

--- a/doajtest/unit/test_article_match.py
+++ b/doajtest/unit/test_article_match.py
@@ -252,7 +252,7 @@ class TestArticleMatch(DoajTestCase):
         assert isinstance(l, list)
         assert l == []
 
-    def test_08_many_issns(self):
+    def test_07_many_issns(self):
         """Test that a query with a LOT of ISSNs is still successful."""
         a = models.Article()
         b = a.bibjson()

--- a/doajtest/unit/test_article_match.py
+++ b/doajtest/unit/test_article_match.py
@@ -3,6 +3,7 @@ from portality import article, models
 import uuid, time
 from random import randint
 
+
 class TestArticleMatch(DoajTestCase):
 
     def setUp(self):
@@ -11,142 +12,99 @@ class TestArticleMatch(DoajTestCase):
     def tearDown(self):
         super(TestArticleMatch, self).tearDown()
 
-    def test_01(self):
-        # make ourselves an example article
-        a = models.Article()
-        b = a.bibjson()
-        b.title = "Example article with a fulltext url"
-        b.add_url("http://examplejournal.telfor.rs/Published/Vol1No1/Vol1No1_A5.pdf", urltype="fulltext")
-        a.save()
+    def test_01_same_fulltext(self):
+        """Check duplication detection on articles with the same fulltext URL"""
+
+        # A list of various URLs to check matching on
+        ftus = [
+            "http://examplejournal.telfor.rs/Published/Vol1No1/Vol1No1_A5.pdf",
+            "http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf",
+            "http://www.ujcem.med.sumdu.edu.ua/images/sampledata/2013/4/408_412_IV-020.pdf",
+            "http://www.psychologie-aktuell.com/fileadmin/download/ptam/1-2014_20140324/01_Geiser.pdf"
+        ]
+
+        for ftu in ftus:
+            # make ourselves an example article
+            a = models.Article()
+            b = a.bibjson()
+            b.title = "Example article with a fulltext url"
+            b.add_url(ftu, urltype="fulltext")
+            a.save(blocking=True)
+
+            # create a replacement article
+            z = models.Article()
+            y = z.bibjson()
+            y.title = "Replacement article for fulltext url"
+            y.add_url(ftu, urltype="fulltext")
+
+            # get the xwalk to determine if there is a duplicate
+            xwalk = article.XWalk()
+            d = xwalk.get_duplicate(z)
+
+            assert d is not None
+            assert d.bibjson().title == "Example article with a fulltext url"
         
-        # pause to allow the index time to catch up
-        time.sleep(2)
-        
-        # create a replacement article
-        z = models.Article()
-        y = z.bibjson()
-        y.title = "Replacement article for fulltext url"
-        y.add_url("http://examplejournal.telfor.rs/Published/Vol1No1/Vol1No1_A5.pdf", urltype="fulltext")
-        
-        # get the xwalk to determine if there is a duplicate
-        xwalk = article.XWalk()
-        d = xwalk.get_duplicate(z)
-        
-        assert d is not None
-        assert d.bibjson().title == "Example article with a fulltext url"
-        
-    def test_02(self):
+    def test_02_different_fulltext(self):
+        """Check that an article with different fulltext URLs is not considered a duplicate"""
         # make ourselves an example article
         a = models.Article()
         b = a.bibjson()
         b.title = "Example 2 article with a fulltext url"
         b.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
-        a.save()
-        
-        # pause to allow the index time to catch up
-        time.sleep(2)
-        
-        # create a replacement article
+        a.save(blocking=True)
+
+        # create another article
         z = models.Article()
         y = z.bibjson()
         y.title = "Replacement article for fulltext url"
-        y.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
+        y.add_url("http://this.is/a/different/url", urltype="fulltext")
         
         # get the xwalk to determine if there is a duplicate
         xwalk = article.XWalk()
         d = xwalk.get_duplicate(z)
         
-        assert d is not None
-        assert d.bibjson().title == "Example 2 article with a fulltext url"
+        assert d is None
     
-    def test_03(self):
-        # make ourselves an example article
-        a = models.Article()
-        b = a.bibjson()
-        b.title = "Example 2 article with a fulltext url"
-        b.add_url("http://www.ujcem.med.sumdu.edu.ua/images/sampledata/2013/4/408_412_IV-020.pdf", urltype="fulltext")
-        a.save()
-        
-        # pause to allow the index time to catch up
-        time.sleep(2)
-        
-        # create a replacement article
-        z = models.Article()
-        y = z.bibjson()
-        y.title = "Replacement article for fulltext url"
-        y.add_url("http://www.ujcem.med.sumdu.edu.ua/images/sampledata/2013/4/408_412_IV-020.pdf", urltype="fulltext")
-        
-        # get the xwalk to determine if there is a duplicate
-        xwalk = article.XWalk()
-        d = xwalk.get_duplicate(z)
-        
-        assert d is not None
-        assert d.bibjson().title == "Example 2 article with a fulltext url"
-    
-    def test_04(self):
-        # make ourselves an example article
-        a = models.Article()
-        b = a.bibjson()
-        b.title = "Example 2 article with a fulltext url"
-        b.add_url("http://www.psychologie-aktuell.com/fileadmin/download/ptam/1-2014_20140324/01_Geiser.pdf", urltype="fulltext")
-        a.save()
-        
-        # pause to allow the index time to catch up
-        time.sleep(2)
-        
-        # create a replacement article
-        z = models.Article()
-        y = z.bibjson()
-        y.title = "Replacement article for fulltext url"
-        y.add_url("http://www.psychologie-aktuell.com/fileadmin/download/ptam/1-2014_20140324/01_Geiser.pdf", urltype="fulltext")
-        
-        # get the xwalk to determine if there is a duplicate
-        xwalk = article.XWalk()
-        d = xwalk.get_duplicate(z)
-        
-        assert d is not None
-        assert d.bibjson().title == "Example 2 article with a fulltext url"
-    
-    def test_05(self):
+    def test_03_retrieve_latest(self):
+
+        ftu = "http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf"
         # make ourselves a couple of example articles
         a = models.Article()
         b = a.bibjson()
         b.title = "Example A article with a fulltext url"
-        b.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
+        b.add_url(ftu, urltype="fulltext")
         a.save()
         
         # wait for a bit to create good separation between last_updated times
-        time.sleep(2)
+        time.sleep(1.3)
         
         a2 = models.Article()
         b2 = a2.bibjson()
         b2.title = "Example B article with a fulltext url"
-        b2.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
+        b2.add_url(ftu, urltype="fulltext")
         a2.save()
 
         # wait for a bit to create good separation between last_updated times
-        time.sleep(2)
+        time.sleep(1.3)
 
         # create an article which should not be caught by the duplicate detection
         not_duplicate = models.Article()
         not_duplicate_bibjson = not_duplicate.bibjson()
         not_duplicate_bibjson.title = "Example C article with a fulltext url"
-        not_duplicate_bibjson.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf_DIFFERENT", urltype="fulltext")
-        not_duplicate.save()
-        
-        # pause to allow the index time to catch up
-        time.sleep(2)
+        not_duplicate_bibjson.add_url("http://this.is/a/different/url", urltype="fulltext")
+        not_duplicate.save(blocking=True)
         
         # create a replacement article
         z = models.Article()
         y = z.bibjson()
         y.title = "Replacement article for fulltext url"
-        y.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
+        y.add_url(ftu, urltype="fulltext")
         
         # get the xwalk to determine if there is a duplicate
         xwalk = article.XWalk()
         d = xwalk.get_duplicate(z)
-        
+
+        # Check when we ask for one duplicate we get the most recent duplicate.
         assert d is not None
         assert d.bibjson().title == "Example B article with a fulltext url", d.bibjson().title
 
@@ -161,35 +119,33 @@ class TestArticleMatch(DoajTestCase):
         l.sort()
         assert expected == l
 
-    def test_05_with_doi_instead(self):
+    def test_04_with_doi_instead(self):
+        """Detect a duplicate using the DOI field."""
         # make ourselves a couple of example articles
         a = models.Article()
         b = a.bibjson()
-        b.title = "Example A article with a fulltext url"
+        b.title = "Example A article with a DOI"
         b.add_identifier('doi', "10.doi")
         a.save()
 
         # wait for a bit to create good separation between last_updated times
-        time.sleep(2)
+        time.sleep(1.3)
 
         a2 = models.Article()
         b2 = a2.bibjson()
-        b2.title = "Example B article with a fulltext url"
+        b2.title = "Example B article with a DOI"
         b2.add_identifier('doi', "10.doi")
         a2.save()
 
         # wait for a bit to create good separation between last_updated times
-        time.sleep(2)
+        time.sleep(1.3)
 
         # create an article which should not be caught by the duplicate detection
         not_duplicate = models.Article()
         not_duplicate_bibjson = not_duplicate.bibjson()
-        not_duplicate_bibjson.title = "Example C article with a fulltext url"
+        not_duplicate_bibjson.title = "Example C article with a DOI"
         not_duplicate_bibjson.add_identifier('doi', "10.doi.DIFFERENT")
-        not_duplicate.save()
-
-        # pause to allow the index time to catch up
-        time.sleep(2)
+        not_duplicate.save(blocking=True)
 
         # create a replacement article
         z = models.Article()
@@ -201,8 +157,9 @@ class TestArticleMatch(DoajTestCase):
         xwalk = article.XWalk()
         d = xwalk.get_duplicate(z)
 
+        # Check when we ask for one duplicate we get the most recent duplicate.
         assert d is not None
-        assert d.bibjson().title == "Example B article with a fulltext url", d.bibjson().title
+        assert d.bibjson().title == "Example B article with a DOI", d.bibjson().title
 
         # get the xwalk to determine all duplicates
         # sort both results and expectations here to avoid false alarm
@@ -216,69 +173,64 @@ class TestArticleMatch(DoajTestCase):
         l.sort()
         assert expected == l
     
-    def test_06(self):
+    def test_05_merge_replaces_metadata(self):
+        """Ensure that merging replaces metadata of a new article, but keeps its old id."""
+
+        ftu = "http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf"
         id1 = uuid.uuid4().hex
         id2 = uuid.uuid4().hex
+        assert id1 != id2
 
         a = models.Article()
         a.set_id(id1)
         b = a.bibjson()
         b.title = "Example A article with a fulltext url"
         b.abstract = "a bunch of text"
-        b.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
-
+        b.add_url(ftu, urltype="fulltext")
 
         a2 = models.Article()
         a2.set_id(id2)
         b2 = a2.bibjson()
         b2.title = "Example B article with a fulltext url"
-        b2.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
-        
+        b2.add_url(ftu, urltype="fulltext")
+
+        # perform a merge, which updates article records of a2 based on a - including the id.
         assert a2.id == id2
-        
         a2.merge(a)
-        
-        assert a2.id == id1, (a2.id, id1, id2)
+        assert a2.id == id1
+
+        # Check that we have the newer metadata
         assert a2.bibjson().title == "Example B article with a fulltext url"
         assert a2.bibjson().abstract is None
-    
-    def test_07(self):
-        a = models.Article()
-        id_ = uuid.uuid4().hex
-        a.set_id(id_)
-        b = a.bibjson()
-        b.title = "Example A article with a fulltext url"
-        b.abstract = "a bunch of text"
-        b.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
+
+        # Create a 3rd article without an explicit id
+        a3 = models.Article()
+        b3 = a3.bibjson()
+        b3.title = "Example C article with a fulltext url"
+        b3.abstract = "a newer bunch of text"
+        b3.add_url(ftu, urltype="fulltext")
+
+        a3.merge(a2)
+
+        assert a3.id == a2.id == a.id
+        assert a3.bibjson().title == "Example C article with a fulltext url"
+        assert a3.bibjson().abstract == "a newer bunch of text"
         
-        a2 = models.Article()
-        b2 = a2.bibjson()
-        b2.title = "Example B article with a fulltext url"
-        b2.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
-        
-        a2.merge(a)
-        
-        assert a2.id == id_, (a2.id, id_)
-        assert a2.bibjson().title == "Example B article with a fulltext url"
-        assert a2.bibjson().abstract is None
-        
-    def test_08(self):
+    def test_06_test_that_get_duplicates_makes_no_sense(self):
+        """Test the weird behaviour that get_duplicates has..."""
         # make ourselves a couple of example articles
         a = models.Article()
         b = a.bibjson()
         b.title = "Example A article with a fulltext url"
         b.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf", urltype="fulltext")
-        a.save()
+        a.save(blocking=True)
 
         # create an article which should not be caught by the duplicate detection
         not_duplicate = models.Article()
         not_duplicate_bibjson = not_duplicate.bibjson()
         not_duplicate_bibjson.title = "Example C article with a fulltext url"
-        not_duplicate_bibjson.add_url("http://www.sbe.deu.edu.tr/dergi/cilt15.say%C4%B12/06%20AKALIN.pdf_DIFFERENT", urltype="fulltext")
-        not_duplicate.save()
-
-        # pause to allow the index time to catch up
-        time.sleep(2)
+        not_duplicate_bibjson.add_url("http://this.is/a/different/url", urltype="fulltext")
+        not_duplicate.save(blocking=True)
 
         # get the xwalk to determine if there is a duplicate
         xwalk = article.XWalk()
@@ -300,16 +252,14 @@ class TestArticleMatch(DoajTestCase):
         assert isinstance(l, list)
         assert l == []
 
-    def test_09_many_issns(self):
-        # This tests that a query with a LOT of issns is still successful
+    def test_08_many_issns(self):
+        """Test that a query with a LOT of ISSNs is still successful."""
         a = models.Article()
         b = a.bibjson()
         b.journal_issns = ["0000-0000"]
         b.title = "Example A article with a fulltext url"
         b.add_identifier(b.DOI, "10.1234/duplicate")
-        a.save()
-
-        time.sleep(2)
+        a.save(blocking=True)
 
         def random_issn():
             bits = []
@@ -317,7 +267,7 @@ class TestArticleMatch(DoajTestCase):
                 bits.append(str(randint(1, 9)))
             return "".join(bits[:4]) + "-" + "".join(bits[4:])
 
-        issns = [random_issn() for i in range(2000)] + ["0000-0000"]
+        issns = [random_issn() for _ in range(2000)] + ["0000-0000"]
 
         dupes = models.Article.duplicates(issns=issns, doi="10.1234/duplicate")
         assert len(dupes) == 1

--- a/portality/models/article.py
+++ b/portality/models/article.py
@@ -9,8 +9,10 @@ from portality.core import app
 import string
 from unidecode import unidecode
 
+
 class NoJournalException(Exception):
     pass
+
 
 class Article(DomainObject):
     __type__ = "article"

--- a/portality/scripts/remove_duplicate_articles.py
+++ b/portality/scripts/remove_duplicate_articles.py
@@ -42,10 +42,14 @@ if __name__ == "__main__":
     dry_run = args.dry_run
 
     start = datetime.now()
-    count = 0
-    print 'Starting {0} {snapshot} in 5 seconds, Ctrl+C to exit.'.format(start.isoformat(), snapshot=snapshot_report)
+
+    if dry_run:
+        print 'Starting {0} dry run in 5 seconds, Ctrl+C to exit.'.format(start.isoformat())
+    else:
+        print 'Starting {0} {snapshot} in 5 seconds, Ctrl+C to exit.'.format(start.isoformat(), snapshot=snapshot_report)
     time.sleep(5)
 
+    count = 0
     originals = []  # make sure we only delete FORWARD. So, if articles
     # A, B and C are duplicates, we stumble upon A first, and delete B and C.cat
     # We must then ensure we do not delete A if we chance upon B or C

--- a/portality/scripts/remove_duplicate_articles.py
+++ b/portality/scripts/remove_duplicate_articles.py
@@ -28,6 +28,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-g", "--ghost", help="specify if you want the articles being deleted not to be snapshot", action="store_true")
+    parser.add_argument("-d", "--dry-run", help="run this script without actually deleting the articles.", action="store_true")
     parser.add_argument("-y", "--yes", help="are you running this script with output redirection e.g. DOAJENV=production python portality/scripts/remove_duplicate_articles.py >> ~/dedupe_`date +\%%F_\%%H\%%M\%%S`.log 2>&1 ? You really should.", action="store_true")
 
     args = parser.parse_args()
@@ -38,13 +39,15 @@ if __name__ == "__main__":
     snapshot = not args.ghost
     snapshot_report = "with snapshotting" if snapshot else "without snapshotting"
 
+    dry_run = args.dry_run
+
     start = datetime.now()
     count = 0
     print 'Starting {0} {snapshot} in 5 seconds, Ctrl+C to exit.'.format(start.isoformat(), snapshot=snapshot_report)
     time.sleep(5)
 
     originals = []  # make sure we only delete FORWARD. So, if articles
-    # A, B and C are duplicates, we stumble upon A first, and delete B and C.
+    # A, B and C are duplicates, we stumble upon A first, and delete B and C.cat
     # We must then ensure we do not delete A if we chance upon B or C
     # (because they are still in Python memory even though they are not in ES).
     article_iterator = models.Article.iterall(page_size=5000)
@@ -54,10 +57,11 @@ if __name__ == "__main__":
         if duplicates:
             print '{0}:'.format(a.id),  # original: ...
             for d in duplicates:
-                if not d.id in originals:
-                    if snapshot:
-                        d.snapshot()
-                    d.delete()
+                if d.id not in originals:
+                    if not dry_run:
+                        if snapshot:
+                            d.snapshot()
+                        d.delete()
                     count += 1
                     print '{0},'.format(d.id)  # ... duplicate_deleted1, duplicate_deleted2, etc.
                     time.sleep(1)
@@ -65,4 +69,7 @@ if __name__ == "__main__":
 
     end = datetime.now()
     length = end - start
-    print "Ended {0}. {1} articles deleted. Took {2}.".format(end.isoformat(), count, str(length))
+    if dry_run:
+        print "Ended {0}. {1} articles would be deleted. Took {2}.".format(end.isoformat(), count, str(length))
+    else:
+        print "Ended {0}. {1} articles deleted. Took {2}.".format(end.isoformat(), count, str(length))

--- a/portality/scripts/remove_duplicate_articles.py
+++ b/portality/scripts/remove_duplicate_articles.py
@@ -5,6 +5,14 @@ take great care running it - at minimum double check there is a recent
 backup available, there should always be one anyway.
 """
 
+"""
+New functionality for issue 1296:
+* For each article does a global check to see if there are any other articles which are "duplicate"
+* Outputs each "set" of duplicate articles, along with the criteria for which they were determined duplicate
+* Further identifies articles which are duplicate within a single user's account
+* Identifies articles which appear in more than one "set" - that is, they may be duplicate with one set of articles by DOI, and duplicate with a different set by URL, etc
+"""
+
 from portality import models
 from portality.article import XWalk
 from portality.core import app


### PR DESCRIPTION
This is the first half of the article de-duplication work, covering improvements to the tests and a refactor of fetching duplicates.

This doesn't extend into the script required for #1296. It'll be easier to check that one based on this one.