### PR TITLE
make url descriptions clickable

### DIFF
--- a/portality/formcontext/formcontext.py
+++ b/portality/formcontext/formcontext.py
@@ -232,9 +232,9 @@ class PrivateContext(FormContext):
             if field in self.form.data:
                 if self.form[field].data:
                     if not self.form[field].description:
-                        self.form[field].description = 'Full contents: <a href=' + self.form[field].data + ">" + self.form[field].data + "</a>"
+                        self.form[field].description = 'Full contents: <a href=' + self.form[field].data + " target='_blank'>" + self.form[field].data + "</a>"
                     else:
-                        self.form[field].description += '<br><br>Full contents: <a href=' + self.form[field].data + ">" + self.form[field].data + "</a>"
+                        self.form[field].description += '<br><br>Full contents: <a href=' + self.form[field].data + " target='_blank'>" + self.form[field].data + "</a>"
 
     def _carry_fixed_aspects(self):
         if self.source is None:

--- a/portality/formcontext/formcontext.py
+++ b/portality/formcontext/formcontext.py
@@ -16,7 +16,8 @@ ACC_MSG = 'Please note you <span class="red">cannot edit</span> this application
 SCOPE_MSG = 'Please note you <span class="red">cannot edit</span> this application as you don\'t have the necessary ' \
             'account permissions to edit applications which are {0}.'
 
-FIELDS_WITH_DESCRIPTION = ["publisher", "society_institution", "platform", "title", "alternative_title", "url", "processing_charges_url", "submission_charges_url", "articles_last_year_url", "digital_archiving_policy_url", "editorial_board_url", "review_process_url", "instructions_authors_url", "oa_statement_url", "license_url", "waiver_policy_url", "download_statistics_url", "copyright_url", "publishing_rights_url", "plagiarism_screening_url", "license_embedded_url"]
+FIELDS_WITH_DESCRIPTION = ["publisher", "society_institution", "platform", "title", "alternative_title"]
+URL_FIELDS = ["url", "processing_charges_url", "submission_charges_url", "articles_last_year_url", "digital_archiving_policy_url", "editorial_board_url", "review_process_url", "instructions_authors_url", "oa_statement_url", "license_url", "waiver_policy_url", "download_statistics_url", "copyright_url", "publishing_rights_url", "plagiarism_screening_url", "license_embedded_url"]
 
 class FormContext(object):
     def __init__(self, form_data=None, source=None):
@@ -223,6 +224,17 @@ class PrivateContext(FormContext):
                         self.form[field].description = 'Full contents: ' + self.form[field].data
                     else:
                         self.form[field].description += '<br><br>Full contents: ' + self.form[field].data
+
+    def _expand_url_descriptions(self, fields):
+        # add the contents of a few fields to their descriptions since select2 autocomplete
+        # would otherwise obscure the full values
+        for field in fields:
+            if field in self.form.data:
+                if self.form[field].data:
+                    if not self.form[field].description:
+                        self.form[field].description = 'Full contents: <a href=' + self.form[field].data + ">" + self.form[field].data + "</a>"
+                    else:
+                        self.form[field].description += '<br><br>Full contents: <a href=' + self.form[field].data + ">" + self.form[field].data + "</a>"
 
     def _carry_fixed_aspects(self):
         if self.source is None:
@@ -627,11 +639,13 @@ class ManEdApplicationReview(ApplicationContext):
         self.form = forms.ManEdApplicationReviewForm(formdata=self.form_data)
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def source2form(self):
         self.form = forms.ManEdApplicationReviewForm(data=xwalk.SuggestionFormXWalk.obj2form(self.source))
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
         if self.source.application_status == constants.APPLICATION_STATUS_ACCEPTED:
             self.info = ACC_MSG
 
@@ -849,11 +863,13 @@ class EditorApplicationReview(ApplicationContext):
         self.form = forms.EditorApplicationReviewForm(formdata=self.form_data)
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def source2form(self):
         self.form = forms.EditorApplicationReviewForm(data=xwalk.SuggestionFormXWalk.obj2form(self.source))
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
         editor_choices = list(sum(choices.Choices.application_status('editor'), ()))       # flattens the list of tuples
         if self.source.application_status not in editor_choices:
             self.info = SCOPE_MSG.format(self.source.application_status)
