### PR TITLE
change note ordering rules to ensure that notes with the same datesta…

### DIFF
--- a/portality/models/journal.py
+++ b/portality/models/journal.py
@@ -150,7 +150,19 @@ class JournalLikeObject(dataobj.DataObj, DomainObject):
     @property
     def ordered_notes(self):
         notes = self.notes
-        return sorted(notes, key=lambda x: x["date"], reverse=True)
+        clusters = {}
+        for note in notes:
+            if note["date"] not in clusters:
+                clusters[note["date"]] = [note]
+            else:
+                clusters[note["date"]].append(note)
+        ordered_keys = sorted(clusters.keys(), reverse=True)
+        ordered = []
+        for key in ordered_keys:
+            clusters[key].reverse()
+            ordered += clusters[key]
+        return ordered
+        # return sorted(notes, key=lambda x: x["date"], reverse=True)
 
     @property
     def owner(self):


### PR DESCRIPTION
…mp are presented in the order that they were created (which is the reverse of the order they appear in the data)

Ready for merge, see https://github.com/DOAJ/doajPM/issues/1935