### PR TITLE
Change the code path back to cloo/doaj rather than cloo/doaj_python3

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -11,8 +11,8 @@ sudo apt-get install -q -y libxml2-dev libxslt-dev python3.7-dev lib32z1-dev aws
 # Run from the doaj folder that's already checked out
 
 # activate the virtualenv that we expect to be at /home/cloo/doaj
-. /home/cloo/doaj_python3/bin/activate
-cd /home/cloo/doaj_python3/src/doaj
+. /home/cloo/doaj/bin/activate
+cd /home/cloo/doaj/src/doaj
 
 # Install DOAJ submodules and requirements
 git submodule update --init --recursive

--- a/deploy/nginx/doaj
+++ b/deploy/nginx/doaj
@@ -55,13 +55,13 @@ server {
     error_log /var/log/nginx/doaj.error.log;
 
     location =/static/doaj/doajArticle(.*) { # this is for doajArticles.xsd, but is often accessed missing the "s", so use wildcard
-        alias /home/cloo/doaj_python3/src/doaj/portality/static/doaj/doajArticles.xsd;
+        alias /home/cloo/doaj/src/doaj/portality/static/doaj/doajArticles.xsd;
     }
     location =/static/doaj/iso_639-2b.xsd {
-        alias /home/cloo/doaj_python3/src/doaj/portality/static/doaj/iso_639-2b.xsd;
+        alias /home/cloo/doaj/src/doaj/portality/static/doaj/iso_639-2b.xsd;
     }
     location =/robots.txt {
-        alias /home/cloo/doaj_python3/src/doaj/deploy/robots-production.txt;
+        alias /home/cloo/doaj/src/doaj/deploy/robots-production.txt;
     }
     location / {
         return 301 https://$host$request_uri;
@@ -217,10 +217,10 @@ server {
     }
     
     location =/robots.txt {
-        alias /home/cloo/doaj_python3/src/doaj/deploy/robots-production.txt;
+        alias /home/cloo/doaj/src/doaj/deploy/robots-production.txt;
     }
     location /static/ {
-        alias /home/cloo/doaj_python3/src/doaj/portality/static/;
+        alias /home/cloo/doaj/src/doaj/portality/static/;
         autoindex off;
         expires max;
         add_header 'Access-Control-Allow-Origin' '*'; # why are these cors settings needed?

--- a/deploy/nginx/doaj-test
+++ b/deploy/nginx/doaj-test
@@ -22,10 +22,10 @@ server {
         proxy_pass http://localhost:5050/;
     }
     location =/robots.txt {
-        alias /home/cloo/doaj_python3/src/doaj/deploy/robots-test.txt;
+        alias /home/cloo/doaj/src/doaj/deploy/robots-test.txt;
     }
     location /static/ {
-        alias /home/cloo/doaj_python3/src/doaj/portality/static/;
+        alias /home/cloo/doaj/src/doaj/portality/static/;
         autoindex off;
         expires max;
     }

--- a/deploy/supervisor/production-background/huey-long-running.conf
+++ b/deploy/supervisor/production-background/huey-long-running.conf
@@ -1,8 +1,8 @@
 [program:huey-long-running]
-command=/home/cloo/doaj_python3/bin/python /home/cloo/doaj_python3/bin/huey_consumer.py -v portality.tasks.consumer_long_running.long_running
+command=/home/cloo/doaj/bin/python /home/cloo/doaj/bin/huey_consumer.py -v portality.tasks.consumer_long_running.long_running
 environment= DOAJENV=production
 user=cloo
-directory=/home/cloo/doaj_python3/src/doaj
+directory=/home/cloo/doaj/src/doaj
 stdout_logfile=/var/log/supervisor/%(program_name)s-stdout.log
 stderr_logfile=/var/log/supervisor/%(program_name)s-error.log
 autostart=true

--- a/deploy/supervisor/production-background/huey-main.conf
+++ b/deploy/supervisor/production-background/huey-main.conf
@@ -1,8 +1,8 @@
 [program:huey-main]
-command=/home/cloo/doaj_python3/bin/python /home/cloo/doaj_python3/bin/huey_consumer.py -v portality.tasks.consumer_main_queue.main_queue
+command=/home/cloo/doaj/bin/python /home/cloo/doaj/bin/huey_consumer.py -v portality.tasks.consumer_main_queue.main_queue
 environment= DOAJENV=production
 user=cloo
-directory=/home/cloo/doaj_python3/src/doaj
+directory=/home/cloo/doaj/src/doaj
 stdout_logfile=/var/log/supervisor/%(program_name)s-stdout.log
 stderr_logfile=/var/log/supervisor/%(program_name)s-error.log
 autostart=true

--- a/deploy/supervisor/production/doaj.conf
+++ b/deploy/supervisor/production/doaj.conf
@@ -1,8 +1,8 @@
 [program:doaj]
-command=/home/cloo/doaj_python3/bin/gunicorn -c /home/cloo/doaj_python3/src/doaj/deploy/doaj_gunicorn_config.py portality.app:app
+command=/home/cloo/doaj/bin/gunicorn -c /home/cloo/doaj/src/doaj/deploy/doaj_gunicorn_config.py portality.app:app
 environment = DOAJENV=production
 user=cloo
-directory=/home/cloo/doaj_python3/src/doaj
+directory=/home/cloo/doaj/src/doaj
 stdout_logfile=/var/log/supervisor/%(program_name)s-access.log
 stderr_logfile=/var/log/supervisor/%(program_name)s-error.log
 autostart=true

--- a/deploy/supervisor/test/doaj.conf
+++ b/deploy/supervisor/test/doaj.conf
@@ -1,8 +1,8 @@
 [program:doaj]
-command=/home/cloo/doaj_python3/bin/gunicorn -c /home/cloo/doaj_python3/src/doaj/deploy/doaj_test_gunicorn_config.py portality.app:app
+command=/home/cloo/doaj/bin/gunicorn -c /home/cloo/doaj/src/doaj/deploy/doaj_test_gunicorn_config.py portality.app:app
 environment= DOAJENV=test
 user=cloo
-directory=/home/cloo/doaj_python3/src/doaj
+directory=/home/cloo/doaj/src/doaj
 stdout_logfile=/var/log/supervisor/%(program_name)s-access.log
 stderr_logfile=/var/log/supervisor/%(program_name)s-error.log
 autostart=true

--- a/deploy/supervisor/test/huey-long-running.conf
+++ b/deploy/supervisor/test/huey-long-running.conf
@@ -1,8 +1,8 @@
 [program:huey-long-running]
-command=/home/cloo/doaj_python3/bin/python /home/cloo/doaj_python3/bin/huey_consumer.py -v portality.tasks.consumer_long_running.long_running
+command=/home/cloo/doaj/bin/python /home/cloo/doaj/bin/huey_consumer.py -v portality.tasks.consumer_long_running.long_running
 environment= DOAJENV=test
 user=cloo
-directory=/home/cloo/doaj_python3/src/doaj
+directory=/home/cloo/doaj/src/doaj
 stdout_logfile=/var/log/supervisor/%(program_name)s-stdout.log
 stderr_logfile=/var/log/supervisor/%(program_name)s-error.log
 autostart=true

--- a/deploy/supervisor/test/huey-main.conf
+++ b/deploy/supervisor/test/huey-main.conf
@@ -1,8 +1,8 @@
 [program:huey-main]
-command=/home/cloo/doaj_python3/bin/python /home/cloo/doaj_python3/bin/huey_consumer.py -v portality.tasks.consumer_main_queue.main_queue
+command=/home/cloo/doaj/bin/python /home/cloo/doaj/bin/huey_consumer.py -v portality.tasks.consumer_main_queue.main_queue
 environment= DOAJENV=test
 user=cloo
-directory=/home/cloo/doaj_python3/src/doaj
+directory=/home/cloo/doaj/src/doaj
 stdout_logfile=/var/log/supervisor/%(program_name)s-stdout.log
 stderr_logfile=/var/log/supervisor/%(program_name)s-error.log
 autostart=true


### PR DESCRIPTION
This is the prerequisite to running the `finalise_python3` upgrade script to finish the deployment. It changes the DOAJ code back to expecting the path to be `/home/cloo/doaj/src/doaj` - this means the previous deployment scripts and the wiki will be correct.

I've created this as a feature branch so that we can merge to develop and run the test server version of this script first.