### PR TITLE
remove doaj.org as default url base in public search

### DIFF
--- a/portality/static/js/doaj.fieldrender.edges.js
+++ b/portality/static/js/doaj.fieldrender.edges.js
@@ -2110,7 +2110,7 @@ $.extend(true, doaj, {
                 this.doaj_url = params.doaj_url;
             }
             else {
-                this.doaj_url = "https://doaj.org"
+                this.doaj_url = ""
             }
 
             this.actions = edges.getParam(params.actions, []);


### PR DESCRIPTION
make sure that the dev env links to dev env in the public searches if not widget

hotfix for: https://github.com/DOAJ/doajPM/issues/2986