### PR TITLE
Hotfix/2020 11 15 2567 script delete users without journals

### DIFF
--- a/doajtest/unit/test_scripts_accounts_delete_pub_no_journal.py
+++ b/doajtest/unit/test_scripts_accounts_delete_pub_no_journal.py
@@ -1,0 +1,97 @@
+import time
+import esprit
+
+from doajtest.helpers import DoajTestCase
+from doajtest.fixtures.accounts import AccountFixtureFactory
+from doajtest.fixtures.journals import JournalFixtureFactory
+
+from portality import models
+from portality.scripts.accounts_delete_pub_no_journal import accounts_with_no_journals, delete_accounts_by_id
+
+
+class TestScriptsAccountsDeletePubNoJournal(DoajTestCase):
+
+    def setUp(self):
+        super(TestScriptsAccountsDeletePubNoJournal, self).setUp()
+        self.es_conn = esprit.raw.make_connection(None, self.app_test.config["ELASTIC_SEARCH_HOST"], None, self.app_test.config["ELASTIC_SEARCH_DB"])
+
+    def test_01_finds_publishers_with_journals(self):
+        """ Ensure the script doesn't delete accounts that own a journal """
+
+        # Create accounts without journals attached
+        expected_deletes = []
+        for i in range(10):
+            pubsource = AccountFixtureFactory.make_publisher_source()
+            pubaccount = models.Account(**pubsource)
+            pubaccount.set_id()
+            expected_deletes.append(pubaccount.id)
+            pubaccount.save()
+
+        # Create accounts with journals
+        for i in range(5):
+            pubsource = AccountFixtureFactory.make_publisher_source()
+            pubaccount = models.Account(**pubsource)
+            pubaccount.set_id()
+            pubaccount.save()
+
+            # Attach a journal, some in doaj and some not
+            jsource = JournalFixtureFactory.make_journal_source(in_doaj=bool(i % 2))
+            j = models.Journal(**jsource)
+            j.set_id()
+            j.set_owner(pubaccount.id)
+            j.save()
+
+        time.sleep(1)
+
+        # Check we get the expected accounts to delete
+        ids_to_delete = accounts_with_no_journals(self.es_conn)
+        assert sorted(ids_to_delete) == sorted(expected_deletes)
+
+        # Run the deletes
+        delete_accounts_by_id(self.es_conn, ids_to_delete)
+        time.sleep(1)
+
+        # Check we only have the accounts with journals remaining in the index
+        assert len(models.Account.all()) == 5
+        assert models.Account.pull(expected_deletes.pop()) is None
+
+    def test_02_excluded_roles(self):
+        """ Check accounts with roles we exclude from delete are retained despite no journals """
+        EXCLUDED_LIST = ['associate_editor', 'editor', 'admin', 'ultra_bulk_delete']
+
+        sources = [
+            AccountFixtureFactory.make_managing_editor_source(),
+            AccountFixtureFactory.make_assed1_source(),
+            AccountFixtureFactory.make_assed2_source(),
+            AccountFixtureFactory.make_assed3_source(),
+            AccountFixtureFactory.make_editor_source(),
+        ]
+
+        for s in sources:
+            account = models.Account(**s)
+            account.set_id()
+            account.save()
+
+        # Add a few publishers we expect to be deleted
+        publishers = []
+        for s2 in range(len(EXCLUDED_LIST)):
+            pub_source = AccountFixtureFactory.make_publisher_source()
+            pub = models.Account(**pub_source)
+            pub.set_id()
+            publishers.append(pub)
+            pub.save()
+
+        time.sleep(1)
+
+        # Check we get the publishers back when we run the script
+        ids_to_delete = accounts_with_no_journals(self.es_conn)
+        assert sorted(ids_to_delete) == sorted([p.id for p in publishers])
+
+        # Add a reserved role to each publisher so they won't be returned next time
+        for i in range(0, len(publishers)):
+            publisher = publishers[i]
+            publisher.add_role(EXCLUDED_LIST[i])
+            publisher.save(blocking=True)
+
+        ids_to_delete = accounts_with_no_journals(self.es_conn)
+        assert len(ids_to_delete) == 0

