### PR TITLE
Added a modification to the scrub emails script that can work with th…

### DIFF
--- a/doajtest/unit/resources/article_uploads.xml
+++ b/doajtest/unit/resources/article_uploads.xml
@@ -21,6 +21,7 @@
         <authors>
             <author>
                 <name>Papillon, Joëlle</name>
+                <email/>
                 <affiliationId>1</affiliationId>
             </author>
         </authors>
@@ -62,6 +63,7 @@
         <authors>
             <author>
                 <name>Papillon, Joëlle</name>
+                <email/>
                 <affiliationId>1</affiliationId>
             </author>
         </authors>
@@ -103,6 +105,7 @@
         <authors>
             <author>
                 <name>Papillon, Joëlle</name>
+                <email/>
                 <affiliationId>1</affiliationId>
             </author>
         </authors>
@@ -186,6 +189,7 @@
         <authors>
             <author>
                 <name>Papillon, Joëlle</name>
+                <email/>
                 <affiliationId>1</affiliationId>
             </author>
         </authors>
@@ -683,6 +687,7 @@
         <authors>
             <author>
                 <name>Papillon, Joëlle</name>
+                <email/>
                 <affiliationId>1</affiliationId>
             </author>
         </authors>

--- a/doajtest/unit/resources/articlematch.xml
+++ b/doajtest/unit/resources/articlematch.xml
@@ -20,6 +20,7 @@
       <authors>
          <author>
             <name>Papillon, Joëlle</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -60,6 +61,7 @@
       <authors>
          <author>
             <name>Paré, François</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -102,6 +104,7 @@
       <authors>
          <author>
             <name>Scott, Corrie</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -145,6 +148,7 @@
       <authors>
          <author>
             <name>Duvicq, Nelly</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -190,6 +194,7 @@
       <authors>
          <author>
             <name>Beaupré, Jonathan Lamy</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -233,6 +238,7 @@
       <authors>
          <author>
             <name>Beaupré, Jonathan Lamy</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -276,6 +282,7 @@
       <authors>
          <author>
             <name>Beaupré, Jonathan Lamy</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>

--- a/doajtest/unit/resources/partialimport.xml
+++ b/doajtest/unit/resources/partialimport.xml
@@ -15,6 +15,7 @@
       <authors>
          <author>
             <name>Papillon, Joëlle</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -51,6 +52,7 @@
       <authors>
          <author>
             <name>Paré, François</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -89,6 +91,7 @@
       <authors>
          <author>
             <name>Scott, Corrie</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -129,6 +132,7 @@
       <authors>
          <author>
             <name>Duvicq, Nelly</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -168,6 +172,7 @@
       <authors>
          <author>
             <name>Beaupré, Jonathan Lamy</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -210,6 +215,7 @@
       <authors>
          <author>
             <name>Laporte, David</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -247,6 +253,7 @@
       <authors>
          <author>
             <name>Morali, Laure</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>
@@ -280,6 +287,7 @@
       <authors>
          <author>
             <name>Gatti, Maurizio</name>
+            <email/>
             <affiliationId>1</affiliationId>
          </author>
       </authors>

--- a/doajtest/unit/test_ingestarticles.py
+++ b/doajtest/unit/test_ingestarticles.py
@@ -998,6 +998,8 @@ class TestIngestArticles(DoajTestCase):
         assert "unowned" in fr
         assert "9876-5432" in fr["unowned"]
 
+# TODO: reinstate this test when author emails have been disallowed again
+'''
     def test_34_file_upload_author_email(self):
         handle = ArticleFixtureFactory.upload_author_email_address()
         f = MockFileUpload(stream=handle)
@@ -1024,3 +1026,4 @@ class TestIngestArticles(DoajTestCase):
         # and placed into the failed dir
         fad = os.path.join(app.config.get("FAILED_ARTICLE_DIR", "."), id + ".xml")
         assert os.path.exists(fad)
+'''

--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -1044,6 +1044,9 @@ class TestClient(DoajTestCase):
         assert all[0].id == app1.id
         assert all[1].id == app2.id
 
