### PR TITLE
Continuation for closed https://github.com/DOAJ/doaj/pull/1881

### DIFF
--- a/doajtest/unit/test_bll_accept_application.py
+++ b/doajtest/unit/test_bll_accept_application.py
@@ -130,3 +130,16 @@ class TestBLLAcceptApplication(DoajTestCase):
 
             if save:
                 pass
+
+    def test_02_does_not_ingest_empty_string(self):
+        application = Suggestion(**ApplicationFixtureFactory.incoming_application())
+        application.bibjson().add_identifier("pissn", "")
+
+        acc = Account(**AccountFixtureFactory.make_managing_editor_source())
+
+        svc = DOAJ.applicationService()
+        journal = svc.accept_application(application, acc)
+        time.sleep(1)
+
+        assert journal.bibjson().get_one_identifier("pissn") != "", "Journals pissn should not be '' (empty string)"
+        assert journal.bibjson().get_one_identifier("pissn") is None, "Journal should not have pissn at all, instead it exists and equals {}".format(journal.bibjson().get_one_identifier("pissn"))

--- a/portality/bll/services/application.py
+++ b/portality/bll/services/application.py
@@ -365,6 +365,12 @@ class ApplicationService(object):
             journal.set_owner(application.owner)
         journal.set_seal(application.has_seal())
 
+        b = application.bibjson()
+        if b.get_one_identifier("pissn") == "":
+            b.add_identifier("pissn", None)
+        if b.get_one_identifier("eissn") == "":
+            b.add_identifier("eissn", None)
+
         # no relate the journal to the application and place it in_doaj
         journal.add_related_application(application.id, dates.now())
         journal.set_in_doaj(True)

--- a/portality/bll/services/application.py
+++ b/portality/bll/services/application.py
@@ -366,9 +366,9 @@ class ApplicationService(object):
         journal.set_seal(application.has_seal())
 
         b = application.bibjson()
-        if b.get_one_identifier("pissn") == "":
+        if b.pissn == "":
             b.add_identifier("pissn", None)
-        if b.get_one_identifier("eissn") == "":
+        if b.eissn == "":
             b.add_identifier("eissn", None)
 
         # no relate the journal to the application and place it in_doaj

--- a/portality/lib/coerce.py
+++ b/portality/lib/coerce.py
@@ -73,7 +73,7 @@ def to_country_code(val):
     return uc(nv)
 
 def to_issn(issn):
-    if len(issn) > 9:
+    if len(issn) > 9 or issn == '':
         raise ValueError("Unable to normalise {x} to valid ISSN".format(x=issn))
 
     issn = issn.upper()

--- a/portality/scripts/2882_empty_string_issns.py
+++ b/portality/scripts/2882_empty_string_issns.py
@@ -1,0 +1,52 @@
+from portality import models
+from portality.core import es_connection
+import esprit
+import csv
+from portality.util import ipt_prefix
+
+EMPTY_ISSN = {
+"query": {
+        "filtered": {
+            "filter": {
+                "bool": {
+                    "must": {
+                        "term": {"admin.in_doaj": "true"}
+                    }
+                }
+            },
+            "query": {
+                "match_all": {}
+            }
+        }
+    }
+}
+
+if __name__ == "__main__":
+
+    # import argparse
+    # parser = argparse.ArgumentParser()
+    # parser.add_argument("-o", "--out", help="output file path")
+    # args = parser.parse_args()
+    #
+    # if not args.out:
+    #     print("Please specify an output file path with the -o option")
+    #     parser.print_help()
+    #     exit()
+
+    out = "out.csv"
+
+    with open(out, "w", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["ID", "PISSN", "EISSN"])
+        count = 0
+        for j in esprit.tasks.scroll(es_connection, ipt_prefix(models.Journal.__type__), q=EMPTY_ISSN, page_size=100, keepalive='5m'):
+            journal = models.Journal(_source=j)
+            count = count + 1
+            pissn = journal.bibjson().get_one_identifier("pissn")
+            eissn = journal.bibjson().get_one_identifier("eissn")
+            if pissn == "" or eissn == "":
+                try:
+                    writer.writerow([journal.id, pissn, eissn])
+                except AttributeError:
+                    print("Error reading attributes for journal {0}".format(j['id']))
+        print ("Analyzed {} journals in DOAJ".format(count))


### PR DESCRIPTION
Correct changes to https://github.com/DOAJ/doaj/pull/1881, 
Patch for:
DOAJ/doajPM#2882

changes added to coerce.py and application_2_journal crosswalk and new UT provided to make sure that empty string issn in an application will be ignored.

TODO:
- [x] check the data for any empty strings in journals' issns
- [x] make sure we do not have to worry about empty strings issn in crossref articles (DOAJ schema takes care of it) 