### PR TITLE
Feature/1671 note ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tmp/*
 dev.cfg
 app.cfg
 
+# directories of transient stuff that gets created locally
 media/*
 upload/*
 !upload/README.md
@@ -29,6 +30,10 @@ cache/csv/*.csv
 cache/sitemap/*.xml
 portality/migrate/p1p2/*.csv
 portality/migrate/p1p2/*.csv.bak
+local_store/main/*
+!local_store/main/README.md
+local_store/tmp/*
+!local_store/tmp/README.md
 
 # test detritous
 doajtest/unit/*.csv

--- a/doajtest/fixtures/applications.py
+++ b/doajtest/fixtures/applications.py
@@ -124,8 +124,8 @@ APPLICATION_SOURCE = {
     "admin" : {
         "application_status" : constants.APPLICATION_STATUS_PENDING,
         "notes" : [
-            {"note" : "First Note", "date" : "2014-05-21T14:02:45Z"},
-            {"note" : "Second Note", "date" : "2014-05-22T00:00:00Z"}
+            {"note" : "Second Note", "date" : "2014-05-22T00:00:00Z"},
+            {"note": "First Note", "date": "2014-05-21T14:02:45Z"}
         ],
         "contact" : [
             {

--- a/doajtest/fixtures/common.py
+++ b/doajtest/fixtures/common.py
@@ -1,7 +1,7 @@
 NOTES = {
     'notes': [
-        {'date': '2014-05-21T14:02:45Z', 'note': 'First Note'},
-        {'date': '2014-05-22T00:00:00Z', 'note': 'Second Note'}
+        {'date': '2014-05-22T00:00:00Z', 'note': 'Second Note'},
+        {'date': '2014-05-21T14:02:45Z', 'note': 'First Note'}
     ]
 }
 

--- a/doajtest/fixtures/journals.py
+++ b/doajtest/fixtures/journals.py
@@ -156,8 +156,8 @@ JOURNAL_SOURCE = {
     },
     "admin": {
         "notes": [
-            {"note": "First Note", "date": "2014-05-21T14:02:45Z"},
-            {"note": "Second Note", "date": "2014-05-22T00:00:00Z"}
+            {"note": "Second Note", "date": "2014-05-22T00:00:00Z"},
+            {"note": "First Note", "date": "2014-05-21T14:02:45Z"}
         ],
         "contact": [
             {

--- a/doajtest/unit/test_xwalk.py
+++ b/doajtest/unit/test_xwalk.py
@@ -90,8 +90,8 @@ class TestXwalk(DoajTestCase):
         del csource['created_date']
         del csource["admin"]["current_journal"]
         del csource["admin"]["related_journal"]
-        diff_dicts(csource, obj, 'csource', 'modelobj')
-        diff_dicts(csource["bibjson"], obj["bibjson"])
+        #diff_dicts(csource, obj, 'csource', 'modelobj')
+        #diff_dicts(csource["bibjson"], obj["bibjson"])
         assert obj == csource
 
     def test_03_old_style_to_new_style(self):

--- a/portality/templates/formcontext/assed_application_review.html
+++ b/portality/templates/formcontext/assed_application_review.html
@@ -92,6 +92,7 @@
 
             <div class="span12 with-borders form-section">
                 <h3>Notes</h3>
+                <p><strong>Notes are presented in descending date order: the most recent notes appear at the top.</strong></p>
                 <div class="addable-field-container" id="notes-outer-container">
                     {% autoescape off %}
                     {{ form_context.render_field_group("notes") }}

--- a/portality/templates/formcontext/assed_journal_review.html
+++ b/portality/templates/formcontext/assed_journal_review.html
@@ -86,6 +86,7 @@
 
             <div class="span12 with-borders form-section">
                 <h3>Notes</h3>
+                <p><strong>Notes are presented in descending date order: the most recent notes appear at the top.</strong></p>
                 <div class="addable-field-container" id="notes-outer-container">
                     {% autoescape off %}
                     {{ form_context.render_field_group("notes") }}

--- a/portality/templates/formcontext/editor_application_review.html
+++ b/portality/templates/formcontext/editor_application_review.html
@@ -100,6 +100,7 @@
 
             <div class="span12 with-borders form-section">
                 <h3>Notes</h3>
+                <p><strong>Notes are presented in descending date order: the most recent notes appear at the top.</strong></p>
                 <div class="addable-field-container" id="notes-outer-container">
                     {% autoescape off %}
                     {{ form_context.render_field_group("notes") }}

--- a/portality/templates/formcontext/editor_journal_review.html
+++ b/portality/templates/formcontext/editor_journal_review.html
@@ -94,6 +94,7 @@
 
             <div class="span12 with-borders form-section">
                 <h3>Notes</h3>
+                <p><strong>Notes are presented in descending date order: the most recent notes appear at the top.</strong></p>
                 <div class="addable-field-container" id="notes-outer-container">
                     {% autoescape off %}
                     {{ form_context.render_field_group("notes") }}

--- a/portality/templates/formcontext/maned_application_review.html
+++ b/portality/templates/formcontext/maned_application_review.html
@@ -142,6 +142,7 @@
 
             <div class="span12 with-borders form-section">
                 <h3>Notes</h3>
+                <p><strong>Notes are presented in descending date order: the most recent notes appear at the top.</strong></p>
                 <div class="addable-field-container" id="notes-outer-container">
                     {% autoescape off %}
                     {{ form_context.render_field_group("notes") }}

--- a/portality/templates/formcontext/maned_journal_review.html
+++ b/portality/templates/formcontext/maned_journal_review.html
@@ -159,6 +159,7 @@
 
             <div class="span12 with-borders form-section">
                 <h3>Notes</h3>
+                <p><strong>Notes are presented in descending date order: the most recent notes appear at the top.</strong></p>
                 <div class="addable-field-container" id="notes-outer-container">
                     {% autoescape off %}
                     {{ form_context.render_field_group("notes") }}


### PR DESCRIPTION
Don't merge until we have decided on a deployment date.  Propose to do this after the article upload code goes live.  Propose deployment on 2019-02-25.

Orders the notes in descending date order and changes the UI so new notes are added at the top.