### PR TITLE
introduce a short piece of javascript to disable the submit button on…

### DIFF
--- a/portality/settings.py
+++ b/portality/settings.py
@@ -8,7 +8,7 @@ READ_ONLY_MODE = False
 # This puts the cron jobs into READ_ONLY mode
 SCRIPTS_READ_ONLY_MODE = False
 
-DOAJ_VERSION = "2.11.5"
+DOAJ_VERSION = "2.11.6"
 
 OFFLINE_MODE = False
 

--- a/portality/static/doaj/js/suggestions_and_journals.js
+++ b/portality/static/doaj/js/suggestions_and_journals.js
@@ -154,7 +154,11 @@ jQuery(document).ready(function($) {
     $("#editor_group").change(function(event) {
         event.preventDefault();
         $("#editor").html("<option val='' selected='selected'></option>")
-    })
+    });
+
+    $(".application_journal_form").bind("submit", function(event) {
+        $(".save-record").attr("disabled", "disabled");
+    });
 });
 
 function setup_subject_tree() {

--- a/portality/static/doaj/js/suggestions_and_journals.js
+++ b/portality/static/doaj/js/suggestions_and_journals.js
@@ -156,7 +156,7 @@ jQuery(document).ready(function($) {
         $("#editor").html("<option val='' selected='selected'></option>")
     });
 
-    $(".application_journal_form").bind("submit", function(event) {
+    $(".application_journal_form").on("submit", function(event) {
         $(".save-record").attr("disabled", "disabled");
     });
 });

--- a/portality/templates/formcontext/assed_application_review.html
+++ b/portality/templates/formcontext/assed_application_review.html
@@ -8,7 +8,7 @@
 {% set heading_object_type = 'Application' %}
 {% include 'formcontext/_lockable_header.html' %}
 
-<form method="post" action="#first_problem" class="form-horizontal wide" id="suggest_form">
+<form method="post" action="#first_problem" class="form-horizontal wide application_journal_form" id="suggest_form">
     {% if form_context.errors %}
     <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
@@ -23,7 +23,7 @@
                     <div class="span12 with-borders form-section" style="margin-left: 0;">
                         <div class="control-group">
                             <div class="controls">
-                                <button class="btn btn-success" type="submit">SAVE</button>
+                                <button class="btn btn-success save-record" type="submit">SAVE</button>
                             </div>
                         </div>
                     </div>
@@ -74,7 +74,7 @@
                 {% endautoescape %}
                 <div class="control-group">
                     <div class="controls">
-                        <button class="btn btn-success" type="submit">
+                        <button class="btn btn-success save-record" type="submit">
                             SAVE
                         </button>
                     </div>

--- a/portality/templates/formcontext/assed_journal_review.html
+++ b/portality/templates/formcontext/assed_journal_review.html
@@ -8,7 +8,7 @@
 {% set heading_object_type = 'Journal' %}
 {% include 'formcontext/_lockable_header.html' %}
 
-<form method="post" action="#first_problem" class="form-horizontal wide" id="suggest_form">
+<form method="post" action="#first_problem" class="form-horizontal wide application_journal_form" id="suggest_form">
     {% if form_context.errors %}
     <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
@@ -23,7 +23,7 @@
                     <div class="span12 with-borders form-section" style="margin-left: 0;">
                         <div class="control-group">
                             <div class="controls">
-                                <button class="btn btn-success" type="submit">SAVE</button>
+                                <button class="btn btn-success save-record" type="submit">SAVE</button>
                             </div>
                         </div>
                     </div>
@@ -71,7 +71,7 @@
             <div class="span6 with-borders form-section">
                 <div class="control-group">
                     <div class="controls">
-                        <button class="btn btn-success" type="submit">
+                        <button class="btn btn-success save-record" type="submit">
                             SAVE
                         </button>
                     </div>

--- a/portality/templates/formcontext/editor_application_review.html
+++ b/portality/templates/formcontext/editor_application_review.html
@@ -8,7 +8,7 @@
 {% set heading_object_type = 'Application' %}
 {% include 'formcontext/_lockable_header.html' %}
 
-<form method="post" action="#first_problem" class="form-horizontal wide" id="suggest_form">
+<form method="post" action="#first_problem" class="form-horizontal wide application_journal_form" id="suggest_form">
     {% if form_context.errors %}
     <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
@@ -31,7 +31,7 @@
                     <div class="span12 with-borders form-section" style="margin-left: 0;">
                         <div class="control-group">
                             <div class="controls">
-                                <button class="btn btn-success" type="submit">SAVE</button>
+                                <button class="btn btn-success save-record" type="submit">SAVE</button>
                             </div>
                         </div>
                     </div>
@@ -82,7 +82,7 @@
                 {% endautoescape %}
                 <div class="control-group">
                     <div class="controls">
-                        <button class="btn btn-success" type="submit">
+                        <button class="btn btn-success save-record" type="submit">
                             SAVE
                         </button>
                     </div>

--- a/portality/templates/formcontext/editor_journal_review.html
+++ b/portality/templates/formcontext/editor_journal_review.html
@@ -8,7 +8,7 @@
 {% set heading_object_type = 'Journal' %}
 {% include 'formcontext/_lockable_header.html' %}
 
-<form method="post" action="#first_problem" class="form-horizontal wide" id="suggest_form">
+<form method="post" action="#first_problem" class="form-horizontal wide application_journal_form" id="suggest_form">
     {% if form_context.errors %}
     <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
@@ -31,7 +31,7 @@
                     <div class="span12 with-borders form-section" style="margin-left: 0;">
                         <div class="control-group">
                             <div class="controls">
-                                <button class="btn btn-success" type="submit">SAVE</button>
+                                <button class="btn btn-success save-record" type="submit">SAVE</button>
                             </div>
                         </div>
                     </div>
@@ -79,7 +79,7 @@
             <div class="span6 with-borders form-section">
                 <div class="control-group">
                     <div class="controls">
-                        <button class="btn btn-success" type="submit">
+                        <button class="btn btn-success save-record" type="submit">
                             SAVE
                         </button>
                     </div>

--- a/portality/templates/formcontext/maned_application_review.html
+++ b/portality/templates/formcontext/maned_application_review.html
@@ -8,7 +8,7 @@
 {% set heading_object_type = 'Application' %}
 {% include 'formcontext/_lockable_header.html' %}
 
-<form method="post" action="#first_problem" class="form-horizontal wide" id="suggest_form">
+<form method="post" action="#first_problem" class="form-horizontal wide application_journal_form" id="suggest_form">
     {% if form_context.errors %}
     <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
@@ -31,7 +31,7 @@
                     <div class="span12 with-borders form-section" style="margin-left: 0;">
                         <div class="control-group">
                             <div class="controls">
-                                <button class="btn btn-success" type="submit">SAVE</button>
+                                <button class="btn btn-success save-record" type="submit">SAVE</button>
                             </div>
                         </div>
                     </div>
@@ -95,7 +95,7 @@
                 {% endautoescape %}
                 <div class="control-group">
                     <div class="controls">
-                        <button class="btn btn-success" type="submit">
+                        <button class="btn btn-success save-record" type="submit">
                             SAVE
                         </button>
                     </div>

--- a/portality/templates/formcontext/maned_journal_review.html
+++ b/portality/templates/formcontext/maned_journal_review.html
@@ -43,7 +43,7 @@
   </div>
 </div>
 
-<form method="post" action="#first_problem" class="form-horizontal wide" id="suggest_form">
+<form method="post" action="#first_problem" class="form-horizontal wide application_journal_form" id="suggest_form">
     {% if form_context.errors %}
     <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
@@ -66,7 +66,7 @@
                     <div class="span12 with-borders form-section" style="margin-left: 0;">
                         <div class="control-group">
                             <div class="controls">
-                                <button class="btn btn-success" type="submit">SAVE</button>
+                                <button class="btn btn-success save-record" type="submit">SAVE</button>
                             </div>
                             
                             {% autoescape off %}
@@ -140,7 +140,7 @@
             <div class="span6 with-borders form-section">
                 <div class="control-group">
                     <div class="controls">
-                        <button class="btn btn-success" type="submit">
+                        <button class="btn btn-success save-record" type="submit">
                             SAVE
                         </button>
                     </div>

--- a/portality/templates/formcontext/public_application_form.html
+++ b/portality/templates/formcontext/public_application_form.html
@@ -23,7 +23,7 @@ where a single publisher has submitted more than 5 applications with false infor
 all of the publisher's journals and to not accept any more applications for a maximum period of 3 years, depending on 
 the number of journals for which false information was provided and the eventual number of repeated incidents.</p>
 
-<form method="post" action="#first_problem" class="form-horizontal wide" id="suggest_form">
+<form method="post" action="#first_problem" class="form-horizontal wide application_journal_form" id="suggest_form">
     {% if form_context.errors %}
         <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
@@ -43,7 +43,7 @@ the number of journals for which false information was provided and the eventual
 
                 <div class="control-group">
                     <div class="controls">
-                        <button class="btn btn-success" type="submit">
+                        <button class="btn btn-success save-record" type="submit">
                             SUBMIT
                         </button>
                     </div>

--- a/portality/templates/formcontext/publisher_reapplication.html
+++ b/portality/templates/formcontext/publisher_reapplication.html
@@ -13,7 +13,7 @@ do not know the answer to a question, you can request help by contacting us.</p>
 <p>Guides to completing the form are available in <a href="{{ url_for('doaj.translated') }}">other
 languages</a>.</p>
 
-<form method="post" action="#first_problem" class="form-horizontal wide" id="suggest_form">
+<form method="post" action="#first_problem" class="form-horizontal wide application_journal_form" id="suggest_form">
     {% if form_context.errors %}
         <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}
@@ -28,7 +28,7 @@ languages</a>.</p>
             <div class="span6 with-borders form-section">
                 <div class="control-group">
                     <div class="controls">
-                        <button class="btn btn-success" type="submit">
+                        <button class="btn btn-success save-record" type="submit">
                             SUBMIT
                         </button>
                     </div>

--- a/portality/templates/formcontext/readonly_journal.html
+++ b/portality/templates/formcontext/readonly_journal.html
@@ -8,7 +8,7 @@
 {% set heading_object_type = 'Journal' %}
 {% include 'formcontext/_lockable_header.html' %}
 
-<form method="post" action="#first_problem" class="form-horizontal wide" id="suggest_form">
+<form method="post" action="#first_problem" class="form-horizontal wide application_journal_form" id="suggest_form">
     {% if form_context.errors %}
     <h4 class="red form-status">There is a problem with the submitted form.</h4>
     {% endif %}


### PR DESCRIPTION
… journal and application form pages when it is pressed.  This prevents second accidental clicks, which may result in duplicating behaviour.

I have applied this to all the forms, not just the managing editor form, where the problem noted in #1413 first materialised.

Since a submit of the form is always followed by a page reload, there's no need to have a mechanism to re-enable the button - the page reload does this.