### PR TITLE
If size param in query not valid return 10

### DIFF
--- a/portality/bll/services/query.py
+++ b/portality/bll/services/query.py
@@ -199,7 +199,10 @@ class Query(object):
 
     def size(self):
         if "size" in self.q:
-            return int(self.q["size"])
+            try:
+                return int(self.q["size"])
+            except ValueError:
+                return 10
         return 10
 
     def from_result(self):


### PR DESCRIPTION
Fixes: https://github.com/DOAJ/doajPM/issues/2193
If size param is not valid return 10