### PR TITLE
Hotfix/requeue jobs script

### DIFF
--- a/portality/models/background.py
+++ b/portality/models/background.py
@@ -72,6 +72,9 @@ class BackgroundJob(dataobj.DataObj, dao.DomainObject):
     def is_failed(self):
         return self._get_single("status") == u"error"
 
+    def queue(self):
+        self._set_with_struct("status", u"queued")
+
     def add_audit_message(self, msg, timestamp=None):
         if timestamp is None:
             timestamp = dates.now_with_microseconds()

--- a/portality/scripts/requeue_background_job.py
+++ b/portality/scripts/requeue_background_job.py
@@ -1,0 +1,73 @@
+from portality import models
+from portality.lib import dates
+
+from portality.tasks.ingestarticles import IngestArticlesBackgroundTask
+from portality.tasks.suggestion_bulk_edit import SuggestionBulkEditBackgroundTask
+from portality.tasks.sitemap import SitemapBackgroundTask
+from portality.tasks.read_news import ReadNewsBackgroundTask
+from portality.tasks.journal_csv import JournalCSVBackgroundTask
+
+
+SUBMITTERS = {
+    "ingest_articles" : IngestArticlesBackgroundTask,
+    "suggestion_bulk_edit" : SuggestionBulkEditBackgroundTask,
+    "sitemap" : SitemapBackgroundTask,
+    "read_news" : ReadNewsBackgroundTask,
+    "journal_csv" : JournalCSVBackgroundTask
+}
+
+def requeue_jobs(action, status, from_date, to_date):
+    q = JobsQuery(action, status, from_date, to_date)
+
+    jobs = models.BackgroundJob.q2obj(q=q.query())
+
+    print("You are about to re-queue " + str(len(jobs)) + " jobs")
+    doit = raw_input("Proceed? [Y\N]")
+
+    if doit == "Y":
+        for job in jobs:
+            job.queue()
+            SUBMITTERS[action].submit(job)
+
+
+class JobsQuery(object):
+    def __init__(self, action, status, from_date, to_date):
+        self.action = action
+        self.status = status
+        self.from_date = from_date
+        self.to_date = to_date
+
+    def query(self):
+        return {
+            "query" : {
+                "bool" : {
+                    "must" : [
+                        {"term" : {"status.exact" : self.status}},
+                        {"term" : {"action.exact" : self.action}},
+                        {"range" : {"created_date" : {"gte" : self.from_date, "lte" : self.to_date}}}
+                    ]
+                }
+            },
+            "size" : 10000
+        }
+
+# requeue_jobs("complete", "sitemap", None, None)
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("-s", "--status",
+                        help="requeue jobs in this status",
+                        default="queued")
+    parser.add_argument("-a", "--action",
+                        help="Background job action")
+    parser.add_argument("-f", "--from_date",
+                        help="Date from which to look for jobs in the given type and status",
+                        default="1970-01-01T00:00:00Z")
+    parser.add_argument("-t", "--to_date",
+                        help="Date to which to look for jobs in the given type and status",
+                        default=dates.now())
+    args = parser.parse_args()
+
+    requeue_jobs(args.action, args.status, args.from_date, args.to_date)

--- a/portality/scripts/requeue_background_job.py
+++ b/portality/scripts/requeue_background_job.py
@@ -1,3 +1,30 @@
+"""
+Script to allow us to re-queue background jobs of certain kinds.
+
+To use, do:
+
+python portality/scripts/requeue_background_job.py -a [action] -s [status] -f [from date] -t [do date]
+
+-s, -f and -t are optional, with the following default values:
+
+-s : queued
+-f : 1970-01-01T00:00:00Z
+-t : the current timestamp
+
+Currently this script supports re-queuing the following background job types:
+
+ingest_articles
+suggestion_bulk_edit
+sitemap
+read_news
+journal_csv
+
+If you need to re-queue any other kind of job, you need to add it here.
+
+FIXME: in the longer term this needs to live inside a business logic layer which has a fuller understanding
+of manipulating jobs, and the script should just call that functionality.
+
+"""
 from portality import models
 from portality.lib import dates
 


### PR DESCRIPTION
Script to allow us to re-queue background jobs of certain kinds.

To use, do:

python portality/scripts/requeue_background_job.py -a [action] -s [status] -f [from date] -t [do date]

For immediate usage, we need to issue the following commands:

python portality/scripts/requeue_background_job.py -a ingest_articles -t 2017-12-15T11:29:00Z

python portality/scripts/requeue_background_job.py -a suggestion_bulk_edit -t 2017-12-15T11:29:00Z

python portality/scripts/requeue_background_job.py -a sitemap -t 2017-12-15T11:29:00Z

python portality/scripts/requeue_background_job.py -a read_news -t 2017-12-15T11:29:00Z

python portality/scripts/requeue_background_job.py -a journal_csv -t 2017-12-15T11:29:00Z


