### PR TITLE
Feature/1296 cautious deletes

### DIFF
--- a/portality/article.py
+++ b/portality/article.py
@@ -156,10 +156,12 @@ class XWalk(object):
         if len(dois) > 0:
             # there should only be the one
             doi = dois[0]
-            articles = models.Article.duplicates(issns=issns, doi=doi)
-            possible_articles['doi'] = [a for a in articles if a.id != article.id]
-            if possible_articles['doi']:
-                found = True
+            # Only perform de-duplication on genuine DOIs - todo: do we need a full regex check?
+            if isinstance(doi, str) and doi.startswith('10.'):
+                articles = models.Article.duplicates(issns=issns, doi=doi)
+                possible_articles['doi'] = [a for a in articles if a.id != article.id]
+                if possible_articles['doi']:
+                    found = True
 
         # Second test is to look by fulltext url
         urls = b.get_urls(b.FULLTEXT)

--- a/portality/article.py
+++ b/portality/article.py
@@ -156,11 +156,11 @@ class XWalk(object):
         if len(dois) > 0:
             # there should only be the one
             doi = dois[0]
-            # Only perform de-duplication on genuine DOIs - todo: do we need a full regex check?
-            if isinstance(doi, str) and doi.startswith('10.'):
+            # Only perform de-duplication on genuine DOIs
+            if isinstance(doi, basestring) and doi.startswith('10.'):
                 articles = models.Article.duplicates(issns=issns, doi=doi)
                 possible_articles['doi'] = [a for a in articles if a.id != article.id]
-                if possible_articles['doi']:
+                if len(possible_articles['doi']) > 0:
                     found = True
 
         # Second test is to look by fulltext url

--- a/portality/scripts/article_duplicates_report_remove.py
+++ b/portality/scripts/article_duplicates_report_remove.py
@@ -43,8 +43,12 @@ def duplicates_per_article(connection, delete, snapshot, owner=None, query_overr
             if fulltext_dups:
                 print "\t{0} fulltext duplicates: {1}".format(len(fulltext_dups), ", ".join(fulltext_dups))
 
-            set_of_duplicates = set(doi_dups + fulltext_dups)
+            # Only consider duplicates that appear in both lists (we should be cautious with deletes)
+            set_of_duplicates = set(doi_dups).intersection(set(fulltext_dups))
             dupcount += len(set_of_duplicates) + 1                     # The detected duplicates plus the article itself
+
+            if set_of_duplicates:
+                print "\t{0} in intersection: {1}".format(len(set_of_duplicates), ", ".join(set_of_duplicates))
 
             if delete:
                 for dup in set_of_duplicates:


### PR DESCRIPTION
#1296 - Only auto-delete duplicate articles when they are both DOI and full text duplicates.
Make the duplicate detection function a little more discerning when it comes to matching DOIs: they should actually look like DOIs.