### PR TITLE
Hotfix/2626 next button

### DIFF
--- a/portality/forms/application_forms.py
+++ b/portality/forms/application_forms.py
@@ -2719,9 +2719,9 @@ class ListWidgetWithSubfields(object):
         html = ['<%s %s>' % (self.html_tag, html_params(**kwargs))]
         for subfield in field:
             if self.prefix_label:
-                html.append('<li>%s %s' % (subfield.label, subfield(**kwargs)))
+                html.append('<li tabindex=0>%s %s' % (subfield.label, subfield(**kwargs)))
             else:
-                html.append('<li>%s %s' % (subfield(**kwargs), subfield.label))
+                html.append('<li tabindex=0>%s %s' % (subfield(**kwargs), subfield.label))
 
             html.append("</li>")
 

--- a/portality/static/js/application_form.js
+++ b/portality/static/js/application_form.js
@@ -391,7 +391,7 @@ doaj.af.TabbedApplicationForm = class extends doaj.af.BaseApplicationForm {
                 errFirst.triggerHandler("focus");
             }
             else {
-                $("label[for='" + $(errFirst).attr('id') + "']").focus()
+                errFirst.closest("li[tabindex='0']").focus();
             }
             //$(".nextBtn").blur();
             if (showEvenIfInvalid){

--- a/portality/static/js/application_form.js
+++ b/portality/static/js/application_form.js
@@ -282,7 +282,7 @@ doaj.af.TabbedApplicationForm = class extends doaj.af.BaseApplicationForm {
             scrollTop: 0
         }, 500, () => {
             $(this.tabs[n]).show();
-            $("#nextBtn").blur()
+            $(".nextBtn").blur()
         })
     };
 
@@ -387,7 +387,13 @@ doaj.af.TabbedApplicationForm = class extends doaj.af.BaseApplicationForm {
             let errFirst = $(errFields.first()[0].element);
             // The Firefox does not handle focus on hidden fields and select2 does not implement this after autofocus on select2 fields
             // it resolves this issue and fixes: https://github.com/DOAJ/doajPM/issues/2626
-            errFirst.triggerHandler("focus");
+            if ($(errFirst).attr("type") !== "radio"){
+                errFirst.triggerHandler("focus");
+            }
+            else {
+                $("label[for='" + $(errFirst).attr('id') + "']").focus()
+            }
+            //$(".nextBtn").blur();
             if (showEvenIfInvalid){
                 this.currentTab = parseInt(n);
                 this.previousTab = this.currentTab-1;


### PR DESCRIPTION
1. Makes sure that <li> element in questions with radio buttons is focusable so that it can be focused instead of hidden input
2. fixes jquery selector for `nextBtn` in showTab