### PR TITLE
Hotfix/1722 hide not in doaj from publisher

### DIFF
--- a/doajtest/unit/test_query.py
+++ b/doajtest/unit/test_query.py
@@ -20,7 +20,7 @@ QUERY_ROUTE = {
         "journal" : {
             "auth" : True,
             "role" : "publisher",
-            "query_filters" : ["owner"],
+            "query_filters" : ["owner", "only_in_doaj"],
             "result_filters" : ["publisher_result_filter"],
             "dao" : "portality.models.Journal"
         }
@@ -135,7 +135,7 @@ class TestQuery(DoajTestCase):
         assert cfg == {
             "auth" : True,
             "role" : "publisher",
-            "query_filters" : ["owner"],
+            "query_filters" : ["owner", "only_in_doaj"],
             "result_filters" : ["publisher_result_filter"],
             "dao" : "portality.models.Journal"
         }

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -322,7 +322,7 @@ QUERY_ROUTE = {
         "journal" : {
             "auth" : True,
             "role" : "publisher",
-            "query_filters" : ["owner"],
+            "query_filters" : ["owner", "only_in_doaj"],
             "result_filters" : ["publisher_result_filter", "prune_author_emails"],
             "dao" : "portality.models.Journal"
         },


### PR DESCRIPTION
This hides journals from publishers in the publisher area if the journal is not in doaj, as per #1722
