### PR TITLE
upgrade esprit version and make local store store in binary mode

### DIFF
--- a/doajtest/helpers.py
+++ b/doajtest/helpers.py
@@ -7,7 +7,7 @@ from doajtest.bootstrap import prepare_for_test
 import dictdiffer
 from datetime import datetime
 from glob import glob
-import os, csv
+import os, csv, shutil
 from portality.lib import paths
 
 prepare_for_test()
@@ -33,6 +33,7 @@ class DoajTestCase(TestCase):
         self.destroy_index()
         for f in self.list_today_article_history_files() + self.list_today_journal_history_files():
             os.remove(f)
+        shutil.rmtree(paths.rel2abs(__file__, "..", "tmp"), ignore_errors=True)
 
     def list_today_article_history_files(self):
         return glob(os.path.join(app.config['ARTICLE_HISTORY_DIR'], datetime.now().strftime('%Y-%m-%d'), '*'))

--- a/doajtest/unit/test_store.py
+++ b/doajtest/unit/test_store.py
@@ -1,0 +1,48 @@
+from doajtest.helpers import DoajTestCase
+from portality.store import StoreFactory
+from io import StringIO, BytesIO
+
+class SludgePump(object):
+    def __init__(self, size, format="bytes"):
+        self._size = size
+        self._cursor = 0
+
+    def read(self, n):
+        nc = self._cursor + n
+        if nc > self._size:
+            nc = self._size
+        total = nc - n
+        if format == "bytes":
+            return b"x" * total
+        else:
+            return "x" * total
+
+class TestStore(DoajTestCase):
+
+    def setUp(self):
+        super(TestStore, self).setUp()
+
+    def tearDown(self):
+        super(TestStore, self).tearDown()
+
+    def test_01_local(self):
+        local = StoreFactory.get(None)
+
+        stringin = StringIO("test")
+        local.store("string", "string.txt", source_stream=stringin)
+
+        stringout_bin = local.get("string", "string.txt")
+        assert stringout_bin.read().decode("utf-8") == "test"
+
+        stringout_utf8 = local.get("string", "string.txt", encoding="utf-8")
+        assert stringout_utf8.read() == "test"
+
+        bytesin = BytesIO(b"here are some bytes")
+        local.store("bytes", "bytes.bin", source_stream=bytesin)
+
+        bytesout_bin = local.get("bytes", "bytes.bin")
+        assert bytesout_bin.read() == b"here are some bytes"
+
+    def test_02_local_large(self):
+        local = StoreFactory.get(None)
+        local.store("sludge", "sludge.txt", source_stream=SludgePump(100000000, format="text"))

--- a/doajtest/unit/test_store.py
+++ b/doajtest/unit/test_store.py
@@ -11,11 +11,16 @@ class SludgePump(object):
         nc = self._cursor + n
         if nc > self._size:
             nc = self._size
-        total = nc - n
+        total = nc - self._cursor
+        self._cursor = nc
         if format == "bytes":
-            return b"x" * total
+            if total > 0:
+                return b"x" * total
+            return b""
         else:
-            return "x" * total
+            if total > 0:
+                return "x" * total
+            return ""
 
 class TestStore(DoajTestCase):
 
@@ -45,4 +50,9 @@ class TestStore(DoajTestCase):
 
     def test_02_local_large(self):
         local = StoreFactory.get(None)
+
         local.store("sludge", "sludge.txt", source_stream=SludgePump(100000000, format="text"))
+        local.store("sludge", "sludge.bin", source_stream=SludgePump(90000000, format="bytes"))
+
+        assert local.size("sludge", "sludge.txt") == 100000000
+        assert local.size("sludge", "sludge.bin") == 90000000

--- a/portality/legacy_datasets.py
+++ b/portality/legacy_datasets.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 # countries
 with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", 'country-codes.json'), 'rb') as f:
-    countries = json.loads(f.read())
+    countries = json.loads(f.read().decode("utf-8"))
 countries_dict = OrderedDict(sorted(list(countries.items()), key=lambda x: x[1]['name']))
 countries = list(countries_dict.items())
 

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -142,6 +142,7 @@ STORE_LOCAL_DIR = paths.rel2abs(__file__, "..", "local_store", "main")
 STORE_TMP_DIR = paths.rel2abs(__file__, "..", "local_store", "tmp")
 STORE_LOCAL_EXPOSE = False  # if you want to allow files in the local store to be exposed under /store/<path> urls.  For dev only.
 STORE_LOCAL_WRITE_BUFFER_SIZE = 16777216
