### PR TITLE
Simplified and updated the DOI regex

### DIFF
--- a/doajtest/fixtures/dois.py
+++ b/doajtest/fixtures/dois.py
@@ -1,0 +1,29 @@
+DOI_LIST = [
+    "https://doi.org/10.3403/bseniso9233",
+    "https://doi.org/10.1016/s1874-558x(04)80052-6",
+    "https://doi.org/10.1002/9781444341850.ch3",
+    "https://doi.org/10.1016/b978-0-12-417012-4.00029-6",
+    "https://doi.org/10.3403/01095063",
+    "https://doi.org/10.1016/b978-0-12-374407-4.00076-5",
+    "https://doi.org/10.1016/j.foodhyd.2008.08.016",
+    "http://dx.doi.org/10.20914/2310-1202-2016-4-135-140",
+    "http://dx.doi.org/10.1590/S0104-66322008000200008",
+    "http://dx.doi.org/10.1371/journal.pone.0057696",
+    "http://dx.doi.org/10.14295/2238-6416.v71i4.511",
+    "http://dx.doi.org/10.4081/ijas.2009.s2.450",
+]
+
+HANDLE_LIST = [
+    "http://hdl.handle.net/10568/89928",
+    "http://hdl.handle.net/1893/26234",
+    "http://hdl.handle.net/1893/23601",
+    "http://hdl.handle.net/2134/6997"
+]
+
+INVALID_LIST = [
+    "This is not a DOI or handle",
+    "https://doaj.org",
+    "http://dx.doi.org",
+    "https://doi.org",
+    "https://dx.doi.org/invalid"
+]

--- a/doajtest/fixtures/dois.py
+++ b/doajtest/fixtures/dois.py
@@ -11,19 +11,32 @@ DOI_LIST = [
     "http://dx.doi.org/10.1371/journal.pone.0057696",
     "http://dx.doi.org/10.14295/2238-6416.v71i4.511",
     "http://dx.doi.org/10.4081/ijas.2009.s2.450",
+    "https://doi.org/10.3403string/bseniso9233",
+    "https://doi.org/10.3403.999/bseniso9233",
+    "HTTPS://DOI.ORG/10.3403/BSENISO9233",                                         # TODO: do we normalise case on save?
 ]
 
 HANDLE_LIST = [
-    "http://hdl.handle.net/10568/89928",
-    "http://hdl.handle.net/1893/26234",
-    "http://hdl.handle.net/1893/23601",
-    "http://hdl.handle.net/2134/6997"
+    "http://hdl.handle.net/10.1000/182",
+    #"http://hdl.handle.net/10568/89928",       # FIXME: open question whether we should support prefixes other than 10.
+    #"http://hdl.handle.net/1893/23601",
+    #"http://hdl.handle.net/2134/6997"
 ]
 
