### PR TITLE
extend reporting to properly report on possible failed reapplications

### DIFF
--- a/portality/scripts/inconsistent_journal_prov_application.py
+++ b/portality/scripts/inconsistent_journal_prov_application.py
@@ -180,6 +180,6 @@ PROV_QUERY = {
 
 if __name__ == "__main__":
     print 'Starting {0}.'.format(datetime.now())
-    # applications_inconsistencies("apps_with_prov.csv", "apps_accepted_without_journals.csv", local)
+    applications_inconsistencies("apps_with_prov.csv", "apps_accepted_without_journals.csv", local)
     journals_applications_provenance("journals_applications_provenance.csv", "journals_no_accounts.csv", "journals_reapp_fails.csv", local)
     print 'Finished {0}.'.format(datetime.now())


### PR DESCRIPTION
This makes the reporting on possible failed reapplications more accurate, so the results are meaningful