+
+# TODO: reinstate this test when author emails have been disallowed again
+'''
     def test_33_article_with_author_email(self):
         """Check the system disallows articles with emails in the author field"""
         a_source = ArticleFixtureFactory.make_article_source()
@@ -1061,3 +1064,4 @@ class TestClient(DoajTestCase):
         # We can't add an author with an email address any more.
         with self.assertRaises(TypeError):
             a.bibjson().add_author(name='Ms Test', affiliation='School of Rock', email='author@example.com')
+'''

--- a/doajtest/unit/test_query_filters.py
+++ b/doajtest/unit/test_query_filters.py
@@ -108,3 +108,48 @@ class TestQueryFilters(DoajTestCase):
             for forbidden_k in forbidden:
                 assert forbidden_k not in r['_source']['admin'], \
                     '{} key was found in result {}, but it is forbidden and should have been stripped out by the filter'.format(forbidden_k, n)
+
+    def test_08_prune_author_emails(self):
+        """Check we don't let publisher emails through the query endpoint"""
+        res = {
+            "hits": {
+                "hits": [
+                    {"_type": "article", "_source": {"admin": {"seal": False, "publisher_record_id": "some_identifier",
+                                                               "upload_id": "zyxwvutsrqpo_upload_id"}, "bibjson":
+                                                              {"author": [{'name': "Janet Author",
+                                                                           'email': 'janet@example.com'}]}}},
+                    {"_type": "article", "_source": {"admin": {"seal": False, "publisher_record_id": "some_identifier",
+                                                               "upload_id": "zyxwvutsrqpo_upload_id"}, "bibjson":
+                                                              {"author": [{'name': "Janet Author",
+                                                                           'email': 'janet@example.com'},
+                                                                          {'name': "Jimmy Author",
+                                                                          'email': 'jimmy@example.com'}]}}},
+                    {"_type": "article", "_source": {"admin": {"seal": False, "publisher_record_id": "some_identifier",
+                                                               "upload_id": "zyxwvutsrqpo_upload_id"}, "bibjson":
+                                                              {"author": [{'name': "Janet Author"},
+                                                                          {'name': "Jimmy Author"}]}}},
+                ],
+                "total": 3
+            }
+        }
+
+        newres = query_filters.prune_author_emails(res)
+
+        assert newres == {
+            "hits": {
+                "hits": [
+                    {"_type": "article", "_source": {"admin": {"seal": False, "publisher_record_id": "some_identifier",
+                                                               "upload_id": "zyxwvutsrqpo_upload_id"}, "bibjson":
+                                                              {"author": [{'name': "Janet Author"}]}}},
+                    {"_type": "article", "_source": {"admin": {"seal": False, "publisher_record_id": "some_identifier",
+                                                               "upload_id": "zyxwvutsrqpo_upload_id"}, "bibjson":
+                                                              {"author": [{'name': "Janet Author"},
+                                                                          {'name': "Jimmy Author"}]}}},
+                    {"_type": "article", "_source": {"admin": {"seal": False, "publisher_record_id": "some_identifier",
+                                                               "upload_id": "zyxwvutsrqpo_upload_id"}, "bibjson":
+                                                              {"author": [{'name': "Janet Author"},
+                                                                          {'name': "Jimmy Author"}]}}},
+                ],
+                "total": 3
+            }
+        }, newres

--- a/portality/lib/query_filters.py
+++ b/portality/lib/query_filters.py
@@ -5,25 +5,30 @@ from portality import models
 # query filters
 ###############
 
+
 def only_in_doaj(q):
     q.clear_match_all()
     q.add_must({"term" : {"admin.in_doaj" : True}})
     return q
+
 
 def owner(q):
     q.clear_match_all()
     q.add_must({"term" : {"admin.owner.exact" : current_user.id}})
     return q
 
+
 def update_request(q):
     q.clear_match_all()
     q.add_must({"range" : {"created_date" : {"gte" : app.config.get("UPDATE_REQUEST_SHOW_OLDEST")}}})
     return q
 
+
 def associate(q):
     q.clear_match_all()
     q.add_must({"term" : {"admin.editor.exact" : current_user.id}})
     return q
+
 
 def editor(q):
     gnames = []
@@ -33,6 +38,7 @@ def editor(q):
     q.clear_match_all()
     q.add_must({"terms" : {"admin.editor_group.exact" : gnames}})
     return q
