### PR TITLE
Hotfix/2302 2344 article metadata errors

### DIFF
--- a/portality/bll/services/article.py
+++ b/portality/bll/services/article.py
@@ -107,10 +107,6 @@ class ArticleService(object):
 
     def _prepare_update_admin(self, article, duplicate, update_article_id, merge_duplicate):
 
-        # we assume update_article_id is not None as admin update the articles only via Admin Article Form
-        if update_article_id is None:
-            raise exceptions.ConfigurationException("Upload articles for admin available only via Admin Metadata "
-                                                    "Article Form. Contact us if you can see this message")
         is_update = 0
         if duplicate is not None:
             if duplicate.id != update_article_id:
@@ -189,7 +185,8 @@ class ArticleService(object):
         if duplicate_check:
             duplicate = self.get_duplicate(article)
             try:
-                if account.has_role("admin"):
+                if account.has_role("admin") and update_article_id is not None:     # is update_article_id is None then treat as normal publisher upload
+                                                                                    # for testing by admin
                     is_update = self._prepare_update_admin(article, duplicate, update_article_id, merge_duplicate)
                 else:
                     is_update = self._prepare_update_publisher(article, duplicate, merge_duplicate, account, limit_to_account)

--- a/portality/crosswalks/article_crossref_xml.py
+++ b/portality/crosswalks/article_crossref_xml.py
@@ -250,7 +250,8 @@ Example record:
             text = ""
             if text_elems is not None:
                 for elems in text_elems:
-                    text = text + elems.text
+                    if elems.text is not None:
+                        text = text + elems.text
             bibjson.abstract = text[:30000]  # avoids Elasticsearch
             # exceptions about .exact analyser not being able to handle
             # more than 32766 UTF8 characters

--- a/portality/formcontext/formcontext.py
+++ b/portality/formcontext/formcontext.py
@@ -1885,7 +1885,7 @@ class PublisherMetadataForm(MetadataForm):
         self.template = "publisher/metadata.html"
 
     def render_template(self, **kwargs):
-        self._check_for_author_errors()
+        self._check_for_author_errors(**kwargs)
         if "validated" in kwargs and kwargs["validated"] == True:
             self.blank_form()
         return render_template(self.template, form=self.form, form_context=self, author_error=self.author_error)
@@ -1899,6 +1899,6 @@ class AdminMetadataArticleForm(MetadataForm):
         self.template = "admin/article_metadata.html"
 
     def render_template(self, **kwargs):
-        self._check_for_author_errors()
+        self._check_for_author_errors(**kwargs)
         return render_template(self.template, form=self.form, form_context=self, author_error=self.author_error)
 

--- a/portality/formcontext/formcontext.py
+++ b/portality/formcontext/formcontext.py
@@ -1818,6 +1818,21 @@ class MetadataForm(FormContext):
         if remove_author is not None:
             return self.render_template(remove_authors=remove_author)
 
+    def _check_for_author_errors(self, **kwargs):
+
+        if "more_authors" in kwargs and kwargs["more_authors"] == True:
+            self.form.authors.append_entry()
+        if "remove_authors" in kwargs:
+            keep = []
+            while len(self.form.authors.entries) > 0:
+                entry = self.form.authors.pop_entry()
+                if entry.short_name == "authors-" + kwargs["remove_author"]:
+                    break
+                else:
+                    keep.append(entry)
+            while len(keep) > 0:
+                self.form.authors.append_entry(keep.pop().data)
+
     def _validate_authors(self):
         counted = 0
         for entry in self.form.authors.entries:
@@ -1870,22 +1885,7 @@ class PublisherMetadataForm(MetadataForm):
         self.template = "publisher/metadata.html"
 
     def render_template(self, **kwargs):
-        errors = False
-        if "more_authors" in kwargs and kwargs["more_authors"] == True:
-            self.form.authors.append_entry()
-            errors = True
-        if "remove_authors" in kwargs:
-            errors = True
-            keep = []
-            while len(self.form.authors.entries) > 0:
-                entry = self.form.authors.pop_entry()
-                if entry.short_name == "authors-" + kwargs["remove_author"]:
-                    break
-                else:
-                    keep.append(entry)
-            while len(keep) > 0:
-                self.form.authors.append_entry(keep.pop().data)
-
+        self._check_for_author_errors()
         if "validated" in kwargs and kwargs["validated"] == True:
             self.blank_form()
         return render_template(self.template, form=self.form, form_context=self, author_error=self.author_error)
@@ -1899,18 +1899,6 @@ class AdminMetadataArticleForm(MetadataForm):
         self.template = "admin/article_metadata.html"
 
     def render_template(self, **kwargs):