--- a/doajtest/unit/test_scripts_accounts_delete_pub_no_journal.py
+++ b/doajtest/unit/test_scripts_accounts_delete_pub_no_journal.py
@@ -4,9 +4,11 @@ import esprit
 from doajtest.helpers import DoajTestCase
 from doajtest.fixtures.accounts import AccountFixtureFactory
 from doajtest.fixtures.journals import JournalFixtureFactory
+from doajtest.fixtures.applications import ApplicationFixtureFactory
 
 from portality import models
-from portality.scripts.accounts_delete_pub_no_journal import accounts_with_no_journals, delete_accounts_by_id
+from portality.constants import APPLICATION_STATUSES_ALL
+from portality.scripts.accounts_delete_pub_no_journal_or_application import accounts_with_no_journals_or_applications, delete_accounts_by_id
 
 
 class TestScriptsAccountsDeletePubNoJournal(DoajTestCase):
@@ -15,7 +17,7 @@ class TestScriptsAccountsDeletePubNoJournal(DoajTestCase):
         super(TestScriptsAccountsDeletePubNoJournal, self).setUp()
         self.es_conn = esprit.raw.make_connection(None, self.app_test.config["ELASTIC_SEARCH_HOST"], None, self.app_test.config["ELASTIC_SEARCH_DB"])
 
-    def test_01_finds_publishers_with_journals(self):
+    def test_01_dont_delete_if_journal_exists(self):
         """ Ensure the script doesn't delete accounts that own a journal """
 
         # Create accounts without journals attached
@@ -44,7 +46,7 @@ class TestScriptsAccountsDeletePubNoJournal(DoajTestCase):
         time.sleep(1)
 
         # Check we get the expected accounts to delete
-        ids_to_delete = accounts_with_no_journals(self.es_conn)
+        ids_to_delete = accounts_with_no_journals_or_applications(self.es_conn)
         assert sorted(ids_to_delete) == sorted(expected_deletes)
 
         # Run the deletes
@@ -55,8 +57,50 @@ class TestScriptsAccountsDeletePubNoJournal(DoajTestCase):
         assert len(models.Account.all()) == 5
         assert models.Account.pull(expected_deletes.pop()) is None
 
