### PR TITLE
Hotfix/2017 11 07 1390 lcc regen subjects

### DIFF
--- a/portality/migrate/1390_lcc_regen_subjects/operations.py
+++ b/portality/migrate/1390_lcc_regen_subjects/operations.py
@@ -1,0 +1,15 @@
+from portality import models
+
+
+def refresh_subjects(record):
+    """ Using the GenericBibjson we can fix the subjects on journals, applications and articles with this function """
+    bj = record.bibjson()
+    assert isinstance(bj, models.GenericBibJSON)
+    old_subjects = bj.subjects()
+    bj.remove_subjects()
+
+    new_subjects = []
+    for s in old_subjects:
+        # Do stuff
+        new_subjects.append(s)
+    return record

--- a/portality/migrate/1390_lcc_regen_subjects/operations.py
+++ b/portality/migrate/1390_lcc_regen_subjects/operations.py
@@ -14,10 +14,13 @@ def refresh_subjects(record):
             sobj = {"scheme": u'LCC', "term": lcc.lookup_code(s['code']), "code": s['code']}
             new_subjects.append(sobj)
         except KeyError:
-            # Subject has no code, that's fine, let's have a look at it
-            print "Missing code:", s
+            # Carry over the DOAJ schema subjects
+            if 'scheme' in s and s['scheme'] is 'DOAJ':
+                new_subjects.append(s)
+            else:
+                print "Missing code:", s
 
     bj.set_subjects(new_subjects)
-    if bj.subjects() != record.bibjson().subjects():
-        print 'WHAT', bj.subjects()
+    if old_subjects != record.bibjson().subjects():
+        print '{0} Changed.\nold: {1}\nnew: {2}'.format(record['id'], old_subjects, record.bibjson().subjects())
     return record

--- a/portality/migrate/1390_lcc_regen_subjects/operations.py
+++ b/portality/migrate/1390_lcc_regen_subjects/operations.py
@@ -15,7 +15,7 @@ def refresh_subjects(record):
             new_subjects.append(sobj)
         except KeyError:
             # Carry over the DOAJ schema subjects
-            if 'scheme' in s and s['scheme'] is 'DOAJ':
+            if 'scheme' in s and s['scheme'] == 'DOAJ':
                 new_subjects.append(s)
             else:
                 print "Missing code:", s

--- a/portality/migrate/1390_lcc_regen_subjects/operations.py
+++ b/portality/migrate/1390_lcc_regen_subjects/operations.py
@@ -1,4 +1,4 @@
-from portality import models
+from portality import models, lcc
 
 
 def refresh_subjects(record):
@@ -10,6 +10,14 @@ def refresh_subjects(record):
 
     new_subjects = []
     for s in old_subjects:
-        # Do stuff
-        new_subjects.append(s)
+        try:
+            sobj = {"scheme": u'LCC', "term": lcc.lookup_code(s['code']), "code": s['code']}
+            new_subjects.append(sobj)
+        except KeyError:
+            # Subject has no code, that's fine, let's have a look at it
+            print "Missing code:", s
+
+    bj.set_subjects(new_subjects)
+    if bj.subjects() != record.bibjson().subjects():
+        print 'WHAT', bj.subjects()
     return record

--- a/portality/migrate/1390_lcc_regen_subjects/readme.md
+++ b/portality/migrate/1390_lcc_regen_subjects/readme.md
@@ -1,0 +1,9 @@
+#### ```filename```
+*S.E. 2017-11-07*
+
+Fix for issue 1390 - incorrectly spelled subjects affecting discovery.
+Refresh the subject name saved on journals, applications, article bibjson.
+
+Run
+
+    python portality/upgrade.py -u portality/migrate/1390_lcc_regen_subjects/publisher_struct.json

--- a/portality/migrate/1390_lcc_regen_subjects/readme.md
+++ b/portality/migrate/1390_lcc_regen_subjects/readme.md
@@ -6,4 +6,4 @@ Refresh the subject name saved on journals, applications, article bibjson.
 
 Run
 
