### PR TITLE
explicitly order notes for the application and journal forms

### DIFF
--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -112,6 +112,15 @@ class TestClient(DoajTestCase):
         bj2 = j.bibjson()
         assert bj2.publication_time == 7
 
+        # check over ordered note reading
+        j.add_note("another note", "2010-01-01T00:00:00Z")
+        j.add_note("an old note", "2001-01-01T00:00:00Z")
+        ons = j.ordered_notes
+        assert len(ons) == 3
+        assert ons[2]["note"] == "an old note"
+        assert ons[1]["note"] == "testing"
+        assert ons[0]["note"] == "another note"
+
         # now construct from a fixture
         source = JournalFixtureFactory.make_journal_source(include_obsolete_fields=True)
         j = models.Journal(**source)
@@ -161,6 +170,14 @@ class TestClient(DoajTestCase):
         assert s.article_metadata is True
         assert s.suggester.get("name") == "test"
         assert s.suggester.get("email") == "test@test.com"
+
+        # check over ordered note reading
+        s.add_note("another note", "2010-01-01T00:00:00Z")
+        s.add_note("an old note", "2001-01-01T00:00:00Z")
+        ons = s.ordered_notes
+        assert len(ons) == 2
+        assert ons[1]["note"] == "an old note"
+        assert ons[0]["note"] == "another note"
 
         s.prep()
         assert 'index' in s, s

--- a/portality/formcontext/xwalk.py
+++ b/portality/formcontext/xwalk.py
@@ -554,7 +554,7 @@ class SuggestionFormXWalk(JournalGenericXWalk):
 
         forminfo['application_status'] = obj.application_status
 
-        forminfo['notes'] = obj.notes
+        forminfo['notes'] = obj.ordered_notes
 
         forminfo['subject'] = []
         for s in bibjson.subjects():
@@ -913,7 +913,7 @@ class JournalFormXWalk(JournalGenericXWalk):
         forminfo['publishing_rights'] = reverse_interpret_special(bibjson.author_publishing_rights.get('publishing_rights', ''))
         forminfo['publishing_rights_url'] = bibjson.author_publishing_rights.get('url')
 
-        forminfo['notes'] = obj.notes
+        forminfo['notes'] = obj.ordered_notes
 
         forminfo['subject'] = []
         for s in bibjson.subjects():

--- a/portality/models/journal.py
+++ b/portality/models/journal.py
@@ -148,6 +148,11 @@ class JournalLikeObject(dataobj.DataObj, DomainObject):
         return self._get_list("admin.notes")
 
     @property
+    def ordered_notes(self):
+        notes = self.notes
+        return sorted(notes, key=lambda x: x["date"], reverse=True)
+
+    @property
     def owner(self):
         return self._get_single("admin.owner")
 

--- a/portality/static/doaj/js/suggestions_and_journals.js
+++ b/portality/static/doaj/js/suggestions_and_journals.js
@@ -283,8 +283,8 @@ function setup_add_buttons() {
         if (customisations[id]['id']) {
             thebtn += ' id="' + customisations[id]['id'] + '"';
         }
-        thebtn += '>' + value + '</button>';
-        e.append(thebtn);
+        thebtn += ' style="margin-bottom: 20px;">' + value + '</button>';
+        e.prepend(thebtn);
     });
     setup_add_button_handlers();
 }
@@ -312,7 +312,7 @@ function setup_add_button_handlers() {
         if (notes_deletable) { // global variable set by template
             delclass = " deletable "
         }
-        thefield = [
+        var thefield = [
             '<div class="control-group row-fluid' + delclass + '" id="notes-' + cur_number_of_notes + '-container">',
             '    <div class="span8 nested-field-container">',
             '        <label class="control-label" for="note">',
@@ -335,7 +335,7 @@ function setup_add_button_handlers() {
 
         cur_number_of_notes += 1;  // this doesn't get decremented in the remove button because there's no point, WTForms will understand it
             // even if the ID-s go 0, 2, 7, 13 etc.
-        $(this).before(thefield);
+        $(this).after(thefield);
         if (notes_deletable) {
             setup_remove_buttons();
         }
@@ -356,7 +356,7 @@ function setup_remove_buttons() {
         e = $(this);
         id = e.attr('id');
         if(e.find('button[id="remove_'+id+'"]').length == 0) {
-            e.append('<button id="remove_'+id+'" target="'+id+'" class="btn btn-danger remove_button"><i class="icon icon-remove-sign"></i></button>');
+            e.append('<button id="remove_'+id+'" target="'+id+'" class="btn btn-danger remove_button"><i class="icon-white icon-remove-sign"></i></button>');
         }
         setup_remove_button_handler();
     });


### PR DESCRIPTION
This sets the display order of notes on application and journal edit pages to newest first, and makes new notes appear at the top, as required by #1671

Before merging this we need to make sure users are ready for the change to the UI involved.