### PR TITLE
Create a csv file of the 800 oldest journals in DOAJ which have last updated date of Never

### DIFF
--- a/dev-basic.json
+++ b/dev-basic.json
@@ -1,0 +1,25 @@
+{
+	"elastic_search_host" : null,
+	"elastic_search_db" : null,
+	"confirm" : true,
+	"max_content_length" : 100000000,
+	"types" : {
+		"account" : {"import" : true, "limit" : -1},
+		"bulk_upload" : {"import" : false, "limit" : -1},
+		"bulk_reapplication" : {"import" : false, "limit" : -1},
+		"background_job" : {"import" : false, "limit" : -1},
+		"lock" : {"import" : false, "limit" : -1},
+		"journal" : {"import" : true, "limit" : -1},
+		"provenance" : {"import" : false, "limit" : -1},
+		"toc" : {"import" : false, "limit" : -1},
+		"journal_history" : {"import" : false, "limit" : -1},
+		"cache" : {"import" : false, "limit" : -1},
+		"article_history" : {"import" : false, "limit" : -1},
+		"lcc" : {"import" : false, "limit" : -1},
+		"suggestion" : {"import" : true, "limit" : -1},
+		"article" : {"import" : true, "limit" : 100000},
+		"news" : {"import" : true, "limit" : -1},
+		"editor_group" : {"import" : true, "limit" : -1},
+		"upload" : {"import" : false, "limit" : -1}
+	}
+}

--- a/portality/scripts/last_manual_update_never.py
+++ b/portality/scripts/last_manual_update_never.py
@@ -1,0 +1,48 @@
+from portality import models
+from portality.core import app
+from portality.clcsv import UnicodeWriter
+import esprit
+import codecs
+
+
+LAST_MANUAL_UPDATE_NEVER = {
+     "query": {
+        "filtered": {
+            "filter": {
+                "query": {
+                    "term": {
+                        "last_manual_update": "1970-01-01T00:00:00Z"
+                    }
+                }
+            }
+        }
+    },
+    "sort": [{
+        "created_date": "asc"
+    }]
+}
+
+if __name__ == "__main__":
+
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--out", help="output file path")
+    args = parser.parse_args()
+
+    if not args.out:
+        print "Please specify an output file path with the -o option"
+        parser.print_help()
+        exit()
+
+    conn = esprit.raw.make_connection(None, app.config["ELASTIC_SEARCH_HOST"], None, app.config["ELASTIC_SEARCH_DB"])
+
+    with codecs.open(args.out, "wb", "utf-8") as f:
+        writer = UnicodeWriter(f)
+        writer.writerow(["ID", "Journal Name", "E-ISSN", "P-ISSN", "Created Date"])
+
+        for j in esprit.tasks.scroll(conn, models.Journal.__type__, q=LAST_MANUAL_UPDATE_NEVER, limit=800, keepalive='5m'):
+            journal = models.Journal(_source=j)
+            bibjson = journal.bibjson()
+            issns = bibjson.issns()
+
+            writer.writerow([journal.id, bibjson.title, bibjson.get_one_identifier(bibjson.E_ISSN), bibjson.get_one_identifier(bibjson.P_ISSN), journal.created_date])

--- a/portality/scripts/last_manual_update_never.py
+++ b/portality/scripts/last_manual_update_never.py
@@ -8,12 +8,11 @@ import codecs
 LAST_MANUAL_UPDATE_NEVER = {
      "query": {
         "filtered": {
+        	"query": { "term": {"last_manual_update": "1970-01-01T00:00:00Z"}},
             "filter": {
-                "query": {
-                    "term": {
-                        "last_manual_update": "1970-01-01T00:00:00Z"
-                    }
-                }
+            	"bool": {
+	                "must": { "term": {"in_doaj": "true"}}
+	            }
             }
         }
     },


### PR DESCRIPTION
Fixes: https://github.com/DOAJ/doajPM/issues/2068

To get the result file run:
python portality/scripts/last_manual_update_never.py -o result.csv

@Steven-Eardley Could you please run this on the live server and share the result file?