-    python portality/upgrade.py -u portality/migrate/1390_lcc_regen_subjects/publisher_struct.json
+    python portality/upgrade.py -u portality/migrate/1390_lcc_regen_subjects/regen_subjects.json

--- a/portality/migrate/1390_lcc_regen_subjects/regen_subjects.json
+++ b/portality/migrate/1390_lcc_regen_subjects/regen_subjects.json
@@ -1,0 +1,28 @@
+{
+	"types": [
+		{
+			"type" : "suggestion",
+			"init_with_model" : true,
+			"keepalive" : "1m",
+			"functions" : [
+				"portality.migrate.1390_lcc_regen_subjects.operations.refresh_subjects"
+			]
+		},
+		{
+			"type": "journal",
+			"init_with_model": true,
+			"keepalive": "1m",
+			"functions" : [
+				"portality.migrate.1390_lcc_regen_subjects.operations.refresh_subjects"
+			]
+		},
+        {
+            "type": "article",
+			"init_with_model": true,
+			"keepalive": "1m",
+			"functions" : [
+				"portality.migrate.1390_lcc_regen_subjects.operations.refresh_subjects"
+			]
+        }
+	]
+}

--- a/portality/upgrade.py
+++ b/portality/upgrade.py
@@ -124,9 +124,10 @@ if __name__ == "__main__":
     with open(args.upgrade) as f:
         try:
             instructions = json.loads(f.read(), object_pairs_hook=OrderedDict)
-            do_upgrade(instructions, args.verbose)
         except:
             print args.upgrade, "does not parse as JSON"
             exit()
+
+        do_upgrade(instructions, args.verbose)
 
     print 'Finished {0}.'.format(datetime.now())

--- a/portality/upgrade.py
+++ b/portality/upgrade.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from portality.core import app
 from portality import models
 from portality.lib import plugin
