### PR TITLE
add debug toolbar for developers

### DIFF
--- a/portality/core.py
+++ b/portality/core.py
@@ -1,6 +1,7 @@
 import os
 
 from flask import Flask
+from flask_debugtoolbar import DebugToolbarExtension
 from flask_login import LoginManager
 from flask_cors import CORS
 
@@ -28,6 +29,7 @@ def create_app():
     login_manager.init_app(app)
     CORS(app)
     initialise_apm(app)
+    DebugToolbarExtension(app)
     return app
 
 

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -63,6 +63,7 @@ SERVICE_TAGLINE = "DOAJ is an online directory that indexes and provides access 
 HOST = "0.0.0.0"
 DEBUG = False
 DEBUG_TB_TEMPLATE_EDITOR_ENABLED = True
+DEBUG_TB_INTERCEPT_REDIRECTS = False
 PORT = 5004
 SSL = True
 VALID_ENVIRONMENTS = ['dev', 'test', 'staging', 'production', 'harvester']

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -62,6 +62,7 @@ SERVICE_NAME = "Directory of Open Access Journals"
 SERVICE_TAGLINE = "DOAJ is an online directory that indexes and provides access to quality open access, peer-reviewed journals."
 HOST = "0.0.0.0"
 DEBUG = False
+DEBUG_TB_TEMPLATE_EDITOR_ENABLED = True
 PORT = 5004
 SSL = True
 VALID_ENVIRONMENTS = ['dev', 'test', 'staging', 'production', 'harvester']

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
         "elastic-apm[flask]",
         "parameterized==0.6.1",
         "awscli",
-        "boto3==1.9.10"
+        "boto3==1.9.10",
+        "flask-debugtoolbar"
     ] + (["setproctitle"] if "linux" in sys.platform else []),
     url = 'http://cottagelabs.com/',
     author = 'Cottage Labs',


### PR DESCRIPTION
@Steven-Eardley - one for us.  Adds a debug sidebar whenever debug is turned on.  Is useful for dev, but also will always be a visible presence whenever debug is on, which is a reminder when you are or aren't looking at live.