### PR TITLE
Remove ISSN check in deduplication system

### DIFF
--- a/doajtest/unit/test_article_match.py
+++ b/doajtest/unit/test_article_match.py
@@ -270,5 +270,5 @@ class TestArticleMatch(DoajTestCase):
 
         issns = [random_issn() for _ in range(2000)] + ["0000-0000"]
 
-        dupes = models.Article.duplicates(issns=issns, doi="10.1234/duplicate")
+        dupes = models.Article.duplicates(doi="10.1234/duplicate")
         assert len(dupes) == 1

--- a/portality/bll/services/article.py
+++ b/portality/bll/services/article.py
@@ -394,7 +394,7 @@ class ArticleService(object):
         doi = article.get_normalised_doi()
         if doi is not None:
             if isinstance(doi, str) and doi != '':
-                articles = models.Article.duplicates(issns=issns, doi=doi, size=results_per_match_type)
+                articles = models.Article.duplicates(doi=doi, size=results_per_match_type)
                 if len(articles) > 0:
                     possible_articles['doi'] = [a for a in articles if a.id != article.id]
                     if len(possible_articles['doi']) > 0:
@@ -403,7 +403,7 @@ class ArticleService(object):
         # Second test is to look by fulltext url
         fulltext = article.get_normalised_fulltext()
         if fulltext is not None:
-            articles = models.Article.duplicates(issns=issns, fulltexts=fulltext, size=results_per_match_type)
+            articles = models.Article.duplicates(fulltexts=fulltext, size=results_per_match_type)
             if len(articles) > 0:
                 possible_articles['fulltext'] = [a for a in articles if a.id != article.id]
                 if possible_articles['fulltext']:

--- a/portality/models/article.py
+++ b/portality/models/article.py
@@ -20,9 +20,8 @@ class Article(DomainObject):
     __type__ = "article"
 
     @classmethod
-    def duplicates(cls, issns=None, publisher_record_id=None, doi=None, fulltexts=None, title=None, volume=None, number=None, start=None, should_match=None, size=10):
+    def duplicates(cls, publisher_record_id=None, doi=None, fulltexts=None, title=None, volume=None, number=None, start=None, should_match=None, size=10):
         # some input sanitisation
-        issns = issns if isinstance(issns, list) else []
         urls = fulltexts if isinstance(fulltexts, list) else [fulltexts] if isinstance(fulltexts, str) or isinstance(fulltexts, str) else []
 
         # make sure that we're dealing with the normal form of the identifiers
@@ -42,49 +41,19 @@ class Article(DomainObject):
             # leave the doi as it is
             pass
 
-        # in order to make sure we don't send too many terms to the ES query, break the issn list down into chunks
-        terms_limit = app.config.get("ES_TERMS_LIMIT", 1024)
-        issn_groups = []
-        lower = 0
-        upper = terms_limit
-        while lower < len(issns):
-            issn_groups.append(issns[lower:upper])
-            lower = upper
-            upper = lower + terms_limit
+        q = DuplicateArticleQuery(publisher_record_id=publisher_record_id,
+                                    doi=doi,
+                                    urls=urls,
+                                    title=title,
+                                    volume=volume,
+                                    number=number,
+                                    start=start,
+                                    should_match=should_match,
+                                    size=size)
+        # print json.dumps(q.query())
 
-        if issns is not None and len(issns) > 0:
-            duplicate_articles = []
-            for g in issn_groups:
-                q = DuplicateArticleQuery(issns=g,
-                                            publisher_record_id=publisher_record_id,
-                                            doi=doi,
-                                            urls=urls,
-                                            title=title,
-                                            volume=volume,
-                                            number=number,
-                                            start=start,
-                                            should_match=should_match,
-                                            size=size)
-                # print json.dumps(q.query())
-
-                res = cls.query(q=q.query())
-                duplicate_articles += [cls(**hit.get("_source")) for hit in res.get("hits", {}).get("hits", [])]
-
-            return duplicate_articles
-        else:
-            q = DuplicateArticleQuery(publisher_record_id=publisher_record_id,
-                                        doi=doi,
-                                        urls=urls,
-                                        title=title,
-                                        volume=volume,
-                                        number=number,
-                                        start=start,
-                                        should_match=should_match,
-                                        size=size)
-            # print json.dumps(q.query())
-
-            res = cls.query(q=q.query())
-            return [cls(**hit.get("_source")) for hit in res.get("hits", {}).get("hits", [])]
+        res = cls.query(q=q.query())
+        return [cls(**hit.get("_source")) for hit in res.get("hits", {}).get("hits", [])]
 
     @classmethod
     def list_volumes(cls, issns):


### PR DESCRIPTION
The hotfix removes ISSN param and check in deduplication system - always checks the whole DB so that there is no possibility to introduce articles with the same DOI and URL but different ISSNs as an existing article.

Fixes: https://github.com/DOAJ/doajPM/issues/2228