### PR TITLE
make regex.py read the orcid regex from xsd

### DIFF
--- a/portality/regex.py
+++ b/portality/regex.py
@@ -1,16 +1,37 @@
 import re
 
+from lxml import etree
+
+from portality.core import app
+
 DOI = r"^((https?://)?((dx\.)?doi\.org/|hdl\.handle\.net/)|doi:|info:doi/|info:hdl/)?(?P<id>10\.\S+/\S+)$"
 DOI_COMPILED = re.compile(DOI, re.IGNORECASE)
-ORCID = r"^https://orcid\.org/[0-9]{4}-[0-9]{4}-[0-9]{4}-\d{3}[\dX]$"
+ORCID_XPATH = '/xs:schema[@version="1.2"]/xs:complexType[@name="recordType"]/xs:sequence/xs:element[@name="authors"]/xs:complexType/xs:sequence/xs:element[@name="author"]/xs:complexType/xs:sequence/xs:element[@name="orcid_id"]/xs:simpleType/xs:restriction/xs:pattern/@value'
+
+
+def _read_value(id):
+    with open(app.config.get("SCHEMAS")["doaj"]) as xsd:
+        doc = etree.parse(xsd)
+        if id == 'orcid':
+            data = doc.xpath(ORCID_XPATH, namespaces=doc.getroot().nsmap)
+        else:
+            data = doc.xpath(DOI_XPATH, namespaces=doc.getroot().nsmap)
+    return data[0]
+
+
+ORCID = r"^" + _read_value("orcid") + r"$"
 ORCID_COMPILED = re.compile(ORCID)
+
 
 def is_match(pattern, string, *args, **kwargs):
     match = re.match(pattern, string, *args, **kwargs)
+    print(match)
     return match is not None
+
 
 def group_match(pattern, string, name, *args, **kwargs):
     match = re.match(pattern, string, *args, **kwargs)
+    print(match)
     if match is None:
         return None
     return match.group(name)

--- a/portality/static/doaj/doajArticles.xsd
+++ b/portality/static/doaj/doajArticles.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema
-  version = "1.2"
+  version = "1.3"
   xmlns:xs ="http://www.w3.org/2001/XMLSchema"
   xmlns:iso_639-2b="http://www.doaj.org/schemas/iso_639-2b/1.1">
 
@@ -74,7 +74,13 @@
    <xs:element name="startPage" type="xs:string" minOccurs="0"/>
    <xs:element name="endPage" type="xs:string" minOccurs="0"/>
 
-   <xs:element name="doi" type="xs:string"  minOccurs="0"/>
+   <xs:element name="doi" minOccurs="0">
+    <xs:simpleType>
+     <xs:restriction base="xs:string">
+      <xs:pattern value="((https?://)?((dx\.)?doi\.org/|hdl\.handle\.net/)|doi:|info:doi/|info:hdl/)?10\.\S+/\S+"/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:element>
             
    <xs:element name="publisherRecordId" type="xs:string" minOccurs="0"/>
 


### PR DESCRIPTION
Fixes: https://github.com/DOAJ/doajPM/issues/2275

1. The main places where orcid and doi regexes are saved is our XSD
2. regex.py instead of duplicating them reads them from XSD and process them so that they are usable by our system:
  2a. adds `^` and `$` which are default in XSD
  2b. for DOI adds capturing group (not supported in XSD but used later to normalise DOI)