-        if "more_authors" in kwargs and kwargs["more_authors"] == True:
-            self.form.authors.append_entry()
-        if "remove_authors" in kwargs:
-            keep = []
-            while len(self.form.authors.entries) > 0:
-                entry = self.form.authors.pop_entry()
-                if entry.short_name == "authors-" + kwargs["remove_author"]:
-                    break
-                else:
-                    keep.append(entry)
-            while len(keep) > 0:
-                self.form.authors.append_entry(keep.pop().data)
-
+        self._check_for_author_errors()
         return render_template(self.template, form=self.form, form_context=self, author_error=self.author_error)
 

--- a/portality/formcontext/formcontext.py
+++ b/portality/formcontext/formcontext.py
@@ -1842,22 +1842,6 @@ class MetadataForm(FormContext):
     def form2target(self):
         self.target = portality.formcontext.xwalks.metadata_article_form.MetadataArticleFormXwalk.form2obj(form=self.form)
 
-    def render_template(self, **kwargs):
-        if "more_authors" in kwargs and kwargs["more_authors"] == True:
-            self.form.authors.append_entry()
-        if "remove_authors" in kwargs:
-            keep = []
-            while len(self.form.authors.entries) > 0:
-                entry = self.form.authors.pop_entry()
-                if entry.short_name == "authors-" + kwargs["remove_author"]:
-                    break
-                else:
-                    keep.append(entry)
-            while len(keep) > 0:
-                self.form.authors.append_entry(keep.pop().data)
-
-        return render_template(self.template, form=self.form, form_context=self, author_error=self.author_error)
-
     def validate(self):
         if not self._validate_authors():
             self.author_error = True
@@ -1885,6 +1869,26 @@ class PublisherMetadataForm(MetadataForm):
     def set_template(self):
         self.template = "publisher/metadata.html"
 
+    def render_template(self, **kwargs):
+        errors = False
+        if "more_authors" in kwargs and kwargs["more_authors"] == True:
+            self.form.authors.append_entry()
+            errors = True
+        if "remove_authors" in kwargs:
+            errors = True
+            keep = []
+            while len(self.form.authors.entries) > 0:
+                entry = self.form.authors.pop_entry()
+                if entry.short_name == "authors-" + kwargs["remove_author"]:
+                    break
+                else:
+                    keep.append(entry)
+            while len(keep) > 0:
+                self.form.authors.append_entry(keep.pop().data)
+
+        if "validated" in kwargs and kwargs["validated"] == True:
+            self.blank_form()
+        return render_template(self.template, form=self.form, form_context=self, author_error=self.author_error)
 
 class AdminMetadataArticleForm(MetadataForm):
 
@@ -1894,5 +1898,19 @@ class AdminMetadataArticleForm(MetadataForm):
     def set_template(self):
         self.template = "admin/article_metadata.html"
 
+    def render_template(self, **kwargs):
+        if "more_authors" in kwargs and kwargs["more_authors"] == True:
+            self.form.authors.append_entry()
+        if "remove_authors" in kwargs:
+            keep = []
+            while len(self.form.authors.entries) > 0:
+                entry = self.form.authors.pop_entry()
+                if entry.short_name == "authors-" + kwargs["remove_author"]:
+                    break
+                else:
+                    keep.append(entry)
+            while len(keep) > 0:
+                self.form.authors.append_entry(keep.pop().data)
 
+        return render_template(self.template, form=self.form, form_context=self, author_error=self.author_error)
 

--- a/portality/view/publisher.py
+++ b/portality/view/publisher.py
@@ -196,15 +196,17 @@ def metadata():
 
         fc.modify_authors_if_required(request.values)
 
+        validated = False
         if fc.validate():
             try:
                 fc.finalise()
+                validated = True
             except ArticleMergeConflict:
                 Messages.flash(Messages.ARTICLE_METADATA_MERGE_CONFLICT)
             except DuplicateArticleException:
                 Messages.flash(Messages.ARTICLE_METADATA_UPDATE_CONFLICT)
 
-        return fc.render_template()
+        return fc.render_template(validated=validated)
 
 
 @blueprint.route("/help")


### PR DESCRIPTION
Fixed errors:

1. for empty abstract elements the Type Error is not raised
https://github.com/DOAJ/doajPM/issues/2344#event-3252405301

2. An empty form is returned after successful upload of article's metadata:
https://github.com/DOAJ/doajPM/issues/2402

If ANY error occurred (including duplicate errors) returned form is pre-filled with last metadata entered for the easy proof-reading. Is that correct behaviour?

I am not able to reproduce the error from p1: https://github.com/DOAJ/doajPM/issues/2402#issue-603246918

3. If admin uploads the article without upload_article_id (like via publisher's metadata form or API) it is treated as publishers upload) - even though not used in practical context it makes testing easier for admin accounts.