### PR TITLE
fix reference to url upload box for article xml

### DIFF
--- a/portality/view/publisher.py
+++ b/portality/view/publisher.py
@@ -192,7 +192,7 @@ def upload_file():
     # otherwise we are dealing with a POST - file upload or supply of url
     f = request.files.get("file")
     schema = request.values.get("schema")
-    url = request.values.get("url")
+    url = request.values.get("upload-xml-link")
     resp = make_response(redirect(url_for("publisher.upload_file")))
     resp.set_cookie("schema", schema)
 


### PR DESCRIPTION
When the front end for the xml upload page was updated with the new design, the name of the upload box was changed and the back-end was not changed in line with it.