### PR TITLE
Feature/2675 delete notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,10 +92,11 @@ local_store/main/*
 local_store/tmp/*
 !local_store/tmp/README.md
 
-# Static site / Jekyll
+# Static site / Jekyll / rbenv
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata
+.ruby-version
 
 ##generated files
 #static_content/_site

--- a/portality/forms/application_forms.py
+++ b/portality/forms/application_forms.py
@@ -1595,10 +1595,11 @@ class FieldDefinitions:
         "merge_disabled" : "merge_disabled_notes",
         "contexts" : {
             "admin" : {
+                # "merge_disabled" : False,
                 "widgets": [
                     {"infinite_repeat": {"enable_on_repeat": ["textarea"], "allow_delete" : True}},
                     "note_modal"
-                ],
+                ]
             }
         }
     }
@@ -2217,17 +2218,17 @@ def merge_disabled_notes(notes_group, original_form):
     merged = []
     wtf = notes_group.wtfield
     for entry in wtf.entries:
-        if entry.data.get("note") != "":
-            merged.append(entry)
+        if entry.data.get("note") != "" or entry.data.get("note_id") != "":
+            merged.append(entry.data)
     for entry in original_form.notes.entries:
         d = entry.data
-        keep = True
         for m in merged:
-            if m.data.get("id") == entry.data.get("id"):
-                keep = False
+            if m.get("note_id") != "" and m.get("note_id") == entry.data.get("note_id"):
+                # keep = False
+                if m.get("note") == "":
+                    m["note"] = entry.data.get("note")
+                m["note_date"] = entry.data.get("note_date")
                 break
-        if keep:
-            merged.append(entry)
 
     while True:
         try:
@@ -2236,8 +2237,7 @@ def merge_disabled_notes(notes_group, original_form):
             break
 
     for m in merged:
-        wtf.append_entry(m.data)
-
+        wtf.append_entry(m)
 
 #######################################################
 # Validation features

--- a/portality/forms/application_forms.py
+++ b/portality/forms/application_forms.py
@@ -1595,7 +1595,6 @@ class FieldDefinitions:
         "merge_disabled" : "merge_disabled_notes",
         "contexts" : {
             "admin" : {
-                # "merge_disabled" : False,
                 "widgets": [
                     {"infinite_repeat": {"enable_on_repeat": ["textarea"], "allow_delete" : True}},
                     "note_modal"

--- a/portality/forms/application_forms.py
+++ b/portality/forms/application_forms.py
@@ -1592,7 +1592,15 @@ class FieldDefinitions:
             {"infinite_repeat" : {"enable_on_repeat" : ["textarea"]}},
             "note_modal"
         ],
-        "merge_disabled" : "merge_disabled_notes"
+        "merge_disabled" : "merge_disabled_notes",
+        "contexts" : {
+            "admin" : {
+                "widgets": [
+                    {"infinite_repeat": {"enable_on_repeat": ["textarea"], "allow_delete" : True}},
+                    "note_modal"
+                ],
+            }
+        }
     }
 
     NOTE = {

--- a/portality/forms/application_processors.py
+++ b/portality/forms/application_processors.py
@@ -249,7 +249,7 @@ class AdminApplication(ApplicationProcessor):
 
         # This patches the target with things that shouldn't change from the source
         self._carry_fixed_aspects()
-        self._merge_notes_forward()
+        self._merge_notes_forward(allow_delete=True)
 
         # NOTE: this means you can't unset an owner once it has been set.  But you can change it.
         if (self.target.owner is None or self.target.owner == "") and (self.source.owner is not None):
@@ -776,7 +776,7 @@ class ManEdJournalReview(ApplicationProcessor):
             raise Exception("You cannot patch a target from a non-existent source")
 
         self._carry_fixed_aspects()
-        self._merge_notes_forward()
+        self._merge_notes_forward(allow_delete=True)
 
         # NOTE: this means you can't unset an owner once it has been set.  But you can change it.
         if (self.target.owner is None or self.target.owner == "") and (self.source.owner is not None):

--- a/portality/static/js/formulaic.js
+++ b/portality/static/js/formulaic.js
@@ -1357,12 +1357,13 @@ var formulaic = {
             this.idRx = /(.+?-)(\d+)(-.+)/;
             this.template = "";
             this.container = false;
+            this.divs = false;
 
             this.init = function() {
                 this.divs = $("div[name='" + this.fieldDef["name"] + "__group']");
                 for (var i = 0 ; i < this.divs.length; i++) {
                     var div = $(this.divs[i]);
-                    div.append($('<button type="button" data-id="' + i + '" id="remove_field__' + this.fieldDef["name"] + '--id_' + i + '" class="remove_field__button" style="display:none"><span data-feather="x" /></button>'));
+                    div.append($('<button type="button" data-id="' + i + '" id="remove_field__' + this.fieldDef["name"] + '--id_' + i + '" class="remove_field__button" style="display:none">delete <span data-feather="x" /></button>'));
                     feather.replace();
                 }
 
@@ -1457,6 +1458,7 @@ var formulaic = {
             this.removeField = function(element) {
                 var container = $(element).parents("div[name='" + this.fieldDef["name"] + "__group']");
                 container.remove();
+                this.divs = $("div[name='" + this.fieldDef["name"] + "__group']");
             };
 
             this.init();

--- a/portality/static/js/formulaic.js
+++ b/portality/static/js/formulaic.js
@@ -1310,8 +1310,7 @@ var formulaic = {
                     var date = $("#" + this.fieldDef["name"] + "-" + i + "-note_date");
                     var note = $("#" + this.fieldDef["name"] + "-" + i + "-note");
 
-                    container.append('<a href="#" class="' + viewClass + '">view note</a>');
-                    container.append(`
+                    container.append(`<div><a href="#" class="` + viewClass + `">view note</a>
                         <div class="modal" id="` + modalId + `" tabindex="-1" role="dialog" style="display: none; padding-right: 0px; overflow-y: scroll">
                             <div class="modal__dialog" role="document">
                                 <p class="label">NOTE</p> 
@@ -1321,6 +1320,7 @@ var formulaic = {
                                 ` + edges.escapeHtml(note.val()).replace(/\n/g, "<br/>") + `                        
                                 <br/><br/><button type="button" data-dismiss="modal" class="` + closeClass + `">Close</button>
                             </div>
+                        </div>
                         </div>
                     `);
                 }
@@ -1391,6 +1391,10 @@ var formulaic = {
 
                 edges.on(this.addFieldBtn, "click", this, "addField");
                 edges.on(this.removeFieldBtns, "click", this, "removeField");
+
+                if (this.args.allow_delete) {
+                    this.removeFieldBtns.show();
+                }
             };
 
             this.addField = function() {


### PR DESCRIPTION
Gives admins the ability to delete (but not edit) existing notes.

* All notes on the admin view now have a Delete button associated with them.  Any note on the record can be deleted
* Non admins can only Delete notes that they have created since they last saved.  When they save again they cannot delete notes
* Admins cannot edit existing notes

https://github.com/DOAJ/doajPM/issues/2675