### PR TITLE
fix the document shell script and regenerate the md files

### DIFF
--- a/docs/system/Application.md
+++ b/docs/system/Application.md
@@ -1,13 +1,31 @@
-# OutgoingJournal
+# Application
 
 The JSON structure of the model is as follows:
 
 ```json
 {
     "admin": {
-        "in_doaj": true,
-        "seal": true,
-        "ticked": true
+        "application_status": "string",
+        "bulk_upload": "string",
+        "contact": {
+            "email": "string",
+            "name": "string"
+        },
+        "current_journal": "string",
+        "date_applied": "2021-01-11T14:08:19Z",
+        "editor": "string",
+        "editor_group": "string",
+        "last_manual_update": "2021-01-11T14:08:19Z",
+        "notes": [
+            {
+                "date": "2021-01-11T14:08:19Z",
+                "id": "string",
+                "note": "string"
+            }
+        ],
+        "owner": "string",
+        "related_journal": "string",
+        "seal": true
     },
     "bibjson": {
         "alternative_title": "string",
@@ -127,11 +145,52 @@ The JSON structure of the model is as follows:
             "url": "string"
         }
     },
-    "created_date": "2021-01-11T14:08:20Z",
+    "created_date": "2021-01-11T14:08:19Z",
     "es_type": "string",
     "id": "string",
-    "last_manual_update": "2021-01-11T14:08:20Z",
-    "last_updated": "2021-01-11T14:08:20Z"
+    "index": {
+        "application_type": "string",
+        "asciiunpunctitle": "string",
+        "classification": [
+            "string"
+        ],
+        "classification_paths": [
+            "string"
+        ],
+        "continued": "string",
+        "country": "string",
+        "has_apc": "string",
+        "has_editor": "string",
+        "has_editor_group": "string",
+        "has_seal": "string",
+        "issn": [
+            "string"
+        ],
+        "language": [
+            "string"
+        ],
+        "license": [
+            "string"
+        ],
+        "schema_code": [
+            "string"
+        ],
+        "schema_codes_tree": [
+            "string"
+        ],
+        "schema_subject": [
+            "string"
+        ],
+        "subject": [
+            "string"
+        ],
+        "title": [
+            "string"
+        ],
+        "unpunctitle": "string"
+    },
+    "last_manual_update": "2021-01-11T14:08:19Z",
+    "last_updated": "2021-01-11T14:08:19Z"
 }
 ```
 
@@ -139,10 +198,22 @@ Each of the fields is defined as laid out in the table below.  All fields are op
 
 | Field | Description | Datatype | Format | Allowed Values |
 | ----- | ----------- | -------- | ------ | -------------- |
-| admin.in_doaj | Whether the journal appears in the public corpus of DOAJ | bool |  |  |
-| admin.seal | Does the journal qualify for the DOAJ Seal | bool |  |  |
-| admin.ticked | Is the journal ticked?  This means that it has successfully re-applied for continued presence in DOAJ | bool |  |  |
-| bibjson.alternative_title | See application form Q3 - https://doaj.org/application/new#alternative_title-container | str |  |  |
+| admin.application_status |  | str |  |  |
+| admin.bulk_upload |  | str |  |  |
+| admin.contact.email |  | str |  |  |
+| admin.contact.name |  | str |  |  |
+| admin.current_journal |  | str |  |  |
+| admin.date_applied |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| admin.editor |  | str |  |  |
+| admin.editor_group |  | str |  |  |
+| admin.last_manual_update |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| admin.notes.date |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| admin.notes.id |  | str |  |  |
+| admin.notes.note |  | str |  |  |
+| admin.owner |  | str |  |  |
+| admin.related_journal |  | str |  |  |
+| admin.seal |  | bool |  |  |
+| bibjson.alternative_title |  | str |  |  |
 | bibjson.apc.has_apc |  | bool |  |  |
 | bibjson.apc.max.currency |  | str |  |  |
 | bibjson.apc.max.price |  | int |  |  |
@@ -166,14 +237,14 @@ Each of the fields is defined as laid out in the table below.  All fields are op
 | bibjson.institution.country |  | str |  |  |
 | bibjson.institution.name |  | str |  |  |
 | bibjson.is_replaced_by |  | str |  |  |
