### PR TITLE
Hotfix/2017 09 20 1376 reapp housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src*
 .Python
 build/*
 dist/*
+tmp/*
 
 # PyCharm and other IntelliJ-based IDE-s and editors' folder:
 .idea

--- a/portality/background.py
+++ b/portality/background.py
@@ -139,7 +139,7 @@ class BackgroundTask(object):
         Take an arbitrary set of keyword arguments and return an instance of a BackgroundJob,
         or fail with a suitable exception
 
-        :param user: the user creating the job
+        :param username: the user creating the job
         :param kwargs: arbitrary keyword arguments pertaining to this task type
         :return: a BackgroundJob instance representing this task
         """

--- a/portality/scripts/reapplication_reports.py
+++ b/portality/scripts/reapplication_reports.py
@@ -1,0 +1,25 @@
+"""
+Manually execute the reapplication reporting task
+"""
+from portality.background import BackgroundApi
+from portality.core import app
+from portality.lib import dates
+from portality.tasks import reapplication_reporting
+
+if __name__ == "__main__":
+
+    import argparse
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("-o", "--out",
+                        help="Output directory into which reports should be made (will be created if it doesn't exist)",
+                        default="reapplication_report_" + dates.today())
+    parser.add_argument("-e", "--email",
+                        help="Send zip archived reports to email addresses configured via REPORTS_EMAIL_TO in settings",
+                        action='store_true')
+    args = parser.parse_args()
+
+    user = app.config.get("SYSTEM_USERNAME")
+    job = reapplication_reporting.ReportingBackgroundTask.prepare(user, outdir=args.out, email=args.email)
+    task = reapplication_reporting.ReportingBackgroundTask(job)
+    BackgroundApi.execute(task)

--- a/portality/tasks/reapplication_reporting.py
+++ b/portality/tasks/reapplication_reporting.py
@@ -14,6 +14,7 @@ import codecs, os, shutil, re
 
 def reapplication_reports(outdir):
     pipeline = [
+        NoReapplicationReporter(),
         ContinuationNoteReporter(),
         TickReporter()
     ]
@@ -70,6 +71,16 @@ class JournalReporter(object):
         raise NotImplementedError()
 
 
+class NoReapplicationReporter(JournalReporter):
+
+    def test(self, j):
+        if j.current_application is None and not j.is_ticked():
+            self.include(j)
+
+    def filename(self):
+        return '2_journals_without_reapplications_on_' + dates.today() + '.csv'
+
+
 class ContinuationNoteReporter(JournalReporter):
 
     notes_regex = re.compile('^Continuation automatically extracted from journal .* during migration$', re.IGNORECASE)
@@ -80,7 +91,7 @@ class ContinuationNoteReporter(JournalReporter):
                 self.include(j)
 
     def filename(self):
-        return '3_continued_journals_on_' + dates.today() + '.csv'
+        return '3_journals_with_continued_note_on_' + dates.today() + '.csv'
 
 
 class TickReporter(JournalReporter):
@@ -90,7 +101,7 @@ class TickReporter(JournalReporter):
             self.include(j)
 
     def filename(self):
-        return '4_unticked_journals_on_' + dates.today() + '.csv'
+        return '4_journals_without_tick_on_' + dates.today() + '.csv'
 
 
 def email(data_dir, archv_name):

--- a/portality/tasks/reapplication_reporting.py
+++ b/portality/tasks/reapplication_reporting.py
@@ -14,6 +14,7 @@ import codecs, os, shutil, re
 
 def reapplication_reports(outdir):
     pipeline = [
+        RejectedReapplicationReporter(),
         NoReapplicationReporter(),
         ContinuationNoteReporter(),
         TickReporter()
@@ -69,6 +70,19 @@ class JournalReporter(object):
 
     def filename(self):
         raise NotImplementedError()
+
+
+class RejectedReapplicationReporter(JournalReporter):
+
+    def test(self, j):
+        if j.current_application is not None:
+            cur_app = models.Suggestion.pull(j.current_application)
+            if cur_app is not None:
+                if cur_app.current_journal and cur_app.application_status == 'rejected':        # rejected reapplication
+                    self.include(j)
+
+    def filename(self):
+        return '1_journals_with_rejected_reapplication_on_' + dates.today() + '.csv'
 
 
 class NoReapplicationReporter(JournalReporter):

--- a/portality/tasks/reapplication_reporting.py
+++ b/portality/tasks/reapplication_reporting.py
@@ -1,0 +1,422 @@
+""" Report on reapplications for issue https://github.com/DOAJ/doaj/issues/1376 - this is copy of reporting.py, but
+will be discarded in time as reapplications were a one-off. """
+
+from portality import models
+from portality.clcsv import UnicodeWriter
+from portality.lib import dates
+from portality import datasets
+from portality.core import app
+
+from portality.background import BackgroundApi, BackgroundTask
+from portality.tasks.redis_huey import main_queue, schedule
+from portality.decorators import write_required
+
+import codecs, os, shutil
+
+
+def provenance_reports(fr, to, outdir):
+    pipeline = []
+    pipeline.append(ActionCounter("edit", "month"))
+    pipeline.append(ActionCounter("edit", "year"))
+    pipeline.append(StatusCounter("month"))
+    pipeline.append(StatusCounter("year"))
+
+    q = ProvenanceList(fr, to)
+    for prov in models.Provenance.iterate(q.query()):
+        for filt in pipeline:
+            filt.count(prov)
+
+    outfiles = []
+    for p in pipeline:
+        table = p.tabulate()
+        outfile = os.path.join(outdir, p.filename(fr, to))
+        outfiles.append(outfile)
+        with codecs.open(outfile, "wb", "utf-8") as f:
+            writer = UnicodeWriter(f)
+            for row in table:
+                writer.writerow(row)
+
+    return outfiles
+
+
+def content_reports(fr, to, outdir):
+    report = {}
+
+    q = ContentByDate(fr, to)
+    res = models.Suggestion.query(q=q.query())
+    year_buckets = res.get("aggregations", {}).get("years", {}).get("buckets", [])
+    for years in year_buckets:
+        ds = years.get("key_as_string")
+        do = dates.parse(ds)
+        year = do.year
+        if year not in report:
+            report[year] = {}
+        country_buckets = years.get("countries", {}).get("buckets", [])
+        for country in country_buckets:
+            cc = country.get("key")
+            cn = datasets.get_country_name(cc)
+            if cn not in report[year]:
+                report[year][cn] = {}
+            count = country.get("doc_count")
+            report[year][cn]["count"] = count
+
+    table = _tabulate_time_entity_group(report, "Country")
+
+    filename = "applications_by_year_by_country__" + _fft(fr) + "_to_" + _fft(to) + "__on_" + dates.today() + ".csv"
+    outfiles = []
+    outfile = os.path.join(outdir, filename)
+    outfiles.append(outfile)
+    with codecs.open(outfile, "wb", "utf-8") as f:
+        writer = UnicodeWriter(f)
+        for row in table:
+            writer.writerow(row)
+
+    return outfiles
+
+
+def _tabulate_time_entity_group(group, entityKey):
+    date_keys = group.keys()
+    date_keys.sort()
+    table = []
+    padding = []
+    for db in date_keys:
+        users = group[db].keys()
+        for u in users:
+            c = group[db][u]["count"]
+            existing = False
+            for row in table:
+                if row[0] == u:
+                    row.append(c)
+                    existing = True
+            if not existing:
+                table.append([u] + padding + [c])
+        padding.append(0)
+
+    for row in table:
+        if len(row) < len(date_keys) + 1:
+            row += [0] * (len(date_keys) - len(row) + 1)
+
+    table.sort(key=lambda user: user[0])
+    table = [[entityKey] + date_keys] + table
+    return table
+
+
+def _fft(timestamp):
+    """File Friendly Timestamp - Windows doesn't appreciate : / etc in filenames; strip these out"""
+    return dates.reformat(timestamp, app.config.get("DEFAULT_DATE_FORMAT"), "%Y-%m-%d")
+
+
+class ReportCounter(object):
+    def __init__(self, period):
+        self.period = period
+
+    def _flatten_timestamp(self, ts):
+        if self.period == "month":
+            return ts.strftime("%Y-%m")
+        elif self.period == "year":
+            return ts.strftime("%Y")
+
+    def count(self, prov):
+        raise NotImplementedError()
+
+    def tabulate(self):
+        raise NotImplementedError()
+
+    def filename(self, fr, to):
+        raise NotImplementedError()
+
+
+class ActionCounter(ReportCounter):
+    def __init__(self, action, period):
+        self.action = action
+        self.report = {}
+        self._last_period = None
+        super(ActionCounter, self).__init__(period)
+
+    def count(self, prov):
+        if prov.action != self.action:
+            return
+
+        p = self._flatten_timestamp(prov.created_timestamp)
+        if p not in self.report:
+            self.report[p] = {}
+
+        if prov.user not in self.report[p]:
+            self.report[p][prov.user] = {"ids" : []}
+
+        if prov.resource_id not in self.report[p][prov.user]["ids"]:
+            self.report[p][prov.user]["ids"].append(prov.resource_id)
+
+        if p != self._last_period:
+            self._count_down(self._last_period)
+            self._last_period = p
+
+    def tabulate(self):
+        self._count_down(self._last_period)
+        return _tabulate_time_entity_group(self.report, "User")
+
+    def filename(self, fr, to):
+        return self.action + "_by_" + self.period + "__from_" + _fft(fr) + "_to_" + _fft(to) + "__on_" + dates.today() + ".csv"
+
+    def _count_down(self, p):
+        if p is None:
+            return
+        for k in self.report[p].keys():
+            self.report[p][k]["count"] = len(self.report[p][k]["ids"])
+            del self.report[p][k]["ids"]
+
+
+class StatusCounter(ReportCounter):
+    def __init__(self, period):
+        self.report = {}
+        self._last_period = None
+        super(StatusCounter, self).__init__(period)
+
+    def count(self, prov):
+        if not prov.action.startswith("status:"):
+            return
+
+        best_role = self._get_best_role(prov.roles)
+        countable = self._is_countable(prov, best_role)
+
+        if not countable:
+            return
+
+        p = self._flatten_timestamp(prov.created_timestamp)
+        if p not in self.report:
+            self.report[p] = {}
+
+        if prov.user not in self.report[p]:
+            self.report[p][prov.user] = {"ids" : []}
+
+        if prov.resource_id not in self.report[p][prov.user]["ids"]:
+            self.report[p][prov.user]["ids"].append(prov.resource_id)
+
+        if p != self._last_period:
+            self._count_down(self._last_period)
+            self._last_period = p
+
+
+    def _get_best_role(self, roles):
+        role_precedence = ["associate_editor", "editor", "admin"]
+        best_role = None
+        for r in roles:
+            try:
+                if best_role is None and r in role_precedence:
+                    best_role = r
+                if role_precedence.index(r) > role_precedence.index(best_role):
+                    best_role = r
+            except ValueError:
+                pass                            # The user has a role not in our precedence list (e.g. api) - ignore it.
+
+        return best_role
+
+
+    def _is_countable(self, prov, role):
+        countable = False
+
+        if role == "admin" and (prov.action == "status:accepted" or prov.action == "status:rejected"):
+            countable = True
+        elif role == "editor" and prov.action == "status:ready":
+            countable = True
+        elif role == "associate_editor" and prov.action == "status:completed":
+            countable = True
+
+        return countable
+
+
+    def tabulate(self):
+        self._count_down(self._last_period)
+        return _tabulate_time_entity_group(self.report, "User")
+
+    def filename(self, fr, to):
+        return "completion_by_" + self.period + "__from_" + _fft(fr) + "_to_" + _fft(to) + "__on_" + dates.today() + ".csv"
+
+    def _count_down(self, p):
+        if p is None:
+            return
+        for k in self.report[p].keys():
+            self.report[p][k]["count"] = len(self.report[p][k]["ids"])
+            del self.report[p][k]["ids"]
+
+
+class ProvenanceList(object):
+    def __init__(self, fr, to):
+        self.fr = fr
+        self.to = to
+
+    def query(self):
+        return {
+            "query" : {
+                "bool" : {
+                    "must" : [
+                        {"range" : {"created_date" : {"gt" : self.fr, "lte" : self.to}}}
+                    ]
+                }
+            },
+            "sort" : [{"created_date" : {"order" : "asc"}}]
+        }
+
+
+class ContentByDate(object):
+    def __init__(self, fr, to):
+        self.fr = fr
+        self.to = to
+
+    def query(self):
+        return {
+            "query" : {
+                "bool" : {
+                    "must" : [
+                        {"range" : {"created_date" : {"gt" : self.fr, "lte" : self.to}}}
+                    ]
+                }
+            },
+            "size" : 0,
+            "aggs" : {
+                "years" : {
+                    "date_histogram" : {
+                        "field" : "created_date",
+                        "interval" : "year"
+                    },
+                    "aggs" : {
+                        "countries" : {
+                            "terms" : {
+                                "field" : "bibjson.country.exact",
+                                "size" : 1000
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
+def email(data_dir, archv_name):
+    """
+    Compress and email the reports to the specified email address.
+    :param data_dir: Directory containing the reports
+    :param archv_name: Filename for the archive and resulting email attachment
+    """
+    import shutil
+    from portality import app_email
+    from portality.core import app
+
+    email_to = app.config.get('REPORTS_EMAIL_TO', ['feedback@doaj.org'])
+    email_from = app.config.get('SYSTEM_EMAIL_FROM', 'feedback@doaj.org')
+    email_sub = app.config.get('SERVICE_NAME', '') + ' - generated {0}'.format(archv_name)
+    msg = "Attached: {0}.zip\n".format(archv_name)
+
+    # Create an archive of the reports
+    archv = shutil.make_archive(archv_name, "zip", root_dir=data_dir)
+
+    # Read the archive to create an attachment, send it with the app email
+    with open(archv) as f:
+        dat = f.read()
+        attach = [app_email.make_attachment(filename=archv_name, content_type='application/zip', data=dat)]
+        app_email.send_mail(to=email_to, fro=email_from, subject=email_sub, msg_body=msg, files=attach)
+
+    # Clean up the archive
+    os.remove(archv)
+
+
+#########################################################
+# Background task implementation
+
+class ReportingBackgroundTask(BackgroundTask):
+
+    __action__ = "reporting"
+
+    def run(self):
+        """
+        Execute the task as specified by the background_jon
+        :return:
+        """
+        job = self.background_job
+        params = job.params
+
+        outdir = self.get_param(params, "outdir", "report_" + dates.now())
+        fr = self.get_param(params, "from", "1970-01-01T00:00:00Z")
+        to = self.get_param(params, "to", dates.now())
+
+        job.add_audit_message("Saving reports to " + outdir)
+        if not os.path.exists(outdir):
+            os.makedirs(outdir)
+
+        prov_outfiles = provenance_reports(fr, to, outdir)
+        cont_outfiles = content_reports(fr, to, outdir)
+        refs = {}
+        self.set_reference(refs, "provenance_outfiles", prov_outfiles)
+        self.set_reference(refs, "content_outfiles", cont_outfiles)
+        job.reference = refs
+
+        msg = u"Generated reports for period {x} to {y}".format(x=fr, y=to)
+        job.add_audit_message(msg)
+
+        send_email = self.get_param(params, "email", False)
+        if send_email:
+            ref_fr = dates.reformat(fr, app.config.get("DEFAULT_DATE_FORMAT"), "%Y-%m-%d")
+            ref_to = dates.reformat(to, app.config.get("DEFAULT_DATE_FORMAT"), "%Y-%m-%d")
+            archive_name = "reports_" + ref_fr + "_to_" + ref_to
+            email(outdir, archive_name)
+            job.add_audit_message("email alert sent")
+        else:
+            job.add_audit_message("no email alert sent")
+
+    def cleanup(self):
+        """
+        Cleanup after a successful OR failed run of the task
+        :return:
+        """
+        failed = self.background_job.is_failed()
+        if not failed:
+            return
+
+        params = self.background_job.params
+        outdir = self.get_param(params, "outdir")
+
+        if outdir is not None and os.path.exists(outdir):
+            shutil.rmtree(outdir)
+
+        self.background_job.add_audit_message(u"Deleted directory {x} due to job failure".format(x=outdir))
+
+    @classmethod
+    def prepare(cls, username, **kwargs):
+        """
+        Take an arbitrary set of keyword arguments and return an instance of a BackgroundJob,
+        or fail with a suitable exception
+
+        :param username: user to run this job as
+        :param kwargs: arbitrary keyword arguments pertaining to this task type
+        :return: a BackgroundJob instance representing this task
+        """
+
+        job = models.BackgroundJob()
+        job.user = username
+        job.action = cls.__action__
+
+        params = {}
+        cls.set_param(params, "outdir", kwargs.get("outdir", "reapplication_report_" + dates.today()))
+        cls.set_param(params, "email", kwargs.get("email", False))
+        job.params = params
+
+        return job
+
+    @classmethod
+    def submit(cls, background_job):
+        """
+        Submit the specified BackgroundJob to the background queue
+
+        :param background_job: the BackgroundJob instance
+        :return:
+        """
+        background_job.save()
+        run_reports.schedule(args=(background_job.id,), delay=10)
+
+
+@main_queue.task()
+@write_required(script=True)
+def run_reports(job_id):
+    job = models.BackgroundJob.pull(job_id)
+    task = ReportingBackgroundTask(job)
+    BackgroundApi.execute(task)


### PR DESCRIPTION
Mostly a copy of ```reports.py```, but with scheduling removed and the reports changed. Run with:

    python portality/scripts/reapplication_reports.py -o <path_to_empty_dir> -e

and it will email the reports as well as store them in the directory specified. Multiple runs on the same day and target will overwrite the files. Example files as emailed are here (generated from my dev env):
[reapplication_reports_2017-09-22.zip](https://github.com/DOAJ/doaj/files/1325111/reapplication_reports_2017-09-22.zip)

For issue #1376 

## HOTFIX