+
 
 # results filters
 #################
@@ -51,6 +57,21 @@ def public_result_filter(results):
                         del hit["_source"]["admin"][k]
 
     return results
+
+
+def prune_author_emails(results):
+    if "hits" not in results:
+        return results
+    if "hits" not in results["hits"]:
+        return results
+
+    for hit in results["hits"]["hits"]:
+        if "_source" in hit:
+            if "bibjson" in hit["_source"]:
+                if "author" in hit["_source"]["bibjson"]:
+                    for a in hit["_source"]["bibjson"]["author"]:
+                        del a["email"]
+
 
 def publisher_result_filter(results):
     if "hits" not in results:

--- a/portality/lib/query_filters.py
+++ b/portality/lib/query_filters.py
@@ -70,7 +70,10 @@ def prune_author_emails(results):
             if "bibjson" in hit["_source"]:
                 if "author" in hit["_source"]["bibjson"]:
                     for a in hit["_source"]["bibjson"]["author"]:
-                        del a["email"]
+                        if "email" in a:
+                            del a["email"]
+
+    return results
 
 
 def publisher_result_filter(results):

--- a/portality/models/article.py
+++ b/portality/models/article.py
@@ -776,7 +776,8 @@ ARTICLE_BIBJSON_EXTENSION = {
                 "author" : {
                     "fields" : {
                         "name" : {"coerce" : "unicode"},
-                        "affiliation" : {"coerce" : "unicode"}
+                        "affiliation" : {"coerce" : "unicode"},
+                        "email" : {"coerce": "unicode"}
                     }
                 },
 

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -307,14 +307,14 @@ QUERY_ROUTE = {
             "auth" : False,
             "role" : None,
             "query_filters" : ["only_in_doaj"],
-            "result_filters" : ["public_result_filter"],
+            "result_filters" : ["public_result_filter", "prune_author_emails"],
             "dao" : "portality.models.search.JournalArticle"
         },
         "article" : {
             "auth" : False,
             "role" : None,
             "query_filters" : ["only_in_doaj"],
-            "result_filters" : ["public_result_filter"],
+            "result_filters" : ["public_result_filter", "prune_author_emails"],
             "dao" : "portality.models.Article"
         }
     },
@@ -323,14 +323,14 @@ QUERY_ROUTE = {
             "auth" : True,
             "role" : "publisher",
             "query_filters" : ["owner"],
-            "result_filters" : ["publisher_result_filter"],
+            "result_filters" : ["publisher_result_filter", "prune_author_emails"],
             "dao" : "portality.models.Journal"
         },
         "suggestion" : {
             "auth" : True,
             "role" : "publisher",
             "query_filters" : ["owner", "update_request"],
-            "result_filters" : ["publisher_result_filter"],
+            "result_filters" : ["publisher_result_filter", "prune_author_emails"],
             "dao" : "portality.models.Suggestion"
         }
     },
@@ -405,8 +405,9 @@ QUERY_FILTERS = {
     "editor" : "portality.lib.query_filters.editor",
 
     # result filters
-    "public_result_filter" : "portality.lib.query_filters.public_result_filter",
-    "publisher_result_filter" : "portality.lib.query_filters.publisher_result_filter"
+    "public_result_filter": "portality.lib.query_filters.public_result_filter",
+    "publisher_result_filter": "portality.lib.query_filters.publisher_result_filter",
+    "prune_author_emails": "portality.lib.query_filters.prune_author_emails"
 }
 
 UPDATE_REQUESTS_SHOW_OLDEST = "2018-01-01T00:00:00Z"

--- a/portality/static/doaj/doajArticles.xsd
+++ b/portality/static/doaj/doajArticles.xsd
@@ -97,6 +97,7 @@
        <xs:complexType>
         <xs:sequence>
          <xs:element name="name" type="xs:string" />
+         <xs:element name="email" type="xs:string" />
          <xs:element name="affiliationId" 
                      minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>


### PR DESCRIPTION
…e old dataobj but remove the emails - we will still keep the site up with out errors while the script runs.

* reinstated email in the article bibjson model's dataobj so we can load existing articles without DataStructureExceptions

* Also an enhancement - only scroll through articles where the email appears.