### PR TITLE
Feature/2870 subject search

### DIFF
--- a/portality/app.py
+++ b/portality/app.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 import portality.models as models
 from portality.core import app, es_connection, initialise_index
 from portality import settings
+from portality.lib import edges
 
 from portality.view.account import blueprint as account
 from portality.view.admin import blueprint as admin
@@ -262,6 +263,13 @@ def form_diff_table_subject_expand(val):
             results.append(v)
 
     return ", ".join(results)
+
+
+@app.context_processor
+def search_query_source_wrapper():
+    def search_query_source(**params):
+        return edges.make_url_query(**params)
+    return dict(search_query_source=search_query_source)
 
 
 @app.before_request

--- a/portality/lib/edges.py
+++ b/portality/lib/edges.py
@@ -1,0 +1,35 @@
+from urllib import parse
+import json
+
+
+def make_url_query(**params):
+    query = make_query(**params)
+    return parse.quote(json.dumps(query))
+
+
+def make_query(**params):
+    gsq = GeneralSearchQery(**params)
+    return gsq.query()
+
+
+class GeneralSearchQery(object):
+    def __init__(self, terms=None):
+        self.terms = terms
+
+    def query(self):
+        musts = []
+        if self.terms is not None:
+            musts.append(self.terms)
+
+        return {
+            "query" : {
+                "filtered" : {
+                    "filter" : {
+                        "bool": {
+                            "must": musts
+                        }
+                    },
+                    "query" : {"match_all": {}}
+                }
+            }
+        }

--- a/portality/lib/edges.py
+++ b/portality/lib/edges.py
@@ -4,7 +4,7 @@ import json
 
 def make_url_query(**params):
     query = make_query(**params)
-    return parse.quote(json.dumps(query))
+    return parse.quote_plus(json.dumps(query))
 
 
 def make_query(**params):
@@ -14,12 +14,13 @@ def make_query(**params):
 
 class GeneralSearchQery(object):
     def __init__(self, terms=None):
-        self.terms = terms
+        self.terms = terms if isinstance(terms, list) else [terms]
 
     def query(self):
         musts = []
         if self.terms is not None:
