### PR TITLE
Pass account model objects to the BLL from the bulk API rather than L…

### DIFF
--- a/portality/bll/services/article.py
+++ b/portality/bll/services/article.py
@@ -145,9 +145,9 @@ class ArticleService(object):
         """
         Determine if the owner id is the owner of the article
 
-        :param article:
-        :param owner:
-        :return:
+        :param article: an article model
+        :param owner: string account ID
+        :return: True or False
         """
         # first validate the incoming arguments to ensure that we've got the right thing
         argvalidate("is_legitimate_owner", [

--- a/portality/view/api_v1.py
+++ b/portality/view/api_v1.py
@@ -277,7 +277,7 @@ def bulk_application_create():
         raise Api400Error("Supplied data was not valid JSON")
 
     # delegate to the API implementation
-    ids = ApplicationsBulkApi.create(data, current_user)
+    ids = ApplicationsBulkApi.create(data, current_user._get_current_object())
 
     # get all the locations for the ids
     inl = []
@@ -299,7 +299,7 @@ def bulk_application_delete():
     except:
         raise Api400Error("Supplied data was not valid JSON")
 
-    ApplicationsBulkApi.delete(data, current_user)
+    ApplicationsBulkApi.delete(data, current_user._get_current_object())
 
     return no_content()
 
@@ -319,7 +319,7 @@ def bulk_article_create():
         raise Api400Error("Supplied data was not valid JSON")
 
     # delegate to the API implementation
-    ids = ArticlesBulkApi.create(data, current_user)
+    ids = ArticlesBulkApi.create(data, current_user._get_current_object())
 
     # get all the locations for the ids
     inl = []
@@ -341,6 +341,6 @@ def bulk_article_delete():
     except:
         raise Api400Error("Supplied data was not valid JSON")
 
-    ArticlesBulkApi.delete(data, current_user)
+    ArticlesBulkApi.delete(data, current_user._get_current_object())
 
     return no_content()


### PR DESCRIPTION
…ocalProxy from current_user

https://github.com/DOAJ/doajPM/issues/1955

Fix only, tests later.

I've looked at the other uses of current user in similar contexts, and they look OK - it's just when we pass from current_user to the BLL which has argvalidate.