### PR TITLE
Removing duplicated subject

### DIFF
--- a/lccSubjects.xml
+++ b/lccSubjects.xml
@@ -1514,11 +1514,6 @@
     <parent>Chemical technology</parent>
   </subject>
   <subject>
-    <name>Materials of engineering and construction. Mechanics of materials</name>
-    <code>TA401-492</code>
-    <parent>Engineering (General). Civil engineering (General)</parent>
-  </subject>
-  <subject>
     <name>Railroad engineering and operation</name>
     <code>TF1-1620</code>
     <parent>Technology</parent>

--- a/lccSubjects.xml
+++ b/lccSubjects.xml
@@ -2449,11 +2449,6 @@
     <parent>Engineering (General). Civil engineering (General)</parent>
   </subject>
   <subject>
-    <name>Nuclear engineering. Atomic power</name>
-    <code>TK9001-9401</code>
-    <parent>Engineering (General). Civil engineering (General)</parent>
-  </subject>
-  <subject>
     <name>Applied optics. Photonics</name>
     <code>TA1501-1820</code>
     <parent>Engineering (General). Civil engineering (General)</parent>


### PR DESCRIPTION
The subjects `[TK9001-9401] Nuclear engineering. Atomic power` and `[TA401-492] Materials of engineering and construction. Mechanics of materials` are duplicated under different parents. I believe they're being override, as only one of each appears to be on use on the website. They also only appear under one parent [on the LOC website](https://www.loc.gov/aba/cataloging/classification/lcco/lcco_t.pdf).