### PR TITLE
[hotfix] provenance report bug

### DIFF
--- a/doajtest/unit/test_reporting.py
+++ b/doajtest/unit/test_reporting.py
@@ -14,14 +14,18 @@ MONTH_EDIT_OUTPUT = [
     ["User", "2015-01", "2015-02", "2015-03", "2015-04", "2015-05", "2015-06"],
     ["u1", 0, 1, 2, 3, 4, 5],
     ["u2", 6, 7, 8, 9, 10, 0],
-    ["u3", 11, 12, 13, 14, 15, 16]
-]
+    ["u3", 11, 12, 13, 14, 15, 16],
+    ["u4", 2, 5, 0, 8, 13, 21],
+    ["u5", 2, 5, 0, 8, 0, 4],
+]  # TODO add middle 0s to the year and month test data, see if tests fail like here
 
 YEAR_EDIT_OUTPUT = [
     ["User", "2015"],
     ["u1", 15],
     ["u2", 40],
-    ["u3", 81]
+    ["u3", 81],
+    ["u4", 49],
+    ["u5", 19],
 ]
 
 MONTH_COMPLETE_OUTPUT = [

--- a/doajtest/unit/test_reporting.py
+++ b/doajtest/unit/test_reporting.py
@@ -17,7 +17,7 @@ MONTH_EDIT_OUTPUT = [
     ["u3", 11, 12, 13, 14, 15, 16],
     ["u4", 2, 5, 0, 8, 13, 21],
     ["u5", 2, 5, 0, 8, 0, 4],
-]  # TODO add middle 0s to the year and month test data, see if tests fail like here
+]
 
 YEAR_EDIT_OUTPUT = [
     ["User", "2015"],

--- a/portality/tasks/reporting.py
+++ b/portality/tasks/reporting.py
@@ -88,6 +88,22 @@ def _tabulate_time_entity_group(group, entityKey):
                     existing = True
             if not existing:
                 table.append([u] + padding + [c])
+        # get set of the users currently in the table
+        users_added_to_table = set(map(lambda each_row: each_row[0], table))
+
+        # Add a 0 for each user who has been added to the table but doesn't
+        # have any actions in the current time period we're looping over. E.g.
+        # if we're counting edits by month, this would be "users who were active
+        # in a previous month but haven't made any edits this month".
+        previously_active_users = users_added_to_table - set(users)
+        for u in previously_active_users:
+            for row in table:
+                if row[0] == u:
+                    row.append(0)
+
+        # The following is only prefix padding. E.g. if "dom" started making edits in
+        # Jan 2015 but "emanuil" only started in Mar 2015, then "emanuil" needs
+        # 0s filled in for Jan + Feb 2015.
         padding.append(0)
 
     for row in table:

--- a/portality/tasks/reporting.py
+++ b/portality/tasks/reporting.py
@@ -95,10 +95,9 @@ def _tabulate_time_entity_group(group, entityKey):
         # in a previous month but haven't made any edits this month".
         users_in_table = set(map(lambda each_row: each_row[0], table))
         previously_active_users = users_in_table - set(users_active_this_period)
-        for u in previously_active_users:
-            for row in table:
-                if row[0] == u:
-                    row.append(0)
+        for row in table:
+            if row[0] in previously_active_users:
+                row.append(0)
 
         # The following is only prefix padding. E.g. if "dom" started making edits in
         # Jan 2015 but "emanuil" only started in Mar 2015, then "emanuil" needs

--- a/portality/tasks/reporting.py
+++ b/portality/tasks/reporting.py
@@ -78,8 +78,8 @@ def _tabulate_time_entity_group(group, entityKey):
     table = []
     padding = []
     for db in date_keys:
-        users = group[db].keys()
-        for u in users:
+        users_active_this_period = group[db].keys()
+        for u in users_active_this_period:
             c = group[db][u]["count"]
             existing = False
             for row in table:
@@ -88,14 +88,13 @@ def _tabulate_time_entity_group(group, entityKey):
                     existing = True
             if not existing:
                 table.append([u] + padding + [c])
-        # get set of the users currently in the table
-        users_added_to_table = set(map(lambda each_row: each_row[0], table))
 
         # Add a 0 for each user who has been added to the table but doesn't
         # have any actions in the current time period we're looping over. E.g.
         # if we're counting edits by month, this would be "users who were active
         # in a previous month but haven't made any edits this month".
-        previously_active_users = users_added_to_table - set(users)
+        users_in_table = set(map(lambda each_row: each_row[0], table))
+        previously_active_users = users_in_table - set(users_active_this_period)
         for u in previously_active_users:
             for row in table:
                 if row[0] == u:


### PR DESCRIPTION
See https://github.com/DOAJ/doajpm/issues/1488#issuecomment-366869028 for an explanation of the problem.

The fix is to insert a 0 when appropriate. The code already does this for editors who joined DOAJ later than others, for the exact same reason. An editor starting in 2018 shouldn't have their activity displayed as 2015 just because other people were working in 2015 (makes no sense), we've got to take different start months into account. It's the same thing, the code just needs to do it for 0 actions in the middle of an editor's tenure as well as at the start.