-| bibjson.keywords | as per application form Q34 - https://doaj.org/application/new#keywords-container | str |  |  |
-| bibjson.language | as per application form Q35 - https://doaj.org/application/new#languages-container | str | 2 letter ISO language code |  |
-| bibjson.license.BY | Does the licence have an attribution clause. | bool |  |  |
-| bibjson.license.NC | Does the licence have a non-commercial clause. | bool |  |  |
-| bibjson.license.ND | Does the licence have a no-derivatives clause. | bool |  |  |
-| bibjson.license.SA | Does the licence have a share-alike clause. | bool |  |  |
-| bibjson.license.type | The licence type from application form Q47 - https://doaj.org/application/new#license-container | str |  |  |
-| bibjson.license.url | see application form Q49 - https://doaj.org/application/new#license_url-container | str | URL |  |
+| bibjson.keywords |  | str |  |  |
+| bibjson.language |  | str | 2 letter ISO language code |  |
+| bibjson.license.BY |  | bool |  |  |
+| bibjson.license.NC |  | bool |  |  |
+| bibjson.license.ND |  | bool |  |  |
+| bibjson.license.SA |  | bool |  |  |
+| bibjson.license.type |  | str |  |  |
+| bibjson.license.url |  | str | URL |  |
 | bibjson.other_charges.has_other_charges |  | bool |  |  |
 | bibjson.other_charges.url |  | str | URL |  |
 | bibjson.pid_scheme.has_pid_scheme |  | bool |  |  |
@@ -194,14 +265,33 @@ Each of the fields is defined as laid out in the table below.  All fields are op
 | bibjson.ref.license_terms |  | str | URL |  |
 | bibjson.ref.oa_statement |  | str | URL |  |
 | bibjson.replaces |  | str |  |  |
-| bibjson.subject.code | assigned subject code | str |  |  |
-| bibjson.subject.scheme | assigned subject scheme | str |  |  |
-| bibjson.subject.term | assigned subject term | str |  |  |
-| bibjson.title | see application form Q1 - https://doaj.org/application/new#title-container | str |  |  |
+| bibjson.subject.code |  | str |  |  |
+| bibjson.subject.scheme |  | str |  |  |
+| bibjson.subject.term |  | str |  |  |
+| bibjson.title |  | str |  |  |
 | bibjson.waiver.has_waiver |  | bool |  |  |
 | bibjson.waiver.url |  | str | URL |  |
-| created_date | Date the record was created in DOAJ. | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| created_date |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
 | es_type |  | str |  |  |
-| id | ID assigned by DOAJ for the record. | str |  |  |
+| id |  | str |  |  |
+| index.application_type |  | str |  |  |
+| index.asciiunpunctitle |  | str |  |  |
+| index.classification |  | str |  |  |
+| index.classification_paths |  | str |  |  |
+| index.continued |  | str |  |  |
+| index.country |  | str |  |  |
+| index.has_apc |  | str |  |  |
+| index.has_editor |  | str |  |  |
+| index.has_editor_group |  | str |  |  |
+| index.has_seal |  | str |  |  |
+| index.issn |  | str |  |  |
+| index.language |  | str |  |  |
+| index.license |  | str |  |  |
+| index.schema_code |  | str |  |  |
+| index.schema_codes_tree |  | str |  |  |
+| index.schema_subject |  | str |  |  |
+| index.subject |  | str |  |  |
+| index.title |  | str |  |  |
+| index.unpunctitle |  | str |  |  |
 | last_manual_update |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
-| last_updated | Date the record was last updated in DOAJ. | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| last_updated |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |

--- a/docs/system/IncomingAPIApplication.md
+++ b/docs/system/IncomingAPIApplication.md
@@ -44,7 +44,7 @@ The JSON structure of the model is as follows:
             ],
             "url": "string"
         },
-        "discontinued_date": "2020-07-01",
+        "discontinued_date": "2021-01-11",
         "editorial": {
             "board_url": "string",
             "review_process": [
@@ -129,10 +129,10 @@ The JSON structure of the model is as follows:
             "url": "string"
         }
     },
-    "created_date": "2020-07-01T15:43:20Z",
+    "created_date": "2021-01-11T14:08:20Z",
     "id": "string",
-    "last_manual_update": "2020-07-01T15:43:20Z",
-    "last_updated": "2020-07-01T15:43:20Z"
+    "last_manual_update": "2021-01-11T14:08:20Z",
+    "last_updated": "2021-01-11T14:08:20Z"
 }
 ```
 
@@ -187,7 +187,7 @@ Each of the fields is defined as laid out in the table below.  All fields are op
 | bibjson.preservation.has_preservation |  | bool |  |  |
 | bibjson.preservation.national_library |  | str |  |  |
 | bibjson.preservation.service |  | str |  |  |
-| bibjson.preservation.url |  | str |  |  |
+| bibjson.preservation.url |  | str | URL |  |
 | bibjson.publication_time_weeks |  | int |  |  |
 | bibjson.publisher.country |  | str |  |  |
 | bibjson.publisher.name |  | str |  |  |

--- a/docs/system/IncomingAPIArticle.md
+++ b/docs/system/IncomingAPIArticle.md
@@ -5,61 +5,63 @@ The JSON structure of the model is as follows:
 ```json
 {
     "admin": {
-        "in_doaj": true, 
-        "publisher_record_id": "string", 
-        "seal": true, 
+        "in_doaj": true,
+        "publisher_record_id": "string",
+        "seal": true,
         "upload_id": "string"
-    }, 
+    },
     "bibjson": {
-        "abstract": "string", 
+        "abstract": "string",
         "author": [
             {
-                "affiliation": "string", 
-                "name": "string"
+                "affiliation": "string",
+                "name": "string",
+                "orcid_id": "string"
             }
-        ], 
+        ],
         "identifier": [
             {
-                "id": "string", 
+                "id": "string",
                 "type": "string"
             }
-        ], 
+        ],
         "journal": {
-            "country": "string", 
-            "end_page": "string", 
+            "country": "string",
+            "end_page": "string",
             "language": [
                 "string"
-            ], 
-            "number": "string", 
-            "publisher": "string", 
-            "start_page": "string", 
-            "title": "string", 
+            ],
+            "number": "string",
+            "publisher": "string",
+            "start_page": "string",
+            "title": "string",
             "volume": "string"
