### PR TITLE
Hotfix/813 ogurl

### DIFF
--- a/portality/templates/layouts/base.html
+++ b/portality/templates/layouts/base.html
@@ -35,7 +35,7 @@ I'm not sure of the value of it.  Leaving the code snippet here to remind us #}
   <meta name="theme-color" content="#282624">
 
   <!-- OpenGraph -->
-  <meta property="og:url" content={{ request.url }}>
+  <meta property="og:url" content="{{ request.url }}">
   <meta property="og:type" content="website">
   <meta property="og:title" content=" Directory of Open Access Journals">
   <meta property="og:description" content="DOAJ is a community-curated online directory that indexes and provides access to high quality, open access, peer-reviewed journals.">

--- a/portality/templates/layouts/base.html
+++ b/portality/templates/layouts/base.html
@@ -35,7 +35,7 @@ I'm not sure of the value of it.  Leaving the code snippet here to remind us #}
   <meta name="theme-color" content="#282624">
 
   <!-- OpenGraph -->
-  <meta property="{{ request.url }}" content="https://doaj.org">
+  <meta property="og:url" content={{ request.url }}>
   <meta property="og:type" content="website">
   <meta property="og:title" content=" Directory of Open Access Journals">
   <meta property="og:description" content="DOAJ is a community-curated online directory that indexes and provides access to high quality, open access, peer-reviewed journals.">
@@ -87,6 +87,7 @@ I'm not sure of the value of it.  Leaving the code snippet here to remind us #}
 {% endif %}
 
 <body class="{% block body_class %}{% endblock %}" data-spy="scroll" data-offset="70">
+
     <header class="page-header">
         {% include "includes/header.html" %}
         {% block extra_header %}{% endblock %}

--- a/portality/templates/layouts/base.html
+++ b/portality/templates/layouts/base.html
@@ -35,7 +35,7 @@ I'm not sure of the value of it.  Leaving the code snippet here to remind us #}
   <meta name="theme-color" content="#282624">
 
   <!-- OpenGraph -->
-  <meta property="og:url" content="https://doaj.org">
+  <meta property="{{ request.url }}" content="https://doaj.org">
   <meta property="og:type" content="website">
   <meta property="og:title" content=" Directory of Open Access Journals">
   <meta property="og:description" content="DOAJ is a community-curated online directory that indexes and provides access to high quality, open access, peer-reviewed journals.">
@@ -87,7 +87,6 @@ I'm not sure of the value of it.  Leaving the code snippet here to remind us #}
 {% endif %}
 
 <body class="{% block body_class %}{% endblock %}" data-spy="scroll" data-offset="70">
-
     <header class="page-header">
         {% include "includes/header.html" %}
         {% block extra_header %}{% endblock %}


### PR DESCRIPTION
For: https://github.com/DOAJ/doajPM/issues/813

I am not sure if that is still the issue. I deployed to the server two versions of the app. One with the `<meta property="og:url" content="https://doaj.org>` and one with: `<meta property="og:url" content={{ request.url }}>`. I tested it with https://developers.facebook.com/tools/debug/ for journal toc page.
In both cases, canonical URL has been correctly scrapped as testdoaj/toc/xxxx-xxxx url (og:url set to doaj.org seemed to be ignored?). 

I'm submitting this PR with requested change as it seems reasonable but it may need more investigation. Or maybe just I need more explanation on what is expected.