### PR TITLE
Relax requirements for outgoing journal struct

### DIFF
--- a/doajtest/fixtures/journals.py
+++ b/doajtest/fixtures/journals.py
@@ -327,13 +327,13 @@ JOURNAL_APIDO_STRUCT = {
             "fields": {
                 "allows_fulltext_indexing": {"coerce": "bool"},
                 "alternative_title": {"coerce": "unicode"},
-                "apc_url": {"coerce": "url"},
+                "apc_url": {"coerce": "unicode"},
                 "country": {"coerce": "country_code"},
                 "institution": {"coerce": "unicode"},
                 "provider": {"coerce": "unicode"},
                 "publication_time": {"coerce": "integer"},
                 "publisher": {"coerce": "unicode"},
-                "submission_charges_url": {"coerce": "url"},
+                "submission_charges_url": {"coerce": "unicode"},
                 "title": {"coerce": "unicode"},
             },
             "lists": {
@@ -370,7 +370,7 @@ JOURNAL_APIDO_STRUCT = {
 
                 "archiving_policy": {               # NOTE: this is not the same as the storage model, so beware when working with this
                     "fields": {
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     },
                     "lists": {
                         "policy": {"coerce": "unicode", "contains": "object"},
@@ -389,28 +389,28 @@ JOURNAL_APIDO_STRUCT = {
                 "article_statistics": {
                     "fields": {
                         "statistics": {"coerce": "bool"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 
                 "author_copyright": {
                     "fields": {
                         "copyright": {"coerce": "unicode"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 
                 "author_publishing_rights": {
                     "fields": {
                         "publishing_rights": {"coerce": "unicode"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 
                 "editorial_review": {
                     "fields": {
                         "process": {"coerce": "unicode", "allowed_values" : ["Editorial review", "Peer review", "Blind peer review", "Double blind peer review", "Open peer review", "None"]},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 
@@ -425,7 +425,7 @@ JOURNAL_APIDO_STRUCT = {
                     "fields": {
                         "title": {"coerce": "license"},
                         "type": {"coerce": "license"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                         "version": {"coerce": "unicode"},
                         "open_access": {"coerce": "bool"},
                         "BY": {"coerce": "bool"},
@@ -433,37 +433,37 @@ JOURNAL_APIDO_STRUCT = {
                         "ND": {"coerce": "bool"},
                         "SA": {"coerce": "bool"},
                         "embedded": {"coerce": "bool"},
-                        "embedded_example_url": {"coerce": "url"},
+                        "embedded_example_url": {"coerce": "unicode"},
                     }
                 },
 
                 "link": {
                     "fields": {
                         "type": {"coerce": "unicode"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 
                 "oa_start": {
                     "fields": {
                         "year": {"coerce": "integer"},
-                        "volume": {"coerce": "integer"},
-                        "number": {"coerce": "integer"},
+                        "volume": {"coerce": "unicode"},
+                        "number": {"coerce": "unicode"},
                     }
                 },
 
                 "oa_end": {
                     "fields": {
                         "year": {"coerce": "integer"},
-                        "volume": {"coerce": "integer"},
-                        "number": {"coerce": "integer"},
+                        "volume": {"coerce": "unicode"},
+                        "number": {"coerce": "unicode"},
                     }
                 },
 
                 "plagiarism_detection": {
                     "fields": {
                         "detection": {"coerce": "bool"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 

--- a/doajtest/unit/test_api_dataobj.py
+++ b/doajtest/unit/test_api_dataobj.py
@@ -62,12 +62,12 @@ class TestAPIDataObj(DoajTestCase):
             assert isinstance(getattr(do.bibjson, l), list), '{0} declared as "list" but not a list?'.format(l)
 
         assert do.bibjson.oa_start.year == int(self.jm.bibjson().oa_start.get('year'))
-        assert do.bibjson.oa_start.volume == int(self.jm.bibjson().oa_start.get('volume'))
-        assert do.bibjson.oa_start.number == int(self.jm.bibjson().oa_start.get('number'))
+        assert do.bibjson.oa_start.volume == self.jm.bibjson().oa_start.get('volume')
+        assert do.bibjson.oa_start.number == self.jm.bibjson().oa_start.get('number')
 
         assert do.bibjson.oa_end.year == int(self.jm.bibjson().oa_end.get('year'))
-        assert do.bibjson.oa_end.volume == int(self.jm.bibjson().oa_end.get('volume'))
-        assert do.bibjson.oa_end.number == int(self.jm.bibjson().oa_end.get('number'))
+        assert do.bibjson.oa_end.volume == self.jm.bibjson().oa_end.get('volume')
+        assert do.bibjson.oa_end.number == self.jm.bibjson().oa_end.get('number')
 
         assert do.bibjson.apc.currency == self.jm.bibjson().apc['currency']
         assert do.bibjson.apc.average_price == self.jm.bibjson().apc['average_price']

--- a/portality/api/v1/data_objects/journal.py
+++ b/portality/api/v1/data_objects/journal.py
@@ -155,16 +155,16 @@ JOURNAL_STRUCT = {
                 "oa_start": {
                     "fields": {
                         "year": {"coerce": "integer"},
-                        "volume": {"coerce": "integer"},
-                        "number": {"coerce": "integer"},
+                        "volume": {"coerce": "unicode"},
+                        "number": {"coerce": "unicode"},
                     }
                 },
 
                 "oa_end": {
                     "fields": {
                         "year": {"coerce": "integer"},
-                        "volume": {"coerce": "integer"},
-                        "number": {"coerce": "integer"},
+                        "volume": {"coerce": "unicode"},
+                        "number": {"coerce": "unicode"},
                     }
                 },
 

--- a/portality/api/v1/data_objects/journal.py
+++ b/portality/api/v1/data_objects/journal.py
@@ -35,13 +35,13 @@ JOURNAL_STRUCT = {
             "fields": {
                 "allows_fulltext_indexing": {"coerce": "bool"},
                 "alternative_title": {"coerce": "unicode"},
-                "apc_url": {"coerce": "url"},
+                "apc_url": {"coerce": "unicode"},
                 "country": {"coerce": "country_code"},
                 "institution": {"coerce": "unicode"},
                 "provider": {"coerce": "unicode"},
                 "publication_time": {"coerce": "integer"},
                 "publisher": {"coerce": "unicode"},
-                "submission_charges_url": {"coerce": "url"},
+                "submission_charges_url": {"coerce": "unicode"},
                 "title": {"coerce": "unicode"},
             },
             "lists": {
@@ -78,7 +78,7 @@ JOURNAL_STRUCT = {
 
                 "archiving_policy": {               # NOTE: this is not the same as the storage model, so beware when working with this
                     "fields": {
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     },
                     "lists": {
                         "policy": {"coerce": "unicode", "contains": "object"},
@@ -97,28 +97,28 @@ JOURNAL_STRUCT = {
                 "article_statistics": {
                     "fields": {
                         "statistics": {"coerce": "bool"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 
                 "author_copyright": {
                     "fields": {
                         "copyright": {"coerce": "unicode"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 
                 "author_publishing_rights": {
                     "fields": {
                         "publishing_rights": {"coerce": "unicode"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 
                 "editorial_review": {
                     "fields": {
                         "process": {"coerce": "unicode", "allowed_values" : ["Editorial review", "Peer review", "Blind peer review", "Double blind peer review", "Open peer review", "None"]},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 
@@ -133,7 +133,7 @@ JOURNAL_STRUCT = {
                     "fields": {
                         "title": {"coerce": "license"},
                         "type": {"coerce": "license"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                         "version": {"coerce": "unicode"},
                         "open_access": {"coerce": "bool"},
                         "BY": {"coerce": "bool"},
@@ -141,14 +141,14 @@ JOURNAL_STRUCT = {
                         "ND": {"coerce": "bool"},
                         "SA": {"coerce": "bool"},
                         "embedded": {"coerce": "bool"},
-                        "embedded_example_url": {"coerce": "url"},
+                        "embedded_example_url": {"coerce": "unicode"},
                     }
                 },
 
                 "link": {
                     "fields": {
                         "type": {"coerce": "unicode"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 
@@ -171,7 +171,7 @@ JOURNAL_STRUCT = {
                 "plagiarism_detection": {
                     "fields": {
                         "detection": {"coerce": "bool"},
-                        "url": {"coerce": "url"},
+                        "url": {"coerce": "unicode"},
                     }
                 },
 


### PR DESCRIPTION
This PR does not require any URL for outgoing journals - unicode is accepted. That way even if url is not correct the journal metadata still will be displayed.

#Connects to: https://github.com/DOAJ/doajPM/issues/2268#issuecomment-579190600