-        }, 
+        },
         "keywords": [
             "string"
-        ], 
+        ],
         "link": [
             {
-                "content_type": "string", 
-                "type": "string", 
+                "content_type": "string",
+                "type": "string",
                 "url": "string"
             }
-        ], 
-        "month": "string", 
+        ],
+        "month": "string",
         "subject": [
             {
-                "code": "string", 
-                "scheme": "string", 
+                "code": "string",
+                "scheme": "string",
                 "term": "string"
             }
-        ], 
-        "title": "string", 
+        ],
+        "title": "string",
         "year": "string"
-    }, 
-    "created_date": "2019-05-14T11:15:40Z", 
-    "id": "string", 
-    "last_updated": "2019-05-14T11:15:40Z"
+    },
+    "created_date": "2021-01-11T14:08:19Z",
+    "es_type": "string",
+    "id": "string",
+    "last_updated": "2021-01-11T14:08:19Z"
 }
 ```
 
@@ -68,32 +70,34 @@ Each of the fields is defined as laid out in the table below.  All fields are op
 | Field | Description | Datatype | Format | Allowed Values |
 | ----- | ----------- | -------- | ------ | -------------- |
 | admin.in_doaj | Whether the article is in DOAJ, or withdrawn from public view.  You can retrieve this value from DOAJ, but if you provide it back it will be **ignored**. | bool |  |  |
-| admin.publisher_record_id | **Deprecated** Your own ID for the record. | unicode |  |  |
+| admin.publisher_record_id | **Deprecated** Your own ID for the record. | str |  |  |
 | admin.seal | Whether the article is in a journal with the DOAJ Seal.  You can retrieve this value from DOAJ, but if you provide it back it will be **ignored**. | bool |  |  |
-| admin.upload_id | An ID for a batch upload.  You can retrieve this value from DOAJ, but if you provide it back it will be **ignored**. | unicode |  |  |
-| bibjson.abstract | Article abstract | unicode |  |  |
-| bibjson.author.affiliation | An author's affiliation | unicode |  |  |
-| bibjson.author.name | An author's name.  If there is an author record then name is **required** | unicode |  |  |
-| bibjson.identifier.id | An identifier for the article. | unicode |  |  |
-| bibjson.identifier.type | The type of the associated identifier.  Should contain "doi" if available.  An "eissn" or a "pissn" is **required**. | unicode |  |  |
-| bibjson.journal.country | The country of the publisher using the ISO-3166 2-letter country codes.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | unicode |  |  |
-| bibjson.journal.end_page | End page of the article in the journal | unicode |  |  |
-| bibjson.journal.language | The language of the Journal using the ISO-639-1 2-letter language codes.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | unicode |  |  |
-| bibjson.journal.number | The issue number of the journal within which this article appears | unicode |  |  |
-| bibjson.journal.publisher | The name of the publisher of the journal.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | unicode |  |  |
-| bibjson.journal.start_page | The start page of the article in the journal | unicode |  |  |
-| bibjson.journal.title | The journal title. You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | unicode |  |  |
-| bibjson.journal.volume | The volume of the journal within which this article appears | unicode |  |  |
-| bibjson.keywords | Up to 6 free-text keywords describing this article | unicode |  |  |
-| bibjson.link.content_type | The content type of page referenced by the link (for example, text/html) | unicode |  |  |
-| bibjson.link.type | The link type.  Should contain "fulltext" and point to the article fulltext URL in bibjson.link.url | unicode |  |  |
-| bibjson.link.url | The url | unicode | URL |  |
-| bibjson.month | Month of publication for this article | unicode |  |  |
-| bibjson.subject.code | Library of Congress Subject Code.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | unicode |  |  |
-| bibjson.subject.scheme | Library of Congress Subject Scheme.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | unicode |  |  |
-| bibjson.subject.term | Library of Congress Subject Term.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | unicode |  |  |
-| bibjson.title | Article title **required** | unicode |  |  |
-| bibjson.year | Year of publication for this article | unicode |  |  |
-| created_date | Date the record was created in DOAJ. You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | unicode | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
-| id | DOAJ ID for this article.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | unicode |  |  |
-| last_updated | Date this article was last modified in DOAJ.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | unicode | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| admin.upload_id | An ID for a batch upload.  You can retrieve this value from DOAJ, but if you provide it back it will be **ignored**. | str |  |  |
+| bibjson.abstract | Article abstract | str |  |  |
+| bibjson.author.affiliation | An author's affiliation | str |  |  |
+| bibjson.author.name | An author's name.  If there is an author record then name is **required** | str |  |  |
+| bibjson.author.orcid_id |  | str |  |  |
+| bibjson.identifier.id | An identifier for the article. | str |  |  |
+| bibjson.identifier.type | The type of the associated identifier.  Should contain "doi" if available.  An "eissn" or a "pissn" is **required**. | str |  |  |
+| bibjson.journal.country | The country of the publisher using the ISO-3166 2-letter country codes.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | str |  |  |
+| bibjson.journal.end_page | End page of the article in the journal | str |  |  |
+| bibjson.journal.language | The language of the Journal using the ISO-639-1 2-letter language codes.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | str |  |  |
+| bibjson.journal.number | The issue number of the journal within which this article appears | str |  |  |
+| bibjson.journal.publisher | The name of the publisher of the journal.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | str |  |  |
+| bibjson.journal.start_page | The start page of the article in the journal | str |  |  |
+| bibjson.journal.title | The journal title. You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | str |  |  |
+| bibjson.journal.volume | The volume of the journal within which this article appears | str |  |  |
+| bibjson.keywords | Up to 6 free-text keywords describing this article | str |  |  |
+| bibjson.link.content_type | The content type of page referenced by the link (for example, text/html) | str |  |  |
+| bibjson.link.type | The link type.  Should contain "fulltext" and point to the article fulltext URL in bibjson.link.url | str |  |  |
+| bibjson.link.url | The url | str | URL |  |
+| bibjson.month | Month of publication for this article | str |  |  |
+| bibjson.subject.code | Library of Congress Subject Code.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | str |  |  |
+| bibjson.subject.scheme | Library of Congress Subject Scheme.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | str |  |  |
+| bibjson.subject.term | Library of Congress Subject Term.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | str |  |  |
+| bibjson.title | Article title **required** | str |  |  |
+| bibjson.year | Year of publication for this article | str |  |  |
+| created_date | Date the record was created in DOAJ. You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| es_type |  | str |  |  |
+| id | DOAJ ID for this article.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | str |  |  |
+| last_updated | Date this article was last modified in DOAJ.  You can retrieve this value from DOAJ, and it will be **populated for you** when an article is created | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |

--- a/docs/system/Journal.md
+++ b/docs/system/Journal.md
@@ -5,206 +5,199 @@ The JSON structure of the model is as follows:
 ```json
 {
     "admin": {
-        "bulk_upload": "string", 
-        "contact": [
-            {
-                "email": "string", 
-                "name": "string"
-            }
-        ], 
-        "current_application": "string", 
-        "editor": "string", 
-        "editor_group": "string", 
-        "in_doaj": true, 
+        "bulk_upload": "string",
+        "contact": {
+            "email": "string",
+            "name": "string"
+        },
+        "current_application": "string",
+        "editor": "string",
+        "editor_group": "string",
+        "in_doaj": true,
         "notes": [
             {
-                "date": "2018-01-25T09:45:44Z", 
+                "date": "2021-01-11T14:08:18Z",
+                "id": "string",
                 "note": "string"
             }
-        ], 
-        "owner": "string", 
+        ],
+        "owner": "string",
         "related_applications": [
             {
-                "application_id": "string", 
-                "date_accepted": "2018-01-25T09:45:44Z", 
+                "application_id": "string",
+                "date_accepted": "2021-01-11T14:08:18Z",
                 "status": "string"
             }
-        ], 
-        "seal": true, 
+        ],
+        "seal": true,
         "ticked": true