+from portality.lib.dataobj import DataStructureException
 
 MODELS = {
     "journal" : models.Journal,
@@ -53,7 +54,11 @@ def do_upgrade(definition, verbose):
 
             if tdef.get("init_with_model", True):
                 # instantiate an object with the data
-                result = model_class(**result)
+                try:
+                    result = model_class(**result)
+                except DataStructureException as e:
+                    print "Could not create model for {0}, Error: {1}".format(result['id'], e.message)
+                    continue
 
             for function_path in tdef.get("functions", []):
                 fn = plugin.load_function(function_path)

--- a/portality/upgrade.py
+++ b/portality/upgrade.py
@@ -27,15 +27,15 @@ def do_upgrade(definition, verbose):
 
     if source is None:
         source = {
-            "host" : app.config.get("ELASTIC_SEARCH_HOST"),
-            "index" : app.config.get("ELASTIC_SEARCH_DB")
+            "host": app.config.get("ELASTIC_SEARCH_HOST"),
+            "index": app.config.get("ELASTIC_SEARCH_DB")
         }
 
     if target is None:
         target = {
-            "host" : app.config.get("ELASTIC_SEARCH_HOST"),
-            "index" : app.config.get("ELASTIC_SEARCH_DB"),
-            "mappings" : False
+            "host": app.config.get("ELASTIC_SEARCH_HOST"),
+            "index": app.config.get("ELASTIC_SEARCH_DB"),
+            "mappings": False
         }
 
     sconn = esprit.raw.Connection(source.get("host"), source.get("index"))
@@ -68,7 +68,7 @@ def do_upgrade(definition, verbose):
                 result = fn(result)
 
             data = result
-            id = result.get("id", "id not specified")
+            _id = result.get("id", "id not specified")
             if isinstance(result, model_class):
                 # run the tasks specified with this object type
                 tasks = tdef.get("tasks", None)
@@ -85,12 +85,12 @@ def do_upgrade(definition, verbose):
                     pass
 
                 data = result.data
-                id = result.id
+                _id = result.id
 
             # add the data to the batch
             batch.append(data)
             if verbose:
-                print "added", tdef.get("type"), id, "to batch update"
+                print "added", tdef.get("type"), _id, "to batch update"
 
             # When we have enough, do some writing
             if len(batch) >= batch_size:

--- a/portality/upgrade.py
+++ b/portality/upgrade.py
@@ -1,4 +1,5 @@
 import json, os, esprit
+from datetime import datetime
 from collections import OrderedDict
 from portality.core import app
 from portality import models
@@ -6,16 +7,18 @@ from portality.lib import plugin
 from portality.lib.dataobj import DataStructureException
 
 MODELS = {
-    "journal" : models.Journal,
-    "article" : models.Article,
-    "suggestion" : models.Suggestion,
-    "account" : models.Account
+    "journal": models.Journal,
+    "article": models.Article,
+    "suggestion": models.Suggestion,
+    "account": models.Account
 }
+
 
 class UpgradeTask(object):
 
     def upgrade_article(self, article):
         pass
+
 
 def do_upgrade(definition, verbose):
     # get the source and target es definitions
@@ -116,11 +119,14 @@ if __name__ == "__main__":
         print args.upgrade, "does not exist or is not a file"
         exit()
 
+    print 'Starting {0}.'.format(datetime.now())
+
     with open(args.upgrade) as f:
         try:
-            definition = json.loads(f.read(), object_pairs_hook=OrderedDict)
+            instructions = json.loads(f.read(), object_pairs_hook=OrderedDict)
+            do_upgrade(instructions, args.verbose)
         except:
             print args.upgrade, "does not parse as JSON"
             exit()
 
-        do_upgrade(definition, args.verbose)
+    print 'Finished {0}.'.format(datetime.now())


### PR DESCRIPTION
The migration for #1390 - fixing spelling errors in Applications, Journals and Articles' LCC subject categories in the bibjson. Expected output:

```
Running in dev
Loaded final config from /Users/steve/code/cl/doaj/src/doaj/dev.cfg
Starting 2017-11-09 17:20:54.987763.
Upgrading suggestion
writing  500 to suggestion
writing  500 to suggestion
0c1e4e44533e405db9a4a4fdddb7c864 Changed.
old: [{'code': u'H', 'term': u'WRONG SPELLING', 'scheme': u'LCC'}, {'term': u'Carry over', 'scheme': u'DOAJ'}]
new: [{'code': u'H', 'term': u'Social Sciences', 'scheme': u'LCC'}, {'term': u'Carry over', 'scheme': u'DOAJ'}]
...
```

To test this (on a disposable index), the following edit to your index might be useful. You may need to change the ID to a different application:

```
curl -X POST \
  http://localhost:9200/doaj/suggestion/0c1e4e44533e405db9a4a4fdddb7c864/_update \
  -H 'cache-control: no-cache' \
  -d '{
    "doc": {
    	"bibjson": {
        	"subject": [
                {
                    "code": "H",
                    "term": "WRONG SPELLING",
                    "scheme": "LCC"
                },
                {
                	"term": "Carry over",
                    "scheme": "DOAJ"
                }
            ]
    	},
    	"index": {
    		"classification_paths": [
    			"WRONG SPELLING"
    		],
    		"classification": [
    			"WRONG SPELLING"
    		]
    	}
    }
}'
```

The same cURL body can be used for a Journal and Article, too. The ```DOAJ``` scheme code should be carried over to the new record along with a corrected spelling of the ```LCC``` category, in this case, **Social Sciences**. The changes to the index are overwritten by the ```prep()``` method when the model is saved in the upgrade script. 

The script is run as stated in the readme thusly:

    python portality/upgrade.py -u portality/migrate/1390_lcc_regen_subjects/regen_subjects.json

The script is expected to run for a long time, since it runs on all articles.