### PR TITLE
add url validation to file uploader

### DIFF
--- a/portality/crosswalks/article_doaj_xml.py
+++ b/portality/crosswalks/article_doaj_xml.py
@@ -5,6 +5,7 @@ from portality.bll import exceptions
 from portality.crosswalks.exceptions import CrosswalkException
 from portality import models
 from datetime import datetime
+from urlparse import urlparse
 
 class DOAJXWalk(object):
     format_name = "doaj"
@@ -215,7 +216,16 @@ class DOAJXWalk(object):
         if ftel is not None and ftel.text is not None and ftel.text != "":
             ct = ftel.get("format")
             url = ftel.text
-            bibjson.add_url(url, "fulltext", ct)
+
+            try:
+                # url validation
+                result = urlparse(ftel.text)
+                if all([result.scheme, result.netloc, result.path]):
+                    bibjson.add_url(url, "fulltext", ct)
+                else:
+                    raise CrosswalkException(message="Invalid URL: {}".format(ftel.text), inner=e)
+            except Exception as e:
+                raise CrosswalkException(message="Invalid URL: {}".format(ftel.text), inner=e)
 
         # keywords
         keyel = record.find("keywords")


### PR DESCRIPTION
Fixes: https://github.com/DOAJ/doajPM/issues/2041
connected to: https://github.com/DOAJ/doajPM/issues/2038

Simple url validation. Tries to parse url and checks if all parts are included: 
scheme://netloc/path

Examples:
Valid:
http://www.journals.aoftw.edu.uk/view/1202/article.pdf
http://www.cwi.nl:80/%7Eguido/Python.html
http://doaj.org/index

Invalid:
www.journals.aoftw.edu.uk/view/1202
http://doaj.org
journals.aoftw.edu.uk/view/1202
//journals.aoftw.edu.uk/view/1202

Invalid URL causes processing failure with message "Invalid URL: url"