-    }, 
+    },
     "bibjson": {
-        "active": true, 
-        "allows_fulltext_indexing": true, 
-        "alternative_title": "string", 
+        "alternative_title": "string",
         "apc": {
-            "average_price": 0, 
-            "currency": "string"
-        }, 
-        "apc_url": "string", 
-        "archiving_policy": {
-            "known": [
+            "has_apc": true,
+            "max": [
+                {
+                    "currency": "string",
+                    "price": 0
+                }
+            ],
+            "url": "string"
+        },
+        "article": {
+            "i4oc_open_citations": true,
+            "license_display": [
                 "string"
-            ], 
-            "nat_lib": "string", 
-            "other": "string", 
+            ],
+            "license_display_example_url": "string",
+            "orcid": true
+        },
+        "boai": true,
+        "copyright": {
+            "author_retains": true,
             "url": "string"
-        }, 
-        "article_statistics": {
-            "statistics": true, 
+        },
+        "deposit_policy": {
+            "has_policy": true,
+            "is_registered": true,
+            "service": [
+                "string"
+            ],
             "url": "string"
-        }, 
-        "author_copyright": {
-            "copyright": "string", 
-            "url": "string"
-        }, 
-        "author_pays": "string", 
-        "author_pays_url": "string", 
-        "author_publishing_rights": {
-            "publishing_rights": "string", 
-            "url": "string"
-        }, 
-        "country": "string", 
-        "deposit_policy": [
-            "string"
-        ], 
-        "discontinued_date": "2018-01-25", 
-        "editorial_review": {
-            "process": "string", 
-            "url": "string"
-        }, 
-        "format": [
-            "string"
-        ], 
-        "identifier": [
-            {
-                "id": "string", 
-                "type": "string"
-            }
-        ], 
-        "institution": "string", 
+        },
+        "discontinued_date": "2021-01-11",
+        "editorial": {
+            "board_url": "string",
+            "review_process": [
+                "string"
+            ],
+            "review_url": "string"
+        },
+        "eissn": "string",
+        "institution": {
+            "country": "string",
+            "name": "string"
+        },
         "is_replaced_by": [
             "string"
-        ], 
+        ],
         "keywords": [
             "string"
-        ], 
+        ],
         "language": [
             "string"
-        ], 
+        ],
         "license": [
             {
-                "BY": true, 
-                "NC": true, 
-                "ND": true, 
-                "SA": true, 
-                "embedded": true, 
-                "embedded_example_url": "string", 
-                "open_access": true, 
-                "title": "string", 
-                "type": "string", 
-                "url": "string", 
-                "version": "string"
-            }
-        ], 
-        "link": [
-            {
-                "content_type": "string", 
-                "type": "string", 
+                "BY": true,
+                "NC": true,
+                "ND": true,
+                "SA": true,
+                "type": "string",
                 "url": "string"
             }
-        ], 
-        "oa_end": {
-            "number": "string", 
-            "volume": "string", 
-            "year": 0
-        }, 
-        "oa_start": {
-            "number": "string", 
-            "volume": "string", 
-            "year": 0
-        }, 
-        "persistent_identifier_scheme": [
-            "string"
-        ], 
-        "plagiarism_detection": {
-            "detection": true, 
+        ],
+        "other_charges": {
+            "has_other_charges": true,
             "url": "string"
-        }, 
-        "provider": "string", 
-        "publication_time": 0, 
-        "publisher": "string", 
+        },
+        "pid_scheme": {
+            "has_pid_scheme": true,
+            "scheme": [
+                "string"
+            ]
+        },
+        "pissn": "string",
+        "plagiarism": {
+            "detection": true,
+            "url": "string"
+        },
+        "preservation": {
+            "has_preservation": true,
+            "national_library": [
+                "string"
+            ],
+            "service": [
+                "string"
+            ],
+            "url": "string"
+        },
+        "publication_time_weeks": 0,
+        "publisher": {
+            "country": "string",
+            "name": "string"
+        },
+        "ref": {
+            "aims_scope": "string",
+            "author_instructions": "string",
+            "journal": "string",
+            "license_terms": "string",
+            "oa_statement": "string"
+        },
         "replaces": [
             "string"
-        ], 
+        ],
         "subject": [
             {
-                "code": "string", 
-                "scheme": "string", 
+                "code": "string",
+                "scheme": "string",
                 "term": "string"
             }
-        ], 
-        "submission_charges": {
-            "average_price": 0, 
-            "currency": "string"
-        }, 
-        "submission_charges_url": "string", 
-        "title": "string"
-    }, 
-    "created_date": "2018-01-25T09:45:44Z", 
-    "id": "string", 
+        ],
+        "title": "string",
+        "waiver": {
+            "has_waiver": true,
+            "url": "string"
+        }
+    },
+    "created_date": "2021-01-11T14:08:18Z",
+    "es_type": "string",
+    "id": "string",
     "index": {
-        "aims_scope_url": "string", 
-        "asciiunpunctitle": "string", 
-        "author_instructions_url": "string", 
+        "asciiunpunctitle": "string",
         "classification": [
             "string"
-        ], 
+        ],
         "classification_paths": [
             "string"
-        ], 
-        "continued": "string", 
-        "country": "string", 
-        "editorial_board_url": "string", 
-        "has_apc": "string", 
-        "has_editor": "string", 
-        "has_editor_group": "string", 
-        "has_seal": "string", 
-        "homepage_url": "string", 
-        "institution_ac": "string", 
+        ],
+        "continued": "string",
+        "country": "string",
+        "has_apc": "string",
+        "has_editor": "string",
+        "has_editor_group": "string",
+        "has_seal": "string",
+        "institution_ac": "string",
         "issn": [
             "string"
-        ], 
+        ],
         "language": [
             "string"
-        ], 
+        ],
         "license": [
             "string"
-        ], 
-        "oa_statement_url": "string", 
-        "provider_ac": "string", 
-        "publisher": [
-            "string"
-        ], 
-        "publisher_ac": "string", 
+        ],
+        "publisher_ac": "string",
         "schema_code": [
             "string"
-        ], 
+        ],
+        "schema_codes_tree": [
+            "string"
+        ],
         "schema_subject": [
             "string"
-        ], 
+        ],
         "subject": [
             "string"
-        ], 
+        ],
         "title": [
             "string"
-        ], 
-        "unpunctitle": "string", 
-        "waiver_policy_url": "string"
-    }, 
-    "last_manual_update": "2018-01-25T09:45:44Z", 
-    "last_reapplication": "2018-01-25T09:45:44Z", 
-    "last_updated": "2018-01-25T09:45:44Z"
+        ],
+        "unpunctitle": "string"
+    },
+    "last_manual_update": "2021-01-11T14:08:18Z",
+    "last_reapplication": "2021-01-11T14:08:18Z",
+    "last_updated": "2021-01-11T14:08:18Z"
 }
 ```
 
@@ -212,114 +205,103 @@ Each of the fields is defined as laid out in the table below.  All fields are op
 
 | Field | Description | Datatype | Format | Allowed Values |
 | ----- | ----------- | -------- | ------ | -------------- |
-| admin.bulk_upload |  | unicode |  |  |
-| admin.contact.email |  | unicode |  |  |
-| admin.contact.name |  | unicode |  |  |
-| admin.current_application |  | unicode |  |  |
-| admin.editor |  | unicode |  |  |
-| admin.editor_group |  | unicode |  |  |
+| admin.bulk_upload |  | str |  |  |
+| admin.contact.email |  | str |  |  |
+| admin.contact.name |  | str |  |  |
+| admin.current_application |  | str |  |  |
+| admin.editor |  | str |  |  |
+| admin.editor_group |  | str |  |  |
 | admin.in_doaj |  | bool |  |  |
-| admin.notes.date |  | unicode | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
-| admin.notes.note |  | unicode |  |  |
-| admin.owner |  | unicode |  |  |
-| admin.related_applications.application_id |  | unicode |  |  |
-| admin.related_applications.date_accepted |  | unicode | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
-| admin.related_applications.status |  | unicode |  |  |
+| admin.notes.date |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| admin.notes.id |  | str |  |  |
+| admin.notes.note |  | str |  |  |
+| admin.owner |  | str |  |  |
+| admin.related_applications.application_id |  | str |  |  |
+| admin.related_applications.date_accepted |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| admin.related_applications.status |  | str |  |  |
 | admin.seal |  | bool |  |  |
 | admin.ticked |  | bool |  |  |
-| bibjson.active |  | bool |  |  |
-| bibjson.allows_fulltext_indexing |  | bool |  |  |
-| bibjson.alternative_title |  | unicode |  |  |
-| bibjson.apc.average_price |  | int |  |  |
-| bibjson.apc.currency |  | unicode |  |  |
-| bibjson.apc_url |  | unicode |  |  |
-| bibjson.archiving_policy.known |  | unicode |  |  |
-| bibjson.archiving_policy.nat_lib |  | unicode |  |  |
-| bibjson.archiving_policy.other |  | unicode |  |  |
-| bibjson.archiving_policy.url |  | unicode |  |  |
-| bibjson.article_statistics.statistics |  | bool |  |  |
-| bibjson.article_statistics.url |  | unicode |  |  |
-| bibjson.author_copyright.copyright |  | unicode |  |  |
-| bibjson.author_copyright.url |  | unicode |  |  |
-| bibjson.author_pays |  | unicode |  |  |
-| bibjson.author_pays_url |  | unicode |  |  |
-| bibjson.author_publishing_rights.publishing_rights |  | unicode |  |  |
-| bibjson.author_publishing_rights.url |  | unicode |  |  |
-| bibjson.country |  | unicode |  |  |
-| bibjson.deposit_policy |  | unicode |  |  |
-| bibjson.discontinued_date |  | unicode | Date, year first: YYYY-MM-DD |  |
-| bibjson.editorial_review.process |  | unicode |  |  |
-| bibjson.editorial_review.url |  | unicode |  |  |
-| bibjson.format |  | unicode |  |  |
-| bibjson.identifier.id |  | unicode |  |  |
-| bibjson.identifier.type |  | unicode |  |  |
-| bibjson.institution |  | unicode |  |  |
-| bibjson.is_replaced_by |  | unicode |  |  |
-| bibjson.keywords |  | unicode |  |  |
-| bibjson.language |  | unicode |  |  |
+| bibjson.alternative_title |  | str |  |  |
+| bibjson.apc.has_apc |  | bool |  |  |
+| bibjson.apc.max.currency |  | str |  |  |
+| bibjson.apc.max.price |  | int |  |  |
+| bibjson.apc.url |  | str | URL |  |
+| bibjson.article.i4oc_open_citations |  | bool |  |  |
+| bibjson.article.license_display |  | str |  | Embed, Display, No |
+| bibjson.article.license_display_example_url |  | str | URL |  |
+| bibjson.article.orcid |  | bool |  |  |
+| bibjson.boai |  | bool |  |  |
+| bibjson.copyright.author_retains |  | bool |  |  |
+| bibjson.copyright.url |  | str | URL |  |
+| bibjson.deposit_policy.has_policy |  | bool |  |  |
+| bibjson.deposit_policy.is_registered |  | bool |  |  |
+| bibjson.deposit_policy.service |  | str |  |  |
+| bibjson.deposit_policy.url |  | str | URL |  |
+| bibjson.discontinued_date |  | str | Date, year first: YYYY-MM-DD |  |
+| bibjson.editorial.board_url |  | str | URL |  |
+| bibjson.editorial.review_process |  | str |  |  |
+| bibjson.editorial.review_url |  | str | URL |  |
+| bibjson.eissn |  | str |  |  |
+| bibjson.institution.country |  | str |  |  |
+| bibjson.institution.name |  | str |  |  |
+| bibjson.is_replaced_by |  | str |  |  |
+| bibjson.keywords |  | str |  |  |
+| bibjson.language |  | str | 2 letter ISO language code |  |
 | bibjson.license.BY |  | bool |  |  |
 | bibjson.license.NC |  | bool |  |  |
 | bibjson.license.ND |  | bool |  |  |
 | bibjson.license.SA |  | bool |  |  |
-| bibjson.license.embedded |  | bool |  |  |
-| bibjson.license.embedded_example_url |  | unicode |  |  |
-| bibjson.license.open_access |  | bool |  |  |
-| bibjson.license.title |  | unicode |  |  |
-| bibjson.license.type |  | unicode |  |  |
-| bibjson.license.url |  | unicode |  |  |
-| bibjson.license.version |  | unicode |  |  |
-| bibjson.link.content_type |  | unicode |  |  |
-| bibjson.link.type |  | unicode |  |  |
-| bibjson.link.url |  | unicode |  |  |
-| bibjson.oa_end.number |  | unicode |  |  |
-| bibjson.oa_end.volume |  | unicode |  |  |
-| bibjson.oa_end.year |  | int |  |  |
-| bibjson.oa_start.number |  | unicode |  |  |
-| bibjson.oa_start.volume |  | unicode |  |  |
-| bibjson.oa_start.year |  | int |  |  |
-| bibjson.persistent_identifier_scheme |  | unicode |  |  |
-| bibjson.plagiarism_detection.detection |  | bool |  |  |
-| bibjson.plagiarism_detection.url |  | unicode |  |  |
-| bibjson.provider |  | unicode |  |  |
-| bibjson.publication_time |  | int |  |  |
-| bibjson.publisher |  | unicode |  |  |
-| bibjson.replaces |  | unicode |  |  |
-| bibjson.subject.code |  | unicode |  |  |
-| bibjson.subject.scheme |  | unicode |  |  |
-| bibjson.subject.term |  | unicode |  |  |
-| bibjson.submission_charges.average_price |  | int |  |  |
-| bibjson.submission_charges.currency |  | unicode |  |  |
-| bibjson.submission_charges_url |  | unicode |  |  |
-| bibjson.title |  | unicode |  |  |
-| created_date |  | unicode | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
-| id |  | unicode |  |  |
-| index.aims_scope_url |  | unicode |  |  |
-| index.asciiunpunctitle |  | unicode |  |  |
-| index.author_instructions_url |  | unicode |  |  |
-| index.classification |  | unicode |  |  |
-| index.classification_paths |  | unicode |  |  |
-| index.continued |  | unicode |  |  |
-| index.country |  | unicode |  |  |
-| index.editorial_board_url |  | unicode |  |  |
-| index.has_apc |  | unicode |  |  |
-| index.has_editor |  | unicode |  |  |
-| index.has_editor_group |  | unicode |  |  |
-| index.has_seal |  | unicode |  |  |
-| index.homepage_url |  | unicode |  |  |
-| index.institution_ac |  | unicode |  |  |
-| index.issn |  | unicode |  |  |
-| index.language |  | unicode |  |  |
-| index.license |  | unicode |  |  |
-| index.oa_statement_url |  | unicode |  |  |
-| index.provider_ac |  | unicode |  |  |
-| index.publisher |  | unicode |  |  |
-| index.publisher_ac |  | unicode |  |  |
-| index.schema_code |  | unicode |  |  |
-| index.schema_subject |  | unicode |  |  |
-| index.subject |  | unicode |  |  |
-| index.title |  | unicode |  |  |
-| index.unpunctitle |  | unicode |  |  |
-| index.waiver_policy_url |  | unicode |  |  |
-| last_manual_update |  | unicode | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
-| last_reapplication |  | unicode | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
-| last_updated |  | unicode | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| bibjson.license.type |  | str |  |  |
+| bibjson.license.url |  | str | URL |  |
+| bibjson.other_charges.has_other_charges |  | bool |  |  |
+| bibjson.other_charges.url |  | str | URL |  |
+| bibjson.pid_scheme.has_pid_scheme |  | bool |  |  |
+| bibjson.pid_scheme.scheme |  | str |  |  |
+| bibjson.pissn |  | str |  |  |
+| bibjson.plagiarism.detection |  | bool |  |  |
+| bibjson.plagiarism.url |  | str | URL |  |
+| bibjson.preservation.has_preservation |  | bool |  |  |
+| bibjson.preservation.national_library |  | str |  |  |
+| bibjson.preservation.service |  | str |  |  |
+| bibjson.preservation.url |  | str | URL |  |
+| bibjson.publication_time_weeks |  | int |  |  |
+| bibjson.publisher.country |  | str |  |  |
+| bibjson.publisher.name |  | str |  |  |
+| bibjson.ref.aims_scope |  | str | URL |  |
+| bibjson.ref.author_instructions |  | str | URL |  |
+| bibjson.ref.journal |  | str | URL |  |
+| bibjson.ref.license_terms |  | str | URL |  |
+| bibjson.ref.oa_statement |  | str | URL |  |
+| bibjson.replaces |  | str |  |  |
+| bibjson.subject.code |  | str |  |  |
+| bibjson.subject.scheme |  | str |  |  |
+| bibjson.subject.term |  | str |  |  |
+| bibjson.title |  | str |  |  |
+| bibjson.waiver.has_waiver |  | bool |  |  |
+| bibjson.waiver.url |  | str | URL |  |
+| created_date |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| es_type |  | str |  |  |
+| id |  | str |  |  |
+| index.asciiunpunctitle |  | str |  |  |
+| index.classification |  | str |  |  |
+| index.classification_paths |  | str |  |  |
+| index.continued |  | str |  |  |
+| index.country |  | str |  |  |
+| index.has_apc |  | str |  |  |
+| index.has_editor |  | str |  |  |
+| index.has_editor_group |  | str |  |  |
+| index.has_seal |  | str |  |  |
+| index.institution_ac |  | str |  |  |
+| index.issn |  | str |  |  |
+| index.language |  | str |  |  |
+| index.license |  | str |  |  |
+| index.publisher_ac |  | str |  |  |
+| index.schema_code |  | str |  |  |
+| index.schema_codes_tree |  | str |  |  |
+| index.schema_subject |  | str |  |  |
+| index.subject |  | str |  |  |
+| index.title |  | str |  |  |
+| index.unpunctitle |  | str |  |  |
+| last_manual_update |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| last_reapplication |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |
+| last_updated |  | str | UTC ISO formatted date: YYYY-MM-DDTHH:MM:SSZ |  |

--- a/document.sh
+++ b/document.sh
@@ -4,13 +4,12 @@
 #
 # sudo apt-get install python-epydoc
 
-rm docs/code/*
-epydoc --html -o docs/code/ --name "DOAJ" --url https://github.com/DOAJ/doaj --graph all --inheritance grouped --docformat restructuredtext portality
+# rm docs/code/*
+# epydoc --html -o docs/code/ --name "DOAJ" --url https://github.com/DOAJ/doaj --graph all --inheritance grouped --docformat restructuredtext portality
 
 # Generate the model documentation in markdown
-python portality/lib/modeldoc.py -k portality.models.Journal -o docs/system/Journal.md -f docs/system/field_descriptions.txt
-python portality/lib/modeldoc.py -k portality.models.Application -o docs/system/Application.md -f docs/system/field_descriptions.txt
+python portality/lib/seamlessdoc.py -k portality.models.Journal -o docs/system/Journal.md -f docs/system/field_descriptions.txt
+python portality/lib/seamlessdoc.py -k portality.models.Application -o docs/system/Application.md -f docs/system/field_descriptions.txt
 python portality/lib/modeldoc.py -k portality.api.v2.data_objects.article.IncomingArticleDO -o docs/system/IncomingAPIArticle.md -f docs/system/IncomingAPIArticleFieldDescriptions.txt
 python portality/lib/seamlessdoc.py -k portality.api.v2.data_objects.application.IncomingApplication -o docs/system/IncomingAPIApplication.md -f docs/system/IncomingAPIApplicationFieldDescriptions.txt
 python portality/lib/seamlessdoc.py -k portality.api.v2.data_objects.journal.OutgoingJournal -o docs/system/OutgoingAPIJournal.md -f docs/system/OutgoingAPIJournalFieldDescriptions.txt
-


### PR DESCRIPTION
https://github.com/DOAJ/doajPM/issues/2702

The script is fixed, runs with no errors. The docs/code has been commented out as `epydoc` does not support python3. We should consider moving to `sphinx-epytext`. Only mardown documentation has been updated.