@@ -1006,11 +1022,13 @@ class AssEdApplicationReview(ApplicationContext):
         self.form = forms.AssEdApplicationReviewForm(formdata=self.form_data)
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def source2form(self):
         self.form = forms.AssEdApplicationReviewForm(data=xwalk.SuggestionFormXWalk.obj2form(self.source))
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
         associate_editor_choices = list(sum(choices.Choices.application_status(), ()))     # flattens the list of tuples
         if self.source.application_status not in associate_editor_choices:
@@ -1121,11 +1139,13 @@ class PublisherUpdateRequest(ApplicationContext):
     def data2form(self):
         self.form = forms.PublisherUpdateRequestForm(formdata=self.form_data)
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
         self._disable_fields()
 
     def source2form(self):
         self.form = forms.PublisherUpdateRequestForm(data=xwalk.SuggestionFormXWalk.obj2form(self.source))
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
         self._disable_fields()
 
     def pre_validate(self):
@@ -1381,12 +1401,14 @@ class PublisherUpdateRequestReadOnly(PrivateContext):
         self.form = forms.PublisherUpdateRequestForm(formdata=self.form_data)
         # self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
         self.renderer.disable_all_fields(False)
 
     def source2form(self):
         self.form = forms.PublisherUpdateRequestForm(data=xwalk.JournalFormXWalk.obj2form(self.source))
         # self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
         self.renderer.set_disabled_fields(["digital_archiving_policy"])
         # self.renderer.disable_all_fields(True)
 
@@ -1446,11 +1468,13 @@ class ManEdJournalReview(PrivateContext):
         self.form = forms.ManEdJournalReviewForm(formdata=self.form_data)
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def source2form(self):
         self.form = forms.ManEdJournalReviewForm(data=xwalk.JournalFormXWalk.obj2form(self.source))
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def pre_validate(self):
         # Editor field is populated in JS after page load - check the selected editor is actually in that editor group
@@ -1536,6 +1560,7 @@ class ManEdBulkEdit(PrivateContext):
     def data2form(self):
         self.form = forms.ManEdBulkEditJournalForm(formdata=self.form_data)
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
 
 class EditorJournalReview(PrivateContext):
@@ -1568,11 +1593,13 @@ class EditorJournalReview(PrivateContext):
         self.form = forms.EditorJournalReviewForm(formdata=self.form_data)
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def source2form(self):
         self.form = forms.EditorJournalReviewForm(data=xwalk.JournalFormXWalk.obj2form(self.source))
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def form2target(self):
         self.target = xwalk.JournalFormXWalk.form2obj(self.form)
@@ -1644,11 +1671,13 @@ class AssEdJournalReview(PrivateContext):
         self.form = forms.AssEdJournalReviewForm(formdata=self.form_data)
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def source2form(self):
         self.form = forms.AssEdJournalReviewForm(data=xwalk.JournalFormXWalk.obj2form(self.source))
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def form2target(self):
         self.target = xwalk.JournalFormXWalk.form2obj(self.form)
@@ -1711,11 +1740,13 @@ class ReadOnlyJournal(PrivateContext):
         self.form = forms.ReadOnlyJournalForm(formdata=self.form_data)
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def source2form(self):
         self.form = forms.ReadOnlyJournalForm(data=xwalk.JournalFormXWalk.obj2form(self.source))
         self._set_choices()
         self._expand_descriptions(FIELDS_WITH_DESCRIPTION)
+        self._expand_url_descriptions(URL_FIELDS)
 
     def form2target(self):
         pass  # you can't edit objects using this form


### PR DESCRIPTION
Fixes: https://github.com/DOAJ/doajPM/issues/2206
URL fields' full content descriptions are clickable URL and open in a new tab.

![Screenshot from 2019-11-04 10-46-48](https://user-images.githubusercontent.com/8298769/68115641-bf80b480-fef0-11e9-8a38-acee785fb7ad.png)
