### PR TITLE
Release/2020 02 18 crossref release

### DIFF
--- a/portality/crosswalks/article_crossref_xml.py
+++ b/portality/crosswalks/article_crossref_xml.py
@@ -33,6 +33,9 @@ class CrossrefXWalk(object):
             doc = etree.parse(file_handle)
         except etree.XMLSyntaxError as e:  # although the treatment is the same, pulling this out so we remember what the primary kind of exception should be
             raise CrosswalkException(message="Unable to parse XML file", inner=e)
+        except UnicodeDecodeError as e:
+            msg = 'Text decode failed, expected utf-8 encoded XML.'
+            raise CrosswalkException(message='Unable to parse XML file', inner=e, inner_message=msg)
         except Exception as e:
             raise CrosswalkException(message="Unable to parse XML file", inner=e)
 

--- a/portality/crosswalks/article_doaj_xml.py
+++ b/portality/crosswalks/article_doaj_xml.py
@@ -35,6 +35,9 @@ class DOAJXWalk(object):
             doc = etree.parse(file_handle)
         except etree.XMLSyntaxError as e:   # although the treatment is the same, pulling this out so we remember what the primary kind of exception should be
             raise CrosswalkException(message="Unable to parse XML file", inner=e)
+        except UnicodeDecodeError as e:
+            msg = 'Text decode failed, expected utf-8 encoded XML.'
+            raise CrosswalkException(message='Unable to parse XML file', inner=e, inner_message=msg)
         except Exception as e:
             raise CrosswalkException(message="Unable to parse XML file", inner=e)
 

--- a/portality/models/uploads.py
+++ b/portality/models/uploads.py
@@ -2,6 +2,7 @@ from portality.dao import DomainObject
 from datetime import datetime
 from copy import deepcopy
 
+
 class FileUpload(DomainObject):
     __type__ = "upload"
 
@@ -106,67 +107,73 @@ class FileUpload(DomainObject):
         self.data["status"] = "downloaded"
 
     @classmethod
-    def list_valid(self):
+    def list_valid(cls):
         q = ValidFileQuery()
-        return self.iterate(q=q.query(), page_size=10000)
+        return cls.iterate(q=q.query(), page_size=10000)
 
     @classmethod
-    def list_remote(self):
+    def list_remote(cls):
         q = ExistsFileQuery()
-        return self.iterate(q=q.query(), page_size=10000)
+        return cls.iterate(q=q.query(), page_size=10000)
 
     @classmethod
-    def by_owner(self, owner, size=10):
+    def by_owner(cls, owner, size=10):
         q = OwnerFileQuery(owner)
-        res = self.query(q=q.query())
+        res = cls.query(q=q.query())
         rs = [FileUpload(**r.get("_source")) for r in res.get("hits", {}).get("hits", [])]
         return rs
 
