### PR TITLE
add script to flip application status, so we can change the status of…

### DIFF
--- a/portality/scripts/change_application_status.py
+++ b/portality/scripts/change_application_status.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from portality.core import app
+import csv
+from portality.models import Suggestion
+
+def change_status(ids, new_status):
+    for id in ids:
+        a = Suggestion.pull(id)
+        a.set_application_status(new_status)
+        a.save()
+
+if __name__ == "__main__":
+    print 'Starting {0}.'.format(datetime.now())
+
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--csv", help="csv containing ids to change")
+    parser.add_argument("-s", "--status", help="new status to set")
+    args = parser.parse_args()
+
+    if app.config.get("SCRIPTS_READ_ONLY_MODE", False):
+        print "System is in READ-ONLY mode, enforcing read-only for this script"
+        args.write = False
+
+    if not args.csv or not args.status:
+        print "You must provide both the -c and -s options. Exiting."
+        exit(1)
+
+    with open(args.csv, "r") as f:
+        reader = csv.reader(f)
+        ids = [row[0] for row in reader]
+        change_status(ids, args.status)
+
+    print 'Finished {0}.'.format(datetime.now())

--- a/portality/scripts/change_application_status.py
+++ b/portality/scripts/change_application_status.py
@@ -2,8 +2,13 @@ from datetime import datetime
 from portality.core import app
 import csv
 from portality.models import Suggestion
+from portality.formcontext.choices import Choices
 
 def change_status(ids, new_status):
+    statuses = [x[0] for x in Choices.application_status("admin") if x[0] != ""]
+    if new_status not in statuses:
+        raise Exception("Must use an allowed status: " + ", ".join(statuses))
+
     for id in ids:
         a = Suggestion.pull(id)
         a.set_application_status(new_status)


### PR DESCRIPTION
… items that are accepted to something that can be edited

When we apply this we just need a list of ids in a text file, and the status we want to convert them to, then we can run

python change_application_status.py -c [ids] -s [new status]