### PR TITLE
Hotfix/2020 01 02 iss2253 api too many keywords

### DIFF
--- a/doajtest/unit/test_api_crud_article.py
+++ b/doajtest/unit/test_api_crud_article.py
@@ -480,3 +480,22 @@ class TestCrudArticle(DoajTestCase):
         account.set_id("test")
         with self.assertRaises(Api404Error):
             ArticlesCrudApi.delete("adfasdfhwefwef", account)
+
+    def test_12_too_many_keywords(self):
+        """ Check we get an error when we supply too many keywords to the API. """
+
+        # set up all the bits we need
+        account = models.Account()
+        account.set_id('test')
+        account.set_name("Tester")
+        account.set_email("test@test.com")
+        journal = models.Journal(**JournalFixtureFactory.make_journal_source(in_doaj=True))
+        journal.set_owner(account.id)
+        journal.save(blocking=True)
+
+        data = ArticleFixtureFactory.make_article_source()
+        data['bibjson']['keywords'] = ['one', 'two', 'three', 'four', 'five', 'six', 'seven']
+
+        with self.assertRaises(Api400Error):
+            ArticlesCrudApi.create(data, account)
+

--- a/portality/api/v1/crud/articles.py
+++ b/portality/api/v1/crud/articles.py
@@ -70,7 +70,7 @@ class ArticlesCrudApi(CrudApi):
         if account is None:
             raise Api401Error()
 
-        # convert the data into a suitable article model
+        # convert the data into a suitable article model (raises Api400Error if doesn't conform to struct)
         am = cls.prep_article(data)
 
         articleService = DOAJ.articleService()

--- a/portality/lib/dataobj.py
+++ b/portality/lib/dataobj.py
@@ -222,12 +222,16 @@ def string_canonicalise(canon, allow_fail=False):
 ############################################################
 
 ############################################################
-## The core data object which manages all the interactions
-## with the underlying data member variable
+# The core data object which manages all the interactions
+# with the underlying data member variable
+
 
 class DataObjException(Exception):
-    def __init__(self, msg, *args, **kwargs):
-        self.message = msg
+    def __init__(self, *args, **kwargs):
+        try:
+            self.message = args[0]
+        except IndexError:
+            self.message = ''
         super(DataObjException, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
Relates to issue : https://github.com/DOAJ/doajPM/issues/2253

This fix prevents the dataobj custom Exception from intercepting the message text, which was stopping it from propagating in chained exceptions.