+
 class ValidFileQuery(object):
     base_query = {
-        "query" : {
-            "term" : { "status.exact" : "validated" }
+        "query": {
+            "term": {"status.exact": "validated"}
         },
-        "sort" : [
-            {"created_date" : "asc"}
+        "sort": [
+            {"created_date": "asc"}
         ]
     }
+
     def __init__(self):
         self._query = deepcopy(self.base_query)
 
     def query(self):
         return self._query
+
 
 class ExistsFileQuery(object):
     base_query = {
-        "query" : {
-            "term" : { "status.exact" : "exists" }
+        "query": {
+            "term": {"status.exact": "exists"}
         },
-        "sort" : [
-            {"created_date" : "asc"}
+        "sort": [
+            {"created_date": "asc"}
         ]
     }
+
     def __init__(self):
         self._query = deepcopy(self.base_query)
 
     def query(self):
         return self._query
 
+
 class OwnerFileQuery(object):
     base_query = {
-        "query" : {
-            "bool" : {
-                "must" : []
+        "query": {
+            "bool": {
+                "must": []
             }
         },
-        "sort" : [
-            {"created_date" : "desc"}
+        "sort": [
+            {"created_date": "desc"}
         ],
-        "size" : 10
+        "size": 10
     }
+
     def __init__(self, owner, size=10):
         self._query = deepcopy(self.base_query)
-        owner_term = {"match" : {"owner" : owner}}
+        owner_term = {"match": {"owner": owner}}
         self._query["query"]["bool"]["must"].append(owner_term)
         self._query["size"] = size
 

--- a/portality/tasks/ingestarticles.py
+++ b/portality/tasks/ingestarticles.py
@@ -13,14 +13,16 @@ from portality.lib import plugin
 import ftplib, os, requests, traceback, shutil
 from urllib.parse import urlparse
 
-DEFAULT_MAX_REMOTE_SIZE=262144000
-CHUNK_SIZE=1048576
+DEFAULT_MAX_REMOTE_SIZE = 262144000
+CHUNK_SIZE = 1048576
+
 
 def file_failed(path):
     filename = os.path.split(path)[1]
     fad = app.config.get("FAILED_ARTICLE_DIR")
     dest = os.path.join(fad, filename)
     shutil.move(path, dest)
+
 
 def ftp_upload(job, path, parsed_url, file_upload):
     # 1. find out the file size
@@ -35,15 +37,16 @@ def ftp_upload(job, path, parsed_url, file_upload):
                          # hence, widely adopted ugly hack - since you can READ nonlocal
                          # vars from nested funcs, we use a mutable container!
     downloaded = [0]
+
     def ftp_callback(chunk):
-        '''Callback for processing downloaded chunks of the FTP file'''
+        """Callback for processing downloaded chunks of the FTP file"""
         if too_large[0]:
             return
         if type(chunk) == bytes:
-            l = len(chunk)
+            lc = len(chunk)
         else:
-            l = len(bytes(chunk, "utf-8"))
-        downloaded[0] += l
+            lc = len(bytes(chunk, "utf-8"))
+        downloaded[0] += lc
         if downloaded[0] > size_limit:
             too_large[0] = True
             return
@@ -55,7 +58,6 @@ def ftp_upload(job, path, parsed_url, file_upload):
                 else:
                     o.write(chunk)
                 o.flush()
-
 
     try:
         f = ftplib.FTP(parsed_url.hostname, parsed_url.username, parsed_url.password)
@@ -87,7 +89,7 @@ def ftp_upload(job, path, parsed_url, file_upload):
             file_upload.failed("The file at the URL was too large")
             job.add_audit_message("too large")
             try:
-                os.remove(path) # don't keep this file around
+                os.remove(path)  # don't keep this file around
             except:
                 pass
             return False
@@ -161,6 +163,7 @@ def http_upload(job, path, file_upload):
 
     file_upload.downloaded()
     return True
+
 
 class IngestArticlesBackgroundTask(BackgroundTask):
 
@@ -472,7 +475,6 @@ class IngestArticlesBackgroundTask(BackgroundTask):
             previous.insert(0, record)
             raise BackgroundException("Failed to upload file - please contact an administrator")
 
-
     @classmethod
     def _url_upload(cls, username, url, schema, previous):
         # first define a few functions
@@ -493,7 +495,6 @@ class IngestArticlesBackgroundTask(BackgroundTask):
             if get.status_code == requests.codes.ok:
                 return __ok(record, previous)
             return __fail(record, previous, error='error while checking submitted file reference: {0}'.format(get.status_code))
-
 
         def __ftp_upload(record, previous, parsed_url):
             # 1. find out whether the file exists
@@ -519,7 +520,6 @@ class IngestArticlesBackgroundTask(BackgroundTask):
                 return __fail(record, previous, error='error during FTP file existence check: ' + str(e.args))
 
             return __ok(record, previous)
-
 
         def __ok(record, previous):
             record.exists()
@@ -554,6 +554,7 @@ class IngestArticlesBackgroundTask(BackgroundTask):
             raise
         except Exception as e:
             return __fail(record, previous, error="please check it before submitting again; " + str(e))
+
 
 @main_queue.task(**configure("ingest_articles"))
 @write_required(script=True)

--- a/portality/tasks/ingestarticles.py
+++ b/portality/tasks/ingestarticles.py
@@ -282,7 +282,7 @@ class IngestArticlesBackgroundTask(BackgroundTask):
         try:
             xwalk = plugin.load_class(xwalk_name)()
         except IngestException:
-            raise RetryException(u"Unable to load schema {}".format(xwalk_name))
+            raise RetryException("Unable to load schema {}".format(xwalk_name))
 
         ingest_exception = False
         result = {}

--- a/portality/templates/publisher/uploadmetadata.html
+++ b/portality/templates/publisher/uploadmetadata.html
@@ -135,11 +135,7 @@
                         {%  if file.error_details or file.failure_reasons %}
                             <div id="details_{{ file.id }}" style="display:none">
                                 {% if file.error_details %}
-                                    {% if file.error_details == 'utf-8' %}
-                                        Wrong file format.
-                                    {% else %}
-                                        {{ file.error_details }}
-                                    {% endif %}
+                                    {{ file.error_details }}
                                 {% endif %}
 
                                 {% if file.failure_reasons %}


### PR DESCRIPTION
Mainly formatting improvements, but the changes to the _validate_file() functions change how the incorrect filetype error is being displayed.

Previously:
![image](https://user-images.githubusercontent.com/1446355/74741485-cab7e000-5254-11ea-8716-1542d1f7fb18.png)

Now:
![image](https://user-images.githubusercontent.com/1446355/74741523-de634680-5254-11ea-98a5-b664d4e980fb.png)

The error text is in the crosswalk rather than in the template.

Fix for https://github.com/DOAJ/doajPM/issues/2315