### PR TITLE
add callback to animate method, animate html not scrollselector

### DIFF
--- a/portality/static/js/doaj.fieldrender.edges.js
+++ b/portality/static/js/doaj.fieldrender.edges.js
@@ -2076,6 +2076,7 @@ $.extend(true, doaj, {
                 $('html').animate({    // note we do not use component.jq, because the scroll target could be outside it
                     scrollTop: $(this.scrollSelector).offset().top
                 }, 1, () => {
+                    callback("hello")
                     if (callback === "setFrom") {
                         this.component.setFrom(1)
                     }
@@ -2090,7 +2091,12 @@ $.extend(true, doaj, {
 
             this.goToFirst = function (element) {
                 if (this.scroll) {
-                    this.doScroll("setFrom");
+                    var myFunction = edges.objClosure(this, "setFrom")
+                    var that = this;
+                    function showEnclosed() {
+                        that.setFrom(1);
+                    }
+                    this.doScroll(myFunction);
                 }
             };
 

--- a/portality/static/js/doaj.fieldrender.edges.js
+++ b/portality/static/js/doaj.fieldrender.edges.js
@@ -2072,31 +2072,38 @@ $.extend(true, doaj, {
                 }
             };
 
-            this.doScroll = function () {
-                $(this.scrollSelector).animate({    // note we do not use component.jq, because the scroll target could be outside it
+            this.doScroll = function (callback) {
+                $('html').animate({    // note we do not use component.jq, because the scroll target could be outside it
                     scrollTop: $(this.scrollSelector).offset().top
-                }, 1);
+                }, 1, () => {
+                    if (callback === "setFrom") {
+                        this.component.setFrom(1)
+                    }
+                    else if (callback === "decrementPage") {
+                        this.component.decrementPage()
+                    }
+                    else if (callback === "incrementPage") {
+                        this.component.incrementPage()
+                    }
+                });
             };
 
             this.goToFirst = function (element) {
                 if (this.scroll) {
-                    this.doScroll();
+                    this.doScroll("setFrom");
                 }
-                this.component.setFrom(1);
             };
 
             this.goToPrev = function (element) {
                 if (this.scroll) {
-                    this.doScroll();
+                    this.doScroll("decrementPage");
                 }
-                this.component.decrementPage();
             };
 
             this.goToNext = function (element) {
                 if (this.scroll) {
                     this.doScroll();
                 }
-                this.component.incrementPage();
             };
         },
 


### PR DESCRIPTION
Wrong branch name, should have number 2880
patch for https://github.com/DOAJ/doajPM/issues/2880

`$('html')` should be scrolled instead of scroll selector
page should be rendered only after scroll is finished