-INVALID_LIST = [
+INVALID_DOI_LIST = [
     "This is not a DOI or handle",
     "https://doaj.org",
     "http://dx.doi.org",
     "https://doi.org",
-    "https://dx.doi.org/invalid"
+    "https://dx.doi.org/invalid",
+    "http://hd&.handle.net/10.1234/567",
+    "httpx://doi.org/10.3403/bseniso9233",
+    "https:/doi.org/10.3403/bseniso9233",
+    "https://doi.org/10.3403",
+    "https://doi.org.uk/10.3403/bseniso9233",
+    "https://doi.org/10.3403/   556",
+    "   https://doi.org/10.3403/01095063",
+    "https://doi.org/10.3403/01095063       ",
+    "\thttps://doi.org/\t10.3403/01095063\t",
+    "https://doi.org/10.3403/01095063\thttps://doi.org/\t10.3403/01095063\t"
 ]

--- a/doajtest/fixtures/issns.py
+++ b/doajtest/fixtures/issns.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+ISSN_LIST = [
+    "1234-5678",
+    "0000-0000",
+    "2502-471X",
+    "0390-590X",
+    "0390-590x",
+]
+
+INVLAID_ISSN_LIST = [
+    "Certainly not a valid ISSN",
+    "0390--590x",
+    "1-1",
+    "12345678",
+    "@£$%-&*()",
+    "derp-derp",
+    "0390-590xbutwithmoretextafterwards",
+    "   0390-590x   ",
+]

--- a/doajtest/unit/test_regexes.py
+++ b/doajtest/unit/test_regexes.py
@@ -1,8 +1,8 @@
 """ Gather and test DOAJ regexes here """
 
 from doajtest.helpers import DoajTestCase
-from portality.view.forms import DOI_REGEX
-from doajtest.fixtures import dois
+from portality.view.forms import DOI_REGEX, ISSN_REGEX
+from doajtest.fixtures import dois, issns
 
 import re
 
@@ -10,10 +10,10 @@ import re
 class TestRegexes(DoajTestCase):
 
     def setUp(self):
-        super(TestRegexes, self).setUp()
+        pass                                                                               # no need to set up the index
 
     def tearDown(self):
-        super(TestRegexes, self).tearDown()
+        pass
 
     def test_01_DOI_regex(self):
         """ Check that the DOI regex (used for validating forms) accepts what we expect. """
@@ -25,10 +25,18 @@ class TestRegexes(DoajTestCase):
 
         # And handle identifiers too
         for h in dois.HANDLE_LIST:
-            assert not doi_regex.match(h), h
+            assert doi_regex.match(h), h
 
         # But not something unrelated to DOIs
-        for x in dois.INVALID_LIST:
+        for x in dois.INVALID_DOI_LIST:
             assert not doi_regex.match(x), x
 
-    # TODO: test other regexes (ISSN etc)
+    def test_02_ISSN_regex(self):
+        """ Check that the ISSN regex performs correctly. """
+        issn_regex = re.compile(ISSN_REGEX)
+
+        for i in issns.ISSN_LIST:
+            assert issn_regex.match(i), i
+
+        for x in issns.INVLAID_ISSN_LIST:
+            assert not issn_regex.match(x), x

--- a/doajtest/unit/test_regexes.py
+++ b/doajtest/unit/test_regexes.py
@@ -1,0 +1,34 @@
+""" Gather and test DOAJ regexes here """
+
+from doajtest.helpers import DoajTestCase
+from portality.view.forms import DOI_REGEX
+from doajtest.fixtures import dois
+
+import re
+
+
+class TestRegexes(DoajTestCase):
+
+    def setUp(self):
+        super(TestRegexes, self).setUp()
+
+    def tearDown(self):
+        super(TestRegexes, self).tearDown()
+
+    def test_01_DOI_regex(self):
+        """ Check that the DOI regex (used for validating forms) accepts what we expect. """
+        doi_regex = re.compile(DOI_REGEX)
+
+        # DOI regex should match our list of valid DOIs
+        for d in dois.DOI_LIST:
+            assert doi_regex.match(d), d
+
+        # And handle identifiers too
+        for h in dois.HANDLE_LIST:
+            assert not doi_regex.match(h), h
+
+        # But not something unrelated to DOIs
+        for x in dois.INVALID_LIST:
+            assert not doi_regex.match(x), x
+
+    # TODO: test other regexes (ISSN etc)

--- a/portality/view/forms.py
+++ b/portality/view/forms.py
@@ -21,7 +21,7 @@ from portality.formcontext.fields import DOAJSelectField
 ## Forms and related features for Article metadata
 ##########################################################################
 
-DOI_REGEX = "^((http:\/\/){0,1}dx.doi.org/|(http:\/\/){0,1}hdl.handle.net\/|doi:|info:doi:){0,1}(?P<id>10\\..+\/.+)"
+DOI_REGEX = r"^((https?:\/\/)?((dx\.)?doi\.org/|hdl\.handle\.net\/)|doi:|info:doi:)?(?P<id>10\..+\/.+)"
 DOI_ERROR = 'Invalid DOI.  A DOI can optionally start with a prefix (such as "doi:"), followed by "10." and the remainder of the identifier'
 
 # use the year choices in app.cfg or default to 15 years previous.

--- a/portality/view/forms.py
+++ b/portality/view/forms.py
@@ -21,7 +21,7 @@ from portality.formcontext.fields import DOAJSelectField
 ## Forms and related features for Article metadata
 ##########################################################################
 
-DOI_REGEX = r"^((https?:\/\/)?((dx\.)?doi\.org/|hdl\.handle\.net\/)|doi:|info:doi:)?(?P<id>10\..+\/.+)"
+DOI_REGEX = re.compile(r"^((https?://)?((dx\.)?doi\.org/|hdl\.handle\.net/)|doi:|info:doi:)?(?P<id>10\.\S+/\S+)$", re.IGNORECASE)
 DOI_ERROR = 'Invalid DOI.  A DOI can optionally start with a prefix (such as "doi:"), followed by "10." and the remainder of the identifier'
 
 # use the year choices in app.cfg or default to 15 years previous.
@@ -125,7 +125,7 @@ class EditorGroupForm(Form):
 ## Continuations Forms
 ##########################################################################
 
-ISSN_REGEX = re.compile(r'^\d{4}-\d{3}(\d|X|x){1}$')
+ISSN_REGEX = re.compile(r'^\d{4}-\d{3}(\d|X){1}$', re.IGNORECASE)
 ISSN_ERROR = 'An ISSN or EISSN should be 7 or 8 digits long, separated by a dash, e.g. 1234-5678. If it is 7 digits long, it must end with the letter X (e.g. 1234-567X).'
 
 


### PR DESCRIPTION
based on contributions by @katrinleinweber 

I've made this a string literal to improve readability (doing away with the ```\\```), and removed duplicated protocol portions. Finally, escaped an extra ```.``` which allowed us to accept e.g. ```dx.doiZorg``` since it's a wildcard.