### PR TITLE
OpenURL web endpoint tests

### DIFF
--- a/doajtest/unit/test_openurl.py
+++ b/doajtest/unit/test_openurl.py
@@ -7,7 +7,7 @@ from doajtest.helpers import DoajTestCase
 from portality import app, models
 from urllib.parse import urlparse
 
-QUERY='url_ver=Z39.88-2004&url_ctx_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Actx&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&rft.'
+QUERY='url_ver=Z39.88-2004&url_ctx_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Actx&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal'
 
 class TestOpenURL(DoajTestCase):
     @classmethod
@@ -44,12 +44,19 @@ class TestOpenURL(DoajTestCase):
             with self.app_test.test_client() as t_client:
                 resp = t_client.get(url_for('openurl.openurl', issn=j_private1.bibjson().get_one_identifier('pissn')))
                 query = urlparse(resp.location).query
-                assert query == QUERY + 'issn=' + j_private1.bibjson().get_one_identifier('pissn')
+                assert query == QUERY + '&rft.issn=' + j_private1.bibjson().get_one_identifier('pissn')
                 resp = t_client.get(url_for('openurl.openurl')+ query)
                 assert resp.status_code == 404
 
                 resp = t_client.get(url_for('openurl.openurl', issn=j_public1.bibjson().get_one_identifier('pissn')))
                 query = urlparse(resp.location).query
-                assert query == QUERY + 'issn=' + j_public1.bibjson().get_one_identifier('pissn')
+                assert query == QUERY + '&rft.issn=' + j_public1.bibjson().get_one_identifier('pissn')
                 resp = t_client.get(url_for('openurl.openurl') + query)
                 assert resp.status_code == 404
+
+                """ Check for new format """
+
+                resp = t_client.get(url_for('openurl.openurl',
+                                            url_ver='url_ver=Z39.88-2004',
+                                            issn=j_private1.bibjson().get_one_identifier('pissn')))
+                print(resp)

--- a/doajtest/unit/test_openurl.py
+++ b/doajtest/unit/test_openurl.py
@@ -36,9 +36,6 @@ class TestOpenURL(DoajTestCase):
         j_private1.set_in_doaj(False)
         j_private1.save(blocking=True)
 
-
-        print(j_private1.bibjson().get_one_identifier('pissn'), j_public1.bibjson().get_one_identifier('pissn'))
-
         time.sleep(1)
 
         """ Check if we receive only journals in DOAJ """

--- a/doajtest/unit/test_openurl.py
+++ b/doajtest/unit/test_openurl.py
@@ -1,0 +1,47 @@
+import time
+
+from flask import url_for
+
+from doajtest.fixtures import JournalFixtureFactory
+from doajtest.helpers import DoajTestCase
+from portality import app, models
+
+
+class TestOpenURL(DoajTestCase):
+    @classmethod
+    def setUpClass(cls):
+        app.testing = True
+
+    def setUp(self):
+        super(TestOpenURL, self).setUp()
+
+    def test_01_openurl_no_atrrs(self):
+        """ Check we get the correct response from the OAI endpoint ListMetdataFormats request"""
+        with self.app_test.test_request_context():
+            with self.app_test.test_client() as t_client:
+                resp = t_client.get(url_for('openurl.openurl'))
+                assert resp.status_code == 404
+
+                resp = t_client.get(url_for('openurl.help'))
+                assert resp.status_code == 200
+
+    def test_02_openurl_journal(self):
+        journal_sources = JournalFixtureFactory.make_many_journal_sources(4, in_doaj=True)
+        j_public1 = models.Journal(**journal_sources[0])
+        j_public1.save(blocking=True)
+
+        j_public2 = models.Journal(**journal_sources[1])
+        j_public2.save(blocking=True)
+
+
+        j_private1 = models.Journal(**journal_sources[2])
+        j_private1.set_in_doaj(False)
+        j_private1.save(blocking=True)
+
+        j_private2 = models.Journal(**journal_sources[3])
+        j_private2.set_in_doaj(False)
+        j_private2.save(blocking=True)
+
+        time.sleep(1)
+
+        """ Check if we receive only journals in DOAJ """

--- a/portality/view/openurl.py
+++ b/portality/view/openurl.py
@@ -15,7 +15,13 @@ def openurl():
         abort(404)
 
     # Validate the query syntax version and build an object representing it
-    parser_response = parse_query(query=unquote(request.query_string), req=request)
+
+    if isinstance(request.query_string,str):
+        parser_response = parse_query(query=unquote(request.query_string), req=request)
+    else:
+        r = unquote(request.query_string.decode('utf-8'))
+        parser_response = parse_query(query=unquote(r), req=request)
+
 
     # theoretically this can return None, so catch it
     if parser_response is None:
@@ -28,7 +34,7 @@ def openurl():
     # Log this request to analytics
     ga_event = analytics.GAEvent(category=app.config.get('GA_CATEGORY_OPENURL', 'OpenURL'),
                                  action=parser_response.genre,
-                                 label=unquote(request.query_string))
+                                 label=unquote(request.query_string.decode('utf-8')))
     ga_event.submit()
 
     # Get the OpenURLRequest object to issue a query and supply a url for the result
@@ -47,11 +53,15 @@ def parse_query(query, req):
     :return: an object representing the query, or a redirect to the reissued query, or None if failed.
     """
     # Check if this is new or old syntax, translate if necessary
-    if "url_ver=Z39.88-2004" not in query:
-        app.logger.info("Legacy OpenURL 0.1 request: " + unquote(req.url))
+    if 'url_ver=Z39.88-2004' not in query:
+        app.logger.info("Legacy OpenURL 0.1 request: " + unquote(req.url.decode('utf-8')))
         return old_to_new(req)
 
-    app.logger.info("OpenURL 1.0 request: " + unquote(req.url))
+    print(type(req.url))
+    if isinstance(req.url,str):
+        app.logger.info("OpenURL 1.0 request: " + unquote(req.url))
+    else:
+        app.logger.info("OpenURL 1.0 request: " + unquote(req.url.decode('utf-8')))
 
     # Wee function to strip of the referent namespace prefix from parameters
     rem_ns = lambda x: re.sub('rft.', '', x)

--- a/portality/view/openurl.py
+++ b/portality/view/openurl.py
@@ -54,7 +54,11 @@ def parse_query(query, req):
     """
     # Check if this is new or old syntax, translate if necessary
     if 'url_ver=Z39.88-2004' not in query:
-        app.logger.info("Legacy OpenURL 0.1 request: " + unquote(req.url.decode('utf-8')))
+        if isinstance(req.url, str):
+            app.logger.info("Legacy OpenURL 0.1 request: " + unquote(req.url))
+        else:
+            app.logger.info("Legacy OpenURL 0.1 request: " + unquote(req.url.decode('utf-8')))
+
         return old_to_new(req)
 
     print(type(req.url))


### PR DESCRIPTION
This test suit checks the old and new versions of OpenURL requests. Results in 88% of coverage on view/openurl.py and 78% on models/openurl.py.

Additionally, this PR fixes error found (thank you @Steven-Eardley for your help)