### PR TITLE
detect when an LCC subject is incorrectly spelled (or not in the clas…

### DIFF
--- a/portality/models/article.py
+++ b/portality/models/article.py
@@ -463,7 +463,9 @@ class Article(DomainObject):
             scheme = subs.get("scheme")
             term = subs.get("term")
             if scheme == "LCC":
-                classification_paths.append(lcc.pathify(term))
+                path = lcc.pathify(term)
+                if path is not None:
+                    classification_paths.append(path)
 
         # normalise the classification paths, so we only store the longest ones
         classification_paths = lcc.longest(classification_paths)


### PR DESCRIPTION
…sification at all) and just ignore it when creating the indexed data for the search interface and subject browser.  Also adds a test for the case where the classification is not correct

This is the first essential part of a fix for #1390 