### PR TITLE
Feature/af redesign  ipt add es type

### DIFF
--- a/doajtest/fixtures/article.py
+++ b/doajtest/fixtures/article.py
@@ -187,7 +187,8 @@ ARTICLE_STRUCT = {
     "fields": {
         "id": {"coerce": "unicode"},  # Note that we'll leave these in for ease of use by the
         "created_date": {"coerce": "utcdatetime"},  # caller, but we'll need to ignore them on the conversion
-        "last_updated": {"coerce": "utcdatetime"}  # to the real object
+        "last_updated": {"coerce": "utcdatetime"},  # to the real object
+        "es_type": {"coerce": "unicode"}
     },
     "objects": ["admin", "bibjson"],
 

--- a/doajtest/fixtures/v2/journals.py
+++ b/doajtest/fixtures/v2/journals.py
@@ -278,7 +278,8 @@ JOURNAL_APIDO_STRUCT = {
         "id": {"coerce": "unicode"},
         "created_date": {"coerce": "utcdatetime"},
         "last_updated": {"coerce": "utcdatetime"},
-        'last_manual_update': {'coerce': 'utcdatetime'}
+        'last_manual_update': {'coerce': 'utcdatetime'},
+        "es_type": {"coerce": "unicode"}
     },
     "structs": {
         "admin": {

--- a/portality/api/v2/data_objects/application.py
+++ b/portality/api/v2/data_objects/application.py
@@ -36,11 +36,12 @@ OUTGOING_APPLICATION_STRUCT = {
 
 INTERNAL_APPLICATION_STRUCT = {
 "fields": {
-        "id": {"coerce": "unicode"},                # Note that we'll leave these in for ease of use by the
-        "created_date": {"coerce": "utcdatetime"},  # caller, but we'll need to ignore them on the conversion
-        "last_updated": {"coerce": "utcdatetime"}, # to the real object
-        "last_manual_update": {"coerce": "utcdatetime"}
-    },
+    "id": {"coerce": "unicode"},                # Note that we'll leave these in for ease of use by the
+    "created_date": {"coerce": "utcdatetime"},  # caller, but we'll need to ignore them on the conversion
+    "last_updated": {"coerce": "utcdatetime"}, # to the real object
+    "last_manual_update": {"coerce": "utcdatetime"},
+    "es_type": {"coerce": "unicode"}
+},
     "objects": ["admin", "bibjson"],
     "structs": {
         "admin" : {

--- a/portality/api/v2/data_objects/article.py
+++ b/portality/api/v2/data_objects/article.py
@@ -10,7 +10,8 @@ BASE_ARTICLE_STRUCT = {
     "fields": {
         "id": {"coerce": "unicode"},                # Note that we'll leave these in for ease of use by the
         "created_date": {"coerce": "utcdatetime"},  # caller, but we'll need to ignore them on the conversion
-        "last_updated": {"coerce": "utcdatetime"}   # to the real object
+        "last_updated": {"coerce": "utcdatetime"},  # to the real object
+        "es_type": {"coerce": "unicode"}
     },
     "objects": ["admin", "bibjson"],
 

--- a/portality/api/v2/data_objects/journal.py
+++ b/portality/api/v2/data_objects/journal.py
@@ -11,7 +11,8 @@ JOURNAL_STRUCT = {
         "id": {"coerce": "unicode"},
         "created_date": {"coerce": "utcdatetime"},
         "last_updated": {"coerce": "utcdatetime"},
-        "last_manual_update": {"coerce": "utcdatetime"}
+        "last_manual_update": {"coerce": "utcdatetime"},
+        "es_type": {"coerce": "unicode"}
     },
     "structs": {
         "admin": {

--- a/portality/dao.py
+++ b/portality/dao.py
@@ -115,6 +115,9 @@ class DomainObject(UserDict, object):
         if 'id' not in self.data:
             self.data['id'] = self.makeid()
 
+        if 'es_type' not in self.data and self.__type__ is not None:
+            self.data['es_type'] = self.__type__
+
         now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
         if (blocking or differentiate) and "last_updated" in self.data:
             diff = datetime.now() - datetime.strptime(self.data["last_updated"], "%Y-%m-%dT%H:%M:%SZ")

--- a/portality/migrate/20200423_af_redesign/migrate.py
+++ b/portality/migrate/20200423_af_redesign/migrate.py
@@ -131,7 +131,7 @@ permissive_bibjson_struct = {
         },
         "license": {
             "fields": {
-                "es_type": {"coerce": "unicode"},
+                "type": {"coerce": "unicode"},
                 "BY": {"coerce": "bool"},
                 "NC": {"coerce": "bool"},
                 "ND": {"coerce": "bool"},
@@ -541,7 +541,6 @@ batch_size = 1000
 # * article_history
 # * journal_history
 # * toc
-
 # Start with the straight copy operations
 for ct in copy_types:
     tt = ipt_prefix(ct)
@@ -608,7 +607,6 @@ for smt, tmt, source_model, target_model, processor in migrate_types:
     try:
         for result in esprit.tasks.scroll(sconn, smt, q=default_query, keepalive="2m", page_size=1000, scan=True):
             source = source_model(**result)
-            source.data['es_type'] = tmt
             try:
                 source.snapshot()  # FIXME: is this what we should actually do?  It means that the history system has a copy of the record at final stage, which seems sensible
             except AttributeError:
@@ -618,7 +616,7 @@ for smt, tmt, source_model, target_model, processor in migrate_types:
             target = target_model()
             processor(source, target)
             target.prep(is_update=False)  # in order to regenerate all the index fields, etc
-
+            target.data['es_type'] = tmt
             batch.append(target.data)
             if len(batch) >= batch_size:
                 total += len(batch)

--- a/portality/models/background.py
+++ b/portality/models/background.py
@@ -104,7 +104,8 @@ BACKGROUND_STRUCT = {
         "status": {"coerce": "unicode", "allowed_values": ["queued", "processing", "complete", "error", "cancelled"]},
         "user": {"coerce": "unicode"},
         "action": {"coerce": "unicode"},
-        "queue_id": {"coerce": "unicode"}
+        "queue_id": {"coerce": "unicode"},
+        "es_type": {"coerce": "unicode"}
     },
     "lists": {
         "audit": {"contains": "object"}

--- a/portality/models/harvester.py
+++ b/portality/models/harvester.py
@@ -227,6 +227,7 @@ HARVEST_STATE_STRUCT = {
         "issn" : {"coerce" : "unicode"},
         "status" : {"coerce" : "unicode", "allowed_values" : [u"suspended", u"active"]},
         "account" : {"coerce" : "unicode"},
+        "es_type": {"coerce": "unicode"}
     },
     "lists" : {
         "last_harvest" : {"contains" : "object"}

--- a/portality/models/provenance.py
+++ b/portality/models/provenance.py
@@ -135,7 +135,8 @@ PROVENANCE_STRUCT = {
         "type" : {"coerce" : "unicode"},
         "subtype" : {"coerce" : "unicode"},
         "action" : {"coerce" : "unicode"},
-        "resource_id" : {"coerce" : "unicode"}
+        "resource_id" : {"coerce" : "unicode"},
+        "es_type": {"coerce": "unicode"}
     },
     "lists" : {
         "roles" : {"contains" : "field", "coerce" : "unicode"},

--- a/portality/models/search.py
+++ b/portality/models/search.py
@@ -83,7 +83,7 @@ class JournalArticleQuery(object):
         "size" : 0,
         "facets" : {
             "type" : {
-                "terms" : {"field" : "_type"}
+                "terms": {"field": "es_type"}
             },
             "countries" : {
                 "terms" : {"field" : "index.country.exact", "size" : 10000 }

--- a/portality/models/v2/shared_structs.py
+++ b/portality/models/v2/shared_structs.py
@@ -173,7 +173,8 @@ SHARED_JOURNAL_LIKE = {
         "id" : {"coerce" : "unicode"},
         "created_date" : {"coerce" : "utcdatetime"},
         "last_updated" : {"coerce" : "utcdatetime"},
-        "last_manual_update" : {"coerce" : "utcdatetime"}
+        "last_manual_update" : {"coerce" : "utcdatetime"},
+        "es_type": {"coerce": "unicode"}
     },
     "objects" : [
         "admin",

--- a/portality/static/js/edges/admin.journalarticle.edge.js
+++ b/portality/static/js/edges/admin.journalarticle.edge.js
@@ -5,7 +5,7 @@ $.extend(true, doaj, {
 
         journalSelected : function(selector) {
             return function() {
-                var type = doaj.adminJournalArticleSearch.activeEdges[selector].currentQuery.listMust(es.newTermFilter({field: "_type"}));
+                var type = doaj.adminJournalArticleSearch.activeEdges[selector].currentQuery.listMust(es.newTermFilter({field: "es_type"}));
                 // var type = doaj.currentFVOptions.active_filters._type;
                 if (type && type.length > 0) {
                     type = type[0];
@@ -22,7 +22,7 @@ $.extend(true, doaj, {
 
         anySelected : function(selector) {
             return function() {
-                var type = doaj.adminJournalArticleSearch.activeEdges[selector].currentQuery.listMust(es.newTermFilter({field: "_type"}));
+                var type = doaj.adminJournalArticleSearch.activeEdges[selector].currentQuery.listMust(es.newTermFilter({field: "es_type"}));
                 if (!type || type.length === 0) {
                     return {
                         valid: false,
@@ -35,7 +35,7 @@ $.extend(true, doaj, {
 
         typeSelected : function(selector) {
             return function() {
-                var type = doaj.adminJournalArticleSearch.activeEdges[selector].currentQuery.listMust(es.newTermFilter({field: "_type"}));
+                var type = doaj.adminJournalArticleSearch.activeEdges[selector].currentQuery.listMust(es.newTermFilter({field: "es_type"}));
                 if (type && type.length > 0) {
                     return type[0].value;
                 }
@@ -111,7 +111,7 @@ $.extend(true, doaj, {
                 edges.newRefiningANDTermSelector({
                     id: "journals_articles",
                     category: "facet",
-                    field: "_type",
+                    field: "es_type",
                     display: "Journals vs Articles",
                     valueMap : {
                         "journal" : "Journals",
@@ -562,7 +562,7 @@ $.extend(true, doaj, {
                     id: "selected-filters",
                     category: "selected-filters",
                     fieldDisplays: {
-                        "_type": "Showing",
+                        "es_type": "Showing",
                         "admin.in_doaj" : "In DOAJ?",
                         "index.language.exact" : "Journal Language",
                         "bibjson.publisher.exact" : "Publisher",
@@ -576,7 +576,7 @@ $.extend(true, doaj, {
                         "bibjson.journal.title.exact" : "Journal title"
                     },
                     valueMaps : {
-                        "_type" : {
+                        "es_type" : {
                             "journal" : "Journals",
                             "article" : "Articles"
                         },

--- a/portality/static/js/edges/public.journalarticle.edge.js
+++ b/portality/static/js/edges/public.journalarticle.edge.js
@@ -50,7 +50,7 @@ $.extend(true, doaj, {
                 edges.newRefiningANDTermSelector({
                     id : "journal_article",
                     category: "facet",
-                    field: "_type",
+                    field: "es_type",
                     display: "Journals vs. Articles",
                     deactivateThreshold: 1,
                     size: 2,
@@ -317,7 +317,7 @@ $.extend(true, doaj, {
                     id: "selected-filters",
                     category: "selected-filters",
                     fieldDisplays : {
-                        "_type" : "Showing",
+                        "es_type" : "Showing",
                         "index.classification.exact" : "Subject",
                         "index.has_apc.exact" : "Article processing charges (APCs)",
                         "index.has_seal.exact" : "DOAJ Seal",
@@ -331,7 +331,7 @@ $.extend(true, doaj, {
                         "index.date" : "Year of publication"
                     },
                     valueMaps : {
-                        "_type" : {
+                        "es_type" : {
                             "journal" : "Journals",
                             "article" : "Articles"
                         }


### PR DESCRIPTION
adds `es_type` to all models, which functionally replaces `_type`.

I've tested this migration from old to new index-per-type connection, but in theory it should also migrate to new models without ipt too. Edges have been updated too.