-            musts.append(self.terms)
+            for term in self.terms:
+                musts.append({"terms" : term})
 
         return {
             "query" : {

--- a/portality/lib/edges.py
+++ b/portality/lib/edges.py
@@ -13,8 +13,9 @@ def make_query(**params):
 
 
 class GeneralSearchQery(object):
-    def __init__(self, terms=None):
-        self.terms = terms if isinstance(terms, list) else [terms]
+    def __init__(self, terms=None, query_string=None):
+        self.terms = None if terms is None else terms if isinstance(terms, list) else [terms]
+        self.query_string = query_string
 
     def query(self):
         musts = []
@@ -22,15 +23,20 @@ class GeneralSearchQery(object):
             for term in self.terms:
                 musts.append({"terms" : term})
 
-        return {
-            "query" : {
+        query = {"match_all" : {}}
+        if self.query_string is not None:
+            query = {"query_string" : {"default_operator" : "AND", "query" : self.query_string}}
+
+        if len(musts) > 0:
+            query = {
                 "filtered" : {
                     "filter" : {
                         "bool": {
                             "must": musts
                         }
                     },
-                    "query" : {"match_all": {}}
+                    "query" : query
                 }
             }
-        }
+
+        return { "query" : query }

--- a/portality/migrate/20210422_2870_subject_search/README.md
+++ b/portality/migrate/20210422_2870_subject_search/README.md
@@ -1,0 +1,8 @@
+# Subject Search Reindex
+
+Save (and re-generate index) for Application and Journal to get additional index.classification values to support
+searching
+
+Run
+
+    python portality/upgrade.py -u portality/migrate/20210422_2870_subject_search/migrate.json

--- a/portality/migrate/20210422_2870_subject_search/migrate.json
+++ b/portality/migrate/20210422_2870_subject_search/migrate.json
@@ -1,0 +1,15 @@
+{
+    "batch" : 10000,
+	"types": [
+		{
+			"type" : "application",
+			"init_with_model" : true,
+			"keepalive" : "10m"
+		},
+		{
+			"type": "journal",
+			"init_with_model": true,
+			"keepalive": "10m"
+		}
+	]
+}

--- a/portality/models/lcc.py
+++ b/portality/models/lcc.py
@@ -4,14 +4,7 @@ from portality.dao import DomainObject
 class LCC(DomainObject):
     __type__ = "lcc"
 
-    def pathify(self, term, path_separator=": "):
-        """
-        Convert the given term into a string containing the path from the root via the parents to the term
-        :param term:
-        :param path_separator:
-        :return:
-        """
-
+    def term_path(self, term):
         def dive(node, path):
             if node.get("name") == term:
                 path.append(term)
@@ -35,8 +28,20 @@ class LCC(DomainObject):
             path = []
             found = dive(r, path)
             if found:
-                return path_separator.join(path)
+                return path
 
+        return None
+
+    def pathify(self, term, path_separator=": "):
+        """
+        Convert the given term into a string containing the path from the root via the parents to the term
+        :param term:
+        :param path_separator:
+        :return:
+        """
+        path = self.term_path(term)
+        if path is not None:
+            return path_separator.join(path)
         return None
 
     def expand_codes(self, code):

--- a/portality/models/v2/bibjson.py
+++ b/portality/models/v2/bibjson.py
@@ -637,6 +637,28 @@ class JournalLikeBibJSON(SeamlessMixin):
 
         return ["LCC:" + x for x in full_list if x is not None]
 
+    def lcc_paths_and_codes(self):
+        paths_and_codes = {}
+
+        # calculate the classification paths
+        from portality.lcc import lcc  # inline import since this hits the database
+        for subs in self.subjects():
+            scheme = subs.get("scheme")
+            if scheme != "LCC":
+                continue
+            term = subs.get("term")
+            code = subs.get("code")
+            p = lcc.pathify(term)
+            if p is not None:
+                paths_and_codes[p] = "LCC:" + code
+
+        return [(x, paths_and_codes[x]) for x in lcc.longest(list(paths_and_codes.keys()))]
+        #
+        # # normalise the classification paths, so we only store the longest ones
+        # classification_paths = lcc.longest(classification_paths)
+        #
+        # return classification_paths
+
 
     # to help with ToC - we prefer to refer to a journal by E-ISSN, or
     # if not, then P-ISSN

--- a/portality/models/v2/bibjson.py
+++ b/portality/models/v2/bibjson.py
@@ -605,6 +605,10 @@ class JournalLikeBibJSON(SeamlessMixin):
         langs = [to_utf8_unicode(l) for l in langs]
         return list(set(langs))
 
+    def term_path(self, term):
+        from portality.lcc import lcc
+        return lcc.term_path(term)
+
     def lcc_paths(self):
         classification_paths = []
 

--- a/portality/models/v2/bibjson.py
+++ b/portality/models/v2/bibjson.py
@@ -657,12 +657,6 @@ class JournalLikeBibJSON(SeamlessMixin):
                 paths_and_codes[p] = "LCC:" + code
 
         return [(x, paths_and_codes[x]) for x in lcc.longest(list(paths_and_codes.keys()))]
-        #
-        # # normalise the classification paths, so we only store the longest ones
-        # classification_paths = lcc.longest(classification_paths)
-        #
-        # return classification_paths
-
 
     # to help with ToC - we prefer to refer to a journal by E-ISSN, or
     # if not, then P-ISSN

--- a/portality/models/v2/journal.py
+++ b/portality/models/v2/journal.py
@@ -377,6 +377,14 @@ class JournalLikeObject(SeamlessMixin, DomainObject):
             if "code" in subs:
                 schema_codes.append(scheme + ":" + subs.get("code"))
 
+        # now expand the classification to hold all its parent terms too
+        additional = []
+        for c in classification:
+            tp = cbib.term_path(c)
+            if tp is not None:
+                additional += tp
+        classification += additional
+
         # add the keywords to the non-schema subjects (but not the classification)
         subjects += cbib.keywords
 

--- a/portality/templates/doaj/toc.html
+++ b/portality/templates/doaj/toc.html
@@ -409,9 +409,13 @@
                                     {% for path in bibjson.lcc_paths() %}
                                         {% if loop.index0 == 0 %}<dt>LCC subjects <a href="https://www.loc.gov/catdir/cpso/lcco/" target="_blank" rel="noopener"><span data-feather="help-circle" aria-hidden="true"></span><span class="sr-only">Look up the Library of Congress Classification Outline</span></a></dt>{% endif %}
                                         <dd>
-                                            <a href="{{ url_for('doaj.journals_search') }}?ref=toc&source=%7B%22query%22%3A%7B%22query_string%22%3A%7B%22query%22%3A%22{{ path }}%22%2C%22default_operator%22%3A%22AND%22%2C%22default_field%22%3A%22index.classification%22%7D%7D%2C%22size%22%3A50%2C%22sort%22%3A%5B%7B%22created_date%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%7D">
+                                            {% set source = search_query_source(terms={"index.schema_codes_tree.exact": path}) %}
+                                             <a href="{{ url_for('doaj.journals_search') }}?ref=toc&source={{ source }}">
                                                 {{ path }}
                                             </a>
+{#                                            <a href="{{ url_for('doaj.journals_search') }}?ref=toc&source=%7B%22query%22%3A%7B%22query_string%22%3A%7B%22query%22%3A%22{{ path }}%22%2C%22default_operator%22%3A%22AND%22%2C%22default_field%22%3A%22index.classification%22%7D%7D%2C%22size%22%3A50%2C%22sort%22%3A%5B%7B%22created_date%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%7D">#}
+{#                                                {{ path }}#}
+{#                                            </a>#}
                                         </dd>
                                     {% endfor %}
 

--- a/portality/templates/doaj/toc.html
+++ b/portality/templates/doaj/toc.html
@@ -406,16 +406,13 @@
                             <article class="card card--with-icon">
                                 <span data-feather="tag" aria-hidden="true"></span>
                                 <dl>
-                                    {% for path in bibjson.lcc_paths() %}
+                                    {% for path, code in bibjson.lcc_paths_and_codes() %}
                                         {% if loop.index0 == 0 %}<dt>LCC subjects <a href="https://www.loc.gov/catdir/cpso/lcco/" target="_blank" rel="noopener"><span data-feather="help-circle" aria-hidden="true"></span><span class="sr-only">Look up the Library of Congress Classification Outline</span></a></dt>{% endif %}
                                         <dd>
-                                            {% set source = search_query_source(terms={"index.schema_codes_tree.exact": path}) %}
+                                            {% set source = search_query_source(terms=[{"index.schema_codes_tree.exact": [code]}]) %}
                                              <a href="{{ url_for('doaj.journals_search') }}?ref=toc&source={{ source }}">
                                                 {{ path }}
                                             </a>
-{#                                            <a href="{{ url_for('doaj.journals_search') }}?ref=toc&source=%7B%22query%22%3A%7B%22query_string%22%3A%7B%22query%22%3A%22{{ path }}%22%2C%22default_operator%22%3A%22AND%22%2C%22default_field%22%3A%22index.classification%22%7D%7D%2C%22size%22%3A50%2C%22sort%22%3A%5B%7B%22created_date%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%7D">#}
-{#                                                {{ path }}#}
-{#                                            </a>#}
                                         </dd>
                                     {% endfor %}
 

--- a/portality/templates/doaj/toc.html
+++ b/portality/templates/doaj/toc.html
@@ -387,7 +387,8 @@
                                     {% if bibjson.publisher_name %}
                                         <dt>Publisher</dt>
                                         <dd>
-                                          <a href="{{ url_for('doaj.journals_search') }}?ref=toc&source=%7B%22query%22%3A%7B%22filtered%22%3A%7B%22filter%22%3A%7B%22bool%22%3A%7B%22must%22%3A%5B%7B%22terms%22%3A%7B%22bibjson.publisher.name.exact%22%3A%5B%22{{ bibjson.publisher_name|safe }}%22%5D%7D%7D%5D%7D%7D%2C%22query%22%3A%7B%22match_all%22%3A%7B%7D%7D%7D%7D%2C%22size%22%3A50%2C%22sort%22%3A%5B%7B%22created_date%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%7D">{{bibjson.publisher_name}}</a>{% if bibjson.publisher_country %}, {{bibjson.publisher_country_name()}}{% endif %}
+                                            {% set source = search_query_source(terms=[{"bibjson.publisher.name.exact": [bibjson.publisher_name]}]) %}
+                                            <a href="{{ url_for('doaj.journals_search') }}?ref=toc&source={{ source }}">{{bibjson.publisher_name}}</a>{% if bibjson.publisher_country %}, {{bibjson.publisher_country_name()}}{% endif %}
                                         </dd>
                                     {% endif %}
 
@@ -420,7 +421,8 @@
                                         <dt>Keywords</dt>
                                         <dd>
                                             {% for keyword in bibjson.keywords %}
-                                                <a href="{{ url_for('doaj.journals_search') }}?ref=toc&source=%7B%22query%22%3A%7B%22query_string%22%3A%7B%22query%22%3A%22{{ keyword|safe }}%22%2C%22default_operator%22%3A%22AND%22%7D%7D%2C%22size%22%3A50%2C%22sort%22%3A%5B%7B%22created_date%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%7D" class="tag">{{ keyword }}</a>
+                                                {% set source = search_query_source(query_string=keyword) %}
+                                                <a href="{{ url_for('doaj.journals_search') }}?ref=toc&source={{ source }}" class="tag">{{ keyword }}</a>
                                             {% endfor %}
                                         </dd>
                                     {% endif %}


### PR DESCRIPTION
Changes for: https://github.com/DOAJ/doajPM/issues/2870

This does the following things:

* adds a mechanism to generate search urls algorithmically (rather than by copy and paste of the search url with substitutions)
* Changes the ToC to search for subject specifically by LCC code rather than subject term
* Changes the save routine for journals and applications to index the full classification path into index.classification
* Adds a migration script to apply the reindex