### PR TITLE
use striptags instead of safe in articles title

### DIFF
--- a/portality/templates/doaj/article.html
+++ b/portality/templates/doaj/article.html
@@ -89,7 +89,7 @@
 
                 <h1>
                     {%  if bibjson.title %}
-                        {{ bibjson.title | safe }}
+                        {{ bibjson.title | striptags }}
                     {% else %}
                         <em>[Article title missing]</em>
                     {% endif %}


### PR DESCRIPTION
patch for: https://github.com/DOAJ/doajPM/issues/2953