### PR TITLE
Send error emails through mailgun rather than gmail. Removed exceptio…

### DIFF
--- a/portality/error_handler.py
+++ b/portality/error_handler.py
@@ -51,15 +51,17 @@ def setup_error_logging(app):
 
     send_to = app.config.get('ERROR_LOGGING_EMAIL', app.config.get('ADMIN_EMAIL'))
     if send_to and not app.config.get('SUPPRESS_ERROR_EMAILS'):
-        if 'ERROR_MAIL_USERNAME' in app.config and 'ERROR_MAIL_PASSWORD' in app.config:
+        if 'ERROR_MAIL_USERNAME' in app.config and 'ERROR_MAIL_PASSWORD' in app.config and 'ERROR_MAIL_HOSTNAME' in app.config:
             import platform
             hostname = platform.uname()[1]
+
+            # We have to duplicate our email config here as we can't import app_email at this point
             mail_handler = TlsSMTPHandler(
-                ('smtp.gmail.com', 587),
-               'server-error@' + hostname,
-               send_to,
-               'DOAJ Flask Error',
-               credentials=(app.config['ERROR_MAIL_USERNAME'], app.config['ERROR_MAIL_PASSWORD'])
+                (app.config['ERROR_MAIL_HOSTNAME'], 587),
+                'server-error@' + hostname,
+                send_to,
+                'DOAJ Flask Error',
+                credentials=(app.config['ERROR_MAIL_USERNAME'], app.config['ERROR_MAIL_PASSWORD'])
             )
             mail_handler.setLevel(logging.ERROR)
             mail_handler.setFormatter(formatter)

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -38,14 +38,19 @@ SECRET_KEY = "default-key"
 ADMIN_NAME = "DOAJ"
 ADMIN_EMAIL = "sysadmin@cottagelabs.com"
 ADMINS = ["emanuil@cottagelabs.com", "mark@cottagelabs.com"]
-ERROR_LOGGING_EMAIL = 'doaj.internal@gmail.com'
-SUPPRESS_ERROR_EMAILS = False
 SYSTEM_EMAIL_FROM = 'feedback@doaj.org'
 CC_ALL_EMAILS_TO = SYSTEM_EMAIL_FROM  # DOAJ may get a dedicated inbox in the future
 ENABLE_EMAIL = True
 ENABLE_PUBLISHER_EMAIL = True
 MANAGING_EDITOR_EMAIL = "managing-editors@doaj.org"
 CONTACT_FORM_ADDRESS = "feedback+contactform@doaj.org"
+
+# Error logging via email
+SUPPRESS_ERROR_EMAILS = False
+ERROR_LOGGING_EMAIL = 'doaj.internal@gmail.com'
+ERROR_MAIL_HOSTNAME = 'smtp.mailgun.org'
+ERROR_MAIL_USERNAME = None
+ERROR_MAIL_PASSWORD = None
 
 # service info
 SERVICE_NAME = "Directory of Open Access Journals"


### PR DESCRIPTION
…ns rasied by the formcontext email sending - these are logged instead. #1467

## REQUIRES CONFIG CHANGE