### PR TITLE
add custom API route for JCT in progress queries

### DIFF
--- a/portality/app.py
+++ b/portality/app.py
@@ -31,6 +31,7 @@ from portality.view.openurl import blueprint as openurl
 from portality.view.atom import blueprint as atom
 from portality.view.editor import blueprint as editor
 from portality.view.doajservices import blueprint as services
+from portality.view.jct import blueprint as jct
 if 'api' in app.config['FEATURES']:
     from portality.view.api_v1 import blueprint as api_v1
 from portality.view.status import blueprint as status
@@ -50,6 +51,7 @@ if 'api' in app.config['FEATURES']:
     app.register_blueprint(api_v1, url_prefix='/api/v1')
 app.register_blueprint(status, url_prefix='/_status')
 app.register_blueprint(status, url_prefix='/status')   # TODO: remove duplicate route once uptimerobot has been informed
+app.register_blueprint(jct, url_prefix="/jct")
 
 app.register_blueprint(oaipmh)
 app.register_blueprint(openurl)

--- a/portality/crosswalks/jct_inprogress.py
+++ b/portality/crosswalks/jct_inprogress.py
@@ -1,0 +1,34 @@
+from portality.models.journal import JournalBibJSON
+
+class JCTInProgressXWalk(object):
+
+    @classmethod
+    def application2jct(cls, application):
+        bj = application.bibjson()
+        assert isinstance(bj, JournalBibJSON)
+
+        record = {}
+        record["doaj_id"] = application.id
+        record["pissn"] = bj.get_one_identifier(bj.P_ISSN)
+        record["eissn"] = bj.get_one_identifier(bj.E_ISSN)
+
+        record["author_retains_copyright"] = bj.author_copyright.get("copyright") == "True"
+
+        lic = bj.get_license()
+        if lic is not None:
+            record["publishing_license"] = [lic.get("type")]
+            record["license_embedded"] = lic.get("embedded", False)
+
+        record["pids"] = bj.persistent_identifier_scheme
+
+        record["preservation"] = bj.flattened_archiving_policies
+
+        if bj.apc_url is not None or bj.submission_charges_url is not None:
+            record["pricing_info"] = True
+        else:
+            record["pricing_info"] = False
+
+        wiaver_url = bj.get_single_url("waiver_policy")
+        record["waiver"] = wiaver_url is not None
+
+        return record

--- a/portality/view/jct.py
+++ b/portality/view/jct.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, make_response
 from flask_login import current_user, login_required
 from flask import abort
+from portality.decorators import api_key_required
 
 from portality import models as models
 from portality import constants
@@ -19,7 +20,7 @@ INCLUDE_STATUSES = [
 ]
 
 @blueprint.route('/inprogress')
-@login_required
+@api_key_required
 def inprogress():
     if not current_user.has_role("jct_inprogress"):
         abort(404)

--- a/portality/view/jct.py
+++ b/portality/view/jct.py
@@ -1,0 +1,33 @@
+from flask import Blueprint, make_response
+from flask_login import current_user, login_required
+from flask import abort
+
+from portality import models as models
+from portality import constants
+from portality.crosswalks.jct_inprogress import JCTInProgressXWalk
+
+import json
+
+blueprint = Blueprint('jct', __name__)
+
+INCLUDE_STATUSES = [
+    constants.APPLICATION_STATUS_COMPLETED,
+    constants.APPLICATION_STATUS_IN_PROGRESS,
+    constants.APPLICATION_STATUS_READY,
+    constants.APPLICATION_STATUS_REVISIONS_REQUIRED,
+    constants.APPLICATION_STATUS_UPDATE_REQUEST
+]
+
+@blueprint.route('/inprogress')
+@login_required
+def inprogress():
+    if not current_user.has_role("jct_inprogress"):
+        abort(404)
+
+    records = []
+    for application in models.Suggestion.list_by_status(INCLUDE_STATUSES):
+        record = JCTInProgressXWalk.application2jct(application)
+        records.append(record)
+
+    data = json.dumps(records)
+    return make_response((data, 200, {'Content-Type': 'application/json'}))

--- a/portality/view/jct.py
+++ b/portality/view/jct.py
@@ -1,11 +1,12 @@
 from flask import Blueprint, make_response
-from flask_login import current_user, login_required
+from flask_login import current_user
 from flask import abort
 from portality.decorators import api_key_required
 
-from portality import models as models
+from portality import models
 from portality import constants
 from portality.crosswalks.jct_inprogress import JCTInProgressXWalk
+from portality.util import make_json_resp
 
 import json
 
@@ -31,4 +32,4 @@ def inprogress():
         records.append(record)
 
     data = json.dumps(records)
-    return make_response((data, 200, {'Content-Type': 'application/json'}))
+    return make_json_resp(data, 200)


### PR DESCRIPTION
Adds a basic approach to generate data about applications that are in progress with DOAJ.  This is limited to accounts with a particular permission (jct_inprogress), so when this is deployed we will need to set up a user account for JCT and give it that permission.  It only provides essential information on the following statuses:

* in progress
* completed
* ready
* update_request
* revisions_requested

Before we release this just pending confirmation from @dommitchell that the last two statuses can be included, so don't merge just yet.