-    def test_02_excluded_roles(self):
-        """ Check accounts with roles we exclude from delete are retained despite no journals """
+    def test_02_dont_delete_if_application_exists(self):
+        """ After the application form redesign project accounts are created before the journal, so keep accounts with
+        applications in the system """
+
+        # Create accounts without applications attached
+        expected_deletes = []
+        for i in range(10):
+            pubsource = AccountFixtureFactory.make_publisher_source()
+            pubaccount = models.Account(**pubsource)
+            pubaccount.set_id()
+            expected_deletes.append(pubaccount.id)
+            pubaccount.save()
+
+        # Create accounts with applications
+        for i in range(len(APPLICATION_STATUSES_ALL)):
+            pubsource = AccountFixtureFactory.make_publisher_source()
+            pubaccount = models.Account(**pubsource)
+            pubaccount.set_id()
+            pubaccount.save()
+
+            # Attach an application, various statuses
+            asource = ApplicationFixtureFactory.make_application_source()
+            a = models.Suggestion(**asource)
+            a.set_id()
+            a.set_owner(pubaccount.id)
+            a.set_application_status(APPLICATION_STATUSES_ALL[i])
+            a.save()
+
+        time.sleep(1)
+
+        # Check we get the expected accounts to delete
+        ids_to_delete = accounts_with_no_journals_or_applications(self.es_conn)
+        assert sorted(ids_to_delete) == sorted(expected_deletes)
+
+        # Run the deletes
+        delete_accounts_by_id(self.es_conn, ids_to_delete)
+        time.sleep(1)
+
+        # Check we only have the accounts with applications remaining in the index
+        assert len(models.Account.all()) == len(APPLICATION_STATUSES_ALL)
+        assert models.Account.pull(expected_deletes.pop()) is None
+
+    def test_03_excluded_roles(self):
+        """ Check accounts with roles we exclude from delete are retained despite no journals or applications """
         EXCLUDED_LIST = ['associate_editor', 'editor', 'admin', 'ultra_bulk_delete']
 
         sources = [
@@ -84,7 +128,7 @@ class TestScriptsAccountsDeletePubNoJournal(DoajTestCase):
         time.sleep(1)
 
         # Check we get the publishers back when we run the script
-        ids_to_delete = accounts_with_no_journals(self.es_conn)
+        ids_to_delete = accounts_with_no_journals_or_applications(self.es_conn)
         assert sorted(ids_to_delete) == sorted([p.id for p in publishers])
 
         # Add a reserved role to each publisher so they won't be returned next time
@@ -93,5 +137,5 @@ class TestScriptsAccountsDeletePubNoJournal(DoajTestCase):
             publisher.add_role(EXCLUDED_LIST[i])
             publisher.save(blocking=True)
 
-        ids_to_delete = accounts_with_no_journals(self.es_conn)
+        ids_to_delete = accounts_with_no_journals_or_applications(self.es_conn)
         assert len(ids_to_delete) == 0

--- a/portality/scripts/accounts_delete_pub_no_journal.py
+++ b/portality/scripts/accounts_delete_pub_no_journal.py
@@ -13,8 +13,11 @@ from portality import models
 EXCLUDED_ROLES = {'associate_editor', 'editor', 'admin', 'ultra_bulk_delete'}
 
 
-def accounts_with_no_journals(conn):
-    """ Scroll through all accounts, return those with no journal unless they have excluded roles """
+def accounts_with_no_journals(conn, csvwriter=None):
+    """ Scroll through all accounts, return those with no journal unless they have excluded roles
+    :param conn: An Elasticsearch connection
+    :param csvwriter: A CSV writer to output the accounts to
+    """
     gathered_account_ids = []
     for acc in esprit.tasks.scroll(conn, 'account', page_size=100, keepalive='1m'):
         account = models.Account(**acc)
@@ -25,6 +28,19 @@ def accounts_with_no_journals(conn):
         if len(issns) == 0:
             gathered_account_ids.append(account.id)
 
+            # Write the user summary to CSV if provided
+            if csvwriter is not None:
+                csvwriter.writerow([
+                    account.id,
+                    account.name,
+                    account.email,
+                    account.created_date,
+                    account.last_updated,
+                    account.role
+                ])
+
+        # todo: progress feedback would be nice
+
     return gathered_account_ids
 
 
@@ -32,45 +48,53 @@ def delete_accounts_by_id(conn, id_list):
     esprit.raw.bulk_delete(conn, 'account', id_list)
 
 
-def write_csv(filename, id_list):
-    with open(filename, "w", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(["ID", "Name", "Email", "Created", "Last Updated", "Roles"])
-
-        for _id in id_list:
-            account = models.Account.pull(_id)
-            writer.writerow([
-                account.id,
-                account.name,
-                account.email,
-                account.created_date,
-                account.last_updated,
-                account.role
-            ])
-
-
 if __name__ == "__main__":
 
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument("-r", "--report", help="report accounts to CSV (specify filename)")
+    parser.add_argument("-i", "--instructions", help="CSV of accounts to delete, ID must be first column")
     args = parser.parse_args()
 
     conn = esprit.raw.make_connection(None, app.config["ELASTIC_SEARCH_HOST"], None, app.config["ELASTIC_SEARCH_DB"])
 
-    accounts_to_delete = accounts_with_no_journals(conn)
-
-    if args.report:
-        print("Writing CSV summary of accounts to delete")
-        write_csv(args.report, accounts_to_delete)
+    if args.report and args.instructions:
+        print("\nPlease provide EITHER -r or -i arguments with CSV filenames.")
+        parser.print_help()
         exit()
 
-    # Make sure the user is super serious about doing this.
-    resp = input("\nDelete {0} Accounts - are you sure? [y/N]\n".format(len(accounts_to_delete)))
-    if resp.lower() == 'y':
-        # Run the function to remove the field
-        print("Deleting the following accounts... \n")
-        [print(a) for a in accounts_to_delete]
-        delete_accounts_by_id(conn, accounts_to_delete)
-    else:
-        print("Better safe than sorry, exiting.")
+    if args.report:
+        print("Writing CSV summary of accounts to delete, please wait...")
+        with open(args.report, "w", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(["ID", "Name", "Email", "Created", "Last Updated", "Roles"])
+
+            accounts_to_delete = accounts_with_no_journals(conn, writer)
+
+        print("Done!")
+        exit()
+
+    if args.instructions:
+        with open(args.instructions, 'r', encoding="utf-8") as g:
+            reader = csv.reader(g)
+            accounts_to_delete = []
+
+            # Skip the header row
+            next(reader)
+            for line in reader:
+                accounts_to_delete.append(line[0])
+
+        # Make sure the user is super serious about doing this.
+        resp = input("\nDelete {0} Accounts - are you sure? [y/N]\n".format(len(accounts_to_delete)))
+        if resp.lower() == 'y':
+            # Run the function to remove the field
+            print("Deleting accounts... \n")
+            delete_accounts_by_id(conn, accounts_to_delete)
+            print("Done")
+        else:
+            print("Better safe than sorry, exiting.")
+        exit()
+
+    print("\nPlease specify operation to perform")
+    parser.print_help()
+    exit(1)

--- a/portality/scripts/accounts_delete_pub_no_journal.py
+++ b/portality/scripts/accounts_delete_pub_no_journal.py
@@ -1,0 +1,58 @@
+"""
+Delete all non-editorial user accounts not assigned to a journal
+
+python accounts_delete_pub_no_journal.py
+"""
+
+import esprit
+from portality.core import app
+from portality import models
+
+# set of roles to exclude from the deletes
+EXCLUDED_ROLES = {'associate_editor', 'editor', 'admin', 'ultra_bulk_delete'}
+
+
+def accounts_with_no_journals(conn):
+    """ Scroll through all accounts, return those with no journal unless they have excluded roles """
+    gathered_account_ids = []
+    for acc in esprit.tasks.scroll(conn, 'account', page_size=100, keepalive='1m'):
+        account = models.Account(**acc)
+        if set(account.role).intersection(EXCLUDED_ROLES):
+            continue
+
+        issns = models.Journal.issns_by_owner(account.id)
+        if len(issns) == 0:
+            gathered_account_ids.append(account.id)
+
+    return gathered_account_ids
+
+
+def delete_accounts_by_id(conn, id_list):
+    esprit.raw.bulk_delete(conn, 'account', id_list)
+
+
+if __name__ == "__main__":
+
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--out", help="output file path")
+    args = parser.parse_args()
+
+    if not args.out:
+        print("Please specify an output file path with the -o option")
+        parser.print_help()
+        exit()
+
+    conn = esprit.raw.make_connection(None, app.config["ELASTIC_SEARCH_HOST"], None, app.config["ELASTIC_SEARCH_DB"])
+
+    accounts_to_delete = accounts_with_no_journals(conn)
+
+    # Make sure the user is super serious about doing this.
+    resp = input("\nDelete {0} Accounts - are you sure? [y/N]\n".format(len(accounts_to_delete)))
+    if resp.lower() == 'y':
+        # Run the function to remove the field
+        print("Deleting the following accounts... \n")
+        [print(a) for a in accounts_to_delete]
+        delete_accounts_by_id(conn, accounts_to_delete)
+    else:
+        print("Better safe than sorry, exiting.")


### PR DESCRIPTION
Delete users script and tests for issue https://github.com/DOAJ/doajPM/issues/2567

[edited for enhancements below]

To run non-destructively use the `-r` option and supply a filename for the CSV of accounts that will be deleted.

Run again with `-i` with the same filename to be prompted to delete the user accounts. CSV should still contain header rows but user rows can be deleted from CSV if they are to be retained in the system