### PR TITLE
prevent removing last author div from metadata form

### DIFF
--- a/doajtest/unit/test_formcontext_emails.py
+++ b/doajtest/unit/test_formcontext_emails.py
@@ -792,7 +792,7 @@ class TestUpdateRequestReviewEmails(DoajTestCase):
 
         publisher_template = 'publisher_update_request_editor_assigned.txt'
         publisher_to = re.escape(owner.email)
-        publisher_subject = 'your application has been assigned an editor for review'
+        publisher_subject = 'your update request has been assigned an editor for review'
 
         publisher_email_matched = re.search(email_log_regex % (publisher_template, publisher_to, publisher_subject),
                                             info_stream_contents,
@@ -979,7 +979,7 @@ class TestUpdateRequestReviewEmails(DoajTestCase):
 
         publisher_template = 'publisher_update_request_editor_assigned.txt'
         publisher_to = re.escape(owner.email)
-        publisher_subject = 'your application has been assigned an editor for review'
+        publisher_subject = 'your update request has been assigned an editor for review'
 
         publisher_email_matched = re.search(email_log_regex % (publisher_template, publisher_to, publisher_subject),
                                             info_stream_contents,
@@ -1089,7 +1089,7 @@ class TestUpdateRequestReviewEmails(DoajTestCase):
         #   * to the publisher, notifying that an editor is viewing their application
         publisher_template = re.escape('publisher_update_request_inprogress.txt')
         publisher_to = re.escape(owner.email)
-        publisher_subject = 'your application is under review'
+        publisher_subject = 'your update request is under review'
 
         publisher_email_matched = re.search(email_log_regex % (publisher_template, publisher_to, publisher_subject),
                                             info_stream_contents,

--- a/portality/templates/publisher/metadata.html
+++ b/portality/templates/publisher/metadata.html
@@ -127,9 +127,9 @@ $(document).ready(function() {
     function showHideFirstRemoveButton() {
         // Hide delete button when there's just one author
         if ($('[id^=authors-][id$="container"]').length === 1) {
-            $('#remove_authors-0').hide();
+            $('#remove_authors-0').css('visibility', 'hidden')
         } else {
-            $('#remove_authors-0').show();
+            $('#remove_authors-0').css('visibility', 'visible')
         }
     }
     
@@ -183,7 +183,7 @@ $(document).ready(function() {
         rem_b.unbind("click");
         rem_b.click(removeAuthor);
         if (all_e.length === 1){
-            $('#remove_authors-1').show()
+            $('#remove_authors-1').css('visibility', 'visible')
         }
 
         showHideFirstRemoveButton()

--- a/portality/templates/publisher/metadata.html
+++ b/portality/templates/publisher/metadata.html
@@ -123,11 +123,18 @@ $(document).ready(function() {
             ce.attr('name', id);
         })
     }
+
+    function showHideFirstRemoveButton() {
+        // Hide delete button when there's just one author
+        if ($('[id^=authors-][id$="container"]').length === 1) {
+            $('#remove_authors-0').hide();
+        } else {
+            $('#remove_authors-0').show();
+        }
+    }
     
     function removeAuthor() {
         event.preventDefault();
-
-        var all_e = $('[id^=authors-][id$="container"]');
 
         var id = $(this).attr("id");
         var short_name = id.split("_")[1];
@@ -136,14 +143,16 @@ $(document).ready(function() {
         $("#" + container).remove();
 
         var count = 0;
-        $(all_e).each(function() {
+        $('[id^=authors-][id$="container"]').each(function() {
             prepAuthorContainer({
                 element : this,
                 number: count,
                 reset_value: false
             });
             count++;
-        })
+        });
+
+        showHideFirstRemoveButton()
     }
 
     $('input[name=more_authors]').click( function(event) {
@@ -176,6 +185,8 @@ $(document).ready(function() {
         if (all_e.length === 1){
             $('#remove_authors-1').show()
         }
+
+        showHideFirstRemoveButton()
 	});
 
     $(".remove_button").click(removeAuthor);
@@ -186,7 +197,6 @@ $(document).ready(function() {
         tokenSeparators: [","]
     });
 
-    $('#remove_authors-0').hide();
     $("#pissn").select2();
     $("#eissn").select2()
 

--- a/portality/templates/publisher/metadata.html
+++ b/portality/templates/publisher/metadata.html
@@ -127,13 +127,22 @@ $(document).ready(function() {
     
     function removeAuthor() {
         event.preventDefault();
-        
+
+        var all_e = $('[id^=authors-][id$="container"]');
+        if (all_e.length === 1) {
+            console.log($('#remove_warning') == 0)
+            if ($('#remove_warning').length == 0) {
+                all_e.last().append('<div id="remove_warning"><ul class="red"><li>Please provide at least one author</li></ul><div>')
+            }
+            return
+        }
+
         var id = $(this).attr("id")
         var short_name = id.split("_")[1]
         var container = short_name + "-container"
-        
+
         $("#" + container).remove()
-        
+
         var count = 0
         $('[id^=authors-][id$="container"]').each(function() {
             prepAuthorContainer({
@@ -147,11 +156,14 @@ $(document).ready(function() {
 
     $('input[name=more_authors]').click( function (event) {
         event.preventDefault();
-        
+
+        if ($('#remove_warning')){
+            ($('#remove_warning')).remove()
+        }
         // get the last author div in the list
         var all_e = $('[id^=authors-][id$="container"]');
         var e = all_e.last();
-        
+
         // make a clone of the last author div
         var ne = e.clone()[0];
 

--- a/portality/templates/publisher/metadata.html
+++ b/portality/templates/publisher/metadata.html
@@ -86,14 +86,13 @@
 $(document).ready(function() {
 
     function prepAuthorContainer(params) {
-        var ne = params.element
-        var reset = params.reset_value
-        var number = params.number
+        var ne = params.element;
+        var reset = params.reset_value;
+        var number = params.number;
+
+        ne.id = 'authors-' + number + '-container';
         
-        var new_id = 'authors-' + number + '-container';
-        ne.id = new_id;
-        
-        ne = $(ne)
+        ne = $(ne);
         ne.find('[id^=authors-]').each( function () {
             var ce = $(this);
             
@@ -130,30 +129,29 @@ $(document).ready(function() {
 
         var all_e = $('[id^=authors-][id$="container"]');
 
-        var id = $(this).attr("id")
-        var short_name = id.split("_")[1]
-        var container = short_name + "-container"
+        var id = $(this).attr("id");
+        var short_name = id.split("_")[1];
+        var container = short_name + "-container";
 
-        $("#" + container).remove()
+        $("#" + container).remove();
 
-        var count = 0
-        $('[id^=authors-][id$="container"]').each(function() {
+        var count = 0;
+        $(all_e).each(function() {
             prepAuthorContainer({
                 element : this,
                 number: count,
                 reset_value: false
-            })
+            });
             count++;
         })
     }
 
-    $('input[name=more_authors]').click( function (event) {
+    $('input[name=more_authors]').click( function(event) {
         event.preventDefault();
 
         // get the last author div in the list
         var all_e = $('[id^=authors-][id$="container"]');
         var e = all_e.last();
-
 
         // make a clone of the last author div
         var ne = e.clone()[0];
@@ -168,12 +166,13 @@ $(document).ready(function() {
             element : ne,
             number : number,
             reset_value : true
-        })
+        });
 
         e.after(ne);
 
-        $(".remove_button").unbind("click")
-        $(".remove_button").click(removeAuthor)
+        var rem_b = $(".remove_button");
+        rem_b.unbind("click");
+        rem_b.click(removeAuthor);
         if (all_e.length === 1){
             $('#remove_authors-1').show()
         }
@@ -185,13 +184,11 @@ $(document).ready(function() {
         minimumInputLength: 1,
         tags: [],
         tokenSeparators: [","]
-    })
+    });
 
-    $('#remove_authors-0').hide()
-    $("#pissn").select2()
+    $('#remove_authors-0').hide();
+    $("#pissn").select2();
     $("#eissn").select2()
-
-
 
 })
 </script>

--- a/portality/templates/publisher/metadata.html
+++ b/portality/templates/publisher/metadata.html
@@ -99,7 +99,7 @@ $(document).ready(function() {
             
             // reset the value
             if (reset) {
-                ce.attr('value', '');
+                ce.val('')
             }
             
             // set the id as requestsed
@@ -162,14 +162,14 @@ $(document).ready(function() {
         var items = ne.id.split('-');
         var number = parseInt(items[1]);
         number = number + 1;
-        
+
         // increment all the numbers
         prepAuthorContainer({
             element : ne,
             number : number,
             reset_value : true
         })
-        
+
         e.after(ne);
 
         $(".remove_button").unbind("click")

--- a/portality/templates/publisher/metadata.html
+++ b/portality/templates/publisher/metadata.html
@@ -129,13 +129,6 @@ $(document).ready(function() {
         event.preventDefault();
 
         var all_e = $('[id^=authors-][id$="container"]');
-        if (all_e.length === 1) {
-            console.log($('#remove_warning') == 0)
-            if ($('#remove_warning').length == 0) {
-                all_e.last().append('<div id="remove_warning"><ul class="red"><li>Please provide at least one author</li></ul><div>')
-            }
-            return
-        }
 
         var id = $(this).attr("id")
         var short_name = id.split("_")[1]
@@ -157,12 +150,10 @@ $(document).ready(function() {
     $('input[name=more_authors]').click( function (event) {
         event.preventDefault();
 
-        if ($('#remove_warning')){
-            ($('#remove_warning')).remove()
-        }
         // get the last author div in the list
         var all_e = $('[id^=authors-][id$="container"]');
         var e = all_e.last();
+
 
         // make a clone of the last author div
         var ne = e.clone()[0];
@@ -180,9 +171,12 @@ $(document).ready(function() {
         })
         
         e.after(ne);
-        
+
         $(".remove_button").unbind("click")
         $(".remove_button").click(removeAuthor)
+        if (all_e.length === 1){
+            $('#remove_authors-1').show()
+        }
 	});
 
     $(".remove_button").click(removeAuthor);
@@ -193,6 +187,7 @@ $(document).ready(function() {
         tokenSeparators: [","]
     })
 
+    $('#remove_authors-0').hide()
     $("#pissn").select2()
     $("#eissn").select2()
 


### PR DESCRIPTION
On the upload metadata form for a publisher it is possible to remove all the authors' fields. Unfortunately then the button "Add More Authors" doesn't work. Because at least one Author is required I think it is a good idea to just prevent the user from removing all the fields and give him proper error if she/he tries to do so - exactly the same one as she/he would like to submit the form without the authors.
![Screenshot from 2019-10-16 13-54-49](https://user-images.githubusercontent.com/8298769/66921214-a0db7c00-f01c-11e9-8875-32cd55b93d62.png)
