### PR TITLE
modify the API so that GET on a journal does not require the api key,…

### DIFF
--- a/portality/api/common.py
+++ b/portality/api/common.py
@@ -85,7 +85,7 @@ class Api(object):
         return template
 
     @classmethod
-    def _build_swag_response(cls, template, api_key_optional_override=None):
+    def _build_swag_response(cls, template, api_key_optional_override=None, api_key_override=None):
         """
         Construct the swagger response structure upon a template
         :param template
@@ -94,10 +94,12 @@ class Api(object):
         """
         template = deepcopy(template)
         cls._add_swag_tag(template)
-        if api_key_optional_override is not None:
-            cls._add_api_key(template, optional=api_key_optional_override)
-        elif hasattr(cls, 'API_KEY_OPTIONAL'):
-            cls._add_api_key(template, optional=cls.API_KEY_OPTIONAL)
+        if api_key_override is not False:
+            if api_key_optional_override is not None:
+                cls._add_api_key(template, optional=api_key_optional_override)
+            elif hasattr(cls, 'API_KEY_OPTIONAL'):
+                cls._add_api_key(template, optional=cls.API_KEY_OPTIONAL)
+
         return template
 
 

--- a/portality/api/v2/crud/journals.py
+++ b/portality/api/v2/crud/journals.py
@@ -28,9 +28,8 @@ class JournalsCrudApi(CrudApi):
         template['responses']['200']['description'] = 'Detailed documentation on the response format is available <a ' \
                                                       'href="https://github.com/DOAJ/doaj/blob/develop/docs/system' \
                                                       '/OutgoingAPIJournal.md">here</a> '
-        template['responses']['401'] = cls.R401
         template['responses']['404'] = cls.R404
-        return cls._build_swag_response(template)
+        return cls._build_swag_response(template, api_key_override=False)
 
     @classmethod
     def retrieve(cls, jid, account):
@@ -47,16 +46,5 @@ class JournalsCrudApi(CrudApi):
         if j.is_in_doaj():
             return OutgoingJournal.from_model(j)
 
-        # as long as authentication (in the layer above) has been successful, and the account exists, then
-        # we are good to proceed
-        if account is None:
-            raise Api401Error()
-
-        # this journal's metadata is not currently published in DOAJ, so
-        # we need to check ownership
-        # is the current account the owner of the journal
-        # if not we raise a 404 because that id does not exist for that user account.
-        if account.is_anonymous or j.owner != account.id:
-            raise Api404Error()
-
-        return OutgoingJournal.from_model(j)
+        # if the journal is not Public then it doesn't matter who asks for it, it can't be retrieved
+        raise Api404Error()


### PR DESCRIPTION
… and that if the journal is not public it is not served, even if the requester is the owner

This is an updated version of https://github.com/DOAJ/doaj/pull/1717 for the v2 of the API

Once this has been merged, that branch can also be deleted