+STORE_TMP_WRITE_BUFFER_SIZE = 16777216
 
 # containers (buckets in AWS) where various content will be stored
 # These values are placeholders, and must be overridden in live deployment

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -141,6 +141,7 @@ from portality.lib import paths
 STORE_LOCAL_DIR = paths.rel2abs(__file__, "..", "local_store", "main")
 STORE_TMP_DIR = paths.rel2abs(__file__, "..", "local_store", "tmp")
 STORE_LOCAL_EXPOSE = False  # if you want to allow files in the local store to be exposed under /store/<path> urls.  For dev only.
+STORE_LOCAL_WRITE_BUFFER_SIZE = 16777216
 
 # containers (buckets in AWS) where various content will be stored
 # These values are placeholders, and must be overridden in live deployment

--- a/portality/store.py
+++ b/portality/store.py
@@ -175,8 +175,13 @@ class StoreLocal(Store):
         if source_path:
             shutil.copyfile(source_path, tpath)
         elif source_stream:
-            with open(tpath, "wb") as f:
-                f.write(source_stream.read())
+            buffer_size = 16777216
+            data = source_stream.read(buffer_size)
+            mode = "w" if isinstance(data, str) else "wb"
+            with open(tpath, mode) as f:
+                while data:
+                    f.write(data)
+                    data = source_stream.read(buffer_size)
 
     def exists(self, container_id):
         cpath = os.path.join(self.dir, container_id)

--- a/portality/store.py
+++ b/portality/store.py
@@ -175,7 +175,7 @@ class StoreLocal(Store):
         if source_path:
             shutil.copyfile(source_path, tpath)
         elif source_stream:
-            with open(tpath, "w") as f:
+            with open(tpath, "wb") as f:
                 f.write(source_stream.read())
 
     def exists(self, container_id):

--- a/portality/store.py
+++ b/portality/store.py
@@ -232,6 +232,7 @@ class TempStore(StoreLocal):
         self.dir = app.config.get("STORE_TMP_DIR")
         if self.dir is None:
             raise StoreException("STORE_TMP_DIR is not defined in config")
+        self.buffer_size = app.config.get("STORE_TMP_WRITE_BUFFER_SIZE", 16777216)
 
     def path(self, container_id, filename, create_container=False, must_exist=True):
         container_path = os.path.join(self.dir, container_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 # first get esprit, specifically the version we know will work (+ it's
 # not on PyPI)
--e git+https://github.com/CottageLabs/esprit.git@53573377be49e8f29d3819fc4618084cddfdef7d#egg=esprit
+-e git+https://github.com/CottageLabs/esprit.git@fbe1d5900adf88f94fbb1ff8a7b4c5476ce95ec8#egg=esprit
 -e git+https://github.com/CottageLabs/dictdiffer.git@cc86c1ca1a452169b1b2e4a0cb5fc9e6125bc572#egg=dictdiffer
 -e git+https://github.com/DOAJ/flask-swagger.git@f1dbf918d9903a588eed3cce2a87eeccc9f8cc0e#egg=flask-swagger
 -e git+https://github.com/CottageLabs/combinatrix.git@740d255f0050d53a20324df41c08981499bb292c#egg=combinatrix

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 # first get esprit, specifically the version we know will work (+ it's
 # not on PyPI)
--e git+https://github.com/CottageLabs/esprit.git@fbe1d5900adf88f94fbb1ff8a7b4c5476ce95ec8#egg=esprit
+-e git+https://github.com/CottageLabs/esprit.git@6fc6b24450627077f1d38145e14765f776feba8b#egg=esprit
 -e git+https://github.com/CottageLabs/dictdiffer.git@cc86c1ca1a452169b1b2e4a0cb5fc9e6125bc572#egg=dictdiffer
 -e git+https://github.com/DOAJ/flask-swagger.git@f1dbf918d9903a588eed3cce2a87eeccc9f8cc0e#egg=flask-swagger
 -e git+https://github.com/CottageLabs/combinatrix.git@740d255f0050d53a20324df41c08981499bb292c#egg=combinatrix


### PR DESCRIPTION
This PR introduces some improvements in the local and temp store implementations to handle byte or string streams, and also introduces buffered saves to limit local memory usage.  There's some basic tests for this.

We also set the version of esprit to the current master tip, which is the fully updated and working python 3 version.