### PR TITLE
add commas and spaces to APC display

### DIFF
--- a/portality/static/js/doaj.fieldrender.edges.js
+++ b/portality/static/js/doaj.fieldrender.edges.js
@@ -2236,7 +2236,8 @@ $.extend(true, doaj, {
                 var apcs = '<li>';
                 if (edges.hasProp(resultobj, "bibjson.apc.max") && resultobj.bibjson.apc.max.length > 0) {
                     apcs += "APCs: ";
-                    for (var i = 0; i < resultobj.bibjson.apc.max.length; i++) {
+                    let length = resultobj.bibjson.apc.max.length;
+                    for (var i = 0; i < length; i++) {
                         apcs += "<strong>";
                         var apcRecord = resultobj.bibjson.apc.max[i];
                         if (apcRecord.hasOwnProperty("price")) {
@@ -2244,6 +2245,9 @@ $.extend(true, doaj, {
                         }
                         if (apcRecord.currency) {
                             apcs += ' (' + edges.escapeHtml(apcRecord.currency) + ')';
+                        }
+                        if (i < length - 1) {
+                            apcs += ', ';
                         }
                         apcs += "</strong>";
                     }
@@ -2966,7 +2970,8 @@ $.extend(true, doaj, {
                 var apcs = '<li>';
                 if (edges.hasProp(resultobj, "bibjson.apc.max") && resultobj.bibjson.apc.max.length > 0) {
                     apcs += "APCs: ";
-                    for (var i = 0; i < resultobj.bibjson.apc.max.length; i++) {
+                    let length = resultobj.bibjson.apc.max.length;
+                    for (var i = 0; i < length; i++) {
                         apcs += "<strong>";
                         var apcRecord = resultobj.bibjson.apc.max[i];
                         if (apcRecord.hasOwnProperty("price")) {
@@ -2974,6 +2979,9 @@ $.extend(true, doaj, {
                         }
                         if (apcRecord.currency) {
                             apcs += ' (' + edges.escapeHtml(apcRecord.currency) + ')';
+                        }
+                        if (i < length - 1) {
+                            apcs += ', ';
                         }
                         apcs += "</strong>";
                     }

--- a/portality/templates/doaj/toc.html
+++ b/portality/templates/doaj/toc.html
@@ -172,35 +172,46 @@
                                         <p>
                                             {# APCs #}
                                             {% if bibjson.apc %}
-                                                The highest fee charged by this journal is <strong class="label label--large">{{ bibjson.apc[0].get("price", "price unknown") }} {{ bibjson.apc[0].get("currency", " currency unknown") }}</strong> as {% if bibjson.apc_url%}<a href="{{ bibjson.apc_url }}" target="_blank" rel="noopener">{% endif %}publication fees{% if bibjson.apc_url%}</a>{% endif %} (article processing charges or APCs).
-
-                                                {% if bibjson.apc|length > 1 %}
-                                                    In other currencies the APC is:
-                                                    {% for apc in bibjson.apc %}
-                                                        {% if not loop.first %}
-                                                            {{ apc.get("price") }} {{ apc.get("currency") }}
-                                                        {% endif %}
-                                                        {% if not loop.first and not loop.last %}, {% endif %}
-                                                    {% endfor %}
-                                                {% endif %}
+                                                The highest fee charged by this journal is <strong class="label label--large">{{ bibjson.apc[0].get("price", "price unknown") }} {{ bibjson.apc[0].get("currency", " currency unknown") }}</strong> as {% if bibjson.apc_url%}<a href="{{ bibjson.apc_url }}" target="_blank" rel="noopener">{% endif %}publication fees{% if bibjson.apc_url%}</a>{% endif %} (article processing charges or APCs)
+                                                {%- if bibjson.has_other_charges %}
+                                                    and there are
+                                                    {% if bibjson.other_charges_url %}
+                                                        <a href="{{ bibjson.other_charges_url }}" target="_blank" rel="noopener">other charges</a>
+                                                    {%- else %}
+                                                        other charges
+                                                    {%- endif -%}
+                                                 {% endif -%}
+                                                .
                                             {% else %}
-                                                There are <strong class="label label--large">no publication fees</strong> (<a href="{{ bibjson.apc_url }}" target="_blank" rel="noopener">article processing charges or APCs</a>) to publish with this journal{% if bibjson.has_other_charges %}{% else %}.{% endif %}
+                                                There are <strong class="label label--large">no publication fees</strong> (<a href="{{ bibjson.apc_url }}" target="_blank" rel="noopener">article processing charges or APCs</a>) to publish with this journal
+                                                {%- if bibjson.has_other_charges %}
+                                                    but there are
+                                                    {% if bibjson.other_charges_url %}
+                                                        <a href="{{ bibjson.other_charges_url }}" target="_blank" rel="noopener">other charges</a>
+                                                    {% else %}
+                                                        other charges
+                                                    {% endif %}
+                                                {% endif -%}
+                                                .
                                             {% endif %}
+                                        </p>
 
-                                            {% if bibjson.has_other_charges and bibjson.apc %}
-                                                and there are
-                                                {% if bibjson.other_charges_url %}<a href="{{ bibjson.other_charges_url }}" target="_blank" rel="noopener">{% endif %}
-                                            {% elif bibjson.has_other_charges and bibjson.apc != true %}
-                                                but there are
-                                                {% if bibjson.other_charges_url %}<a href="{{ bibjson.other_charges_url }}" target="_blank" rel="noopener">{% endif %}
-                                            {% endif %}
-                                            {% if bibjson.other_charges_url %} other charges</a>.{% endif %}
-                                                </p>
+                                        {% if bibjson.apc|length > 1 %}
+                                            <p>The highest publication fee in other currencies is:</p>
+                                            <ul>
+                                            {% for apc in bibjson.apc %}
+                                                {% if not loop.first %}
+                                                    <li>{{ apc.get("price") }} {{ apc.get("currency") }}</li>
+                                                {% endif %}
+                                            {% endfor %}
+                                            </ul>
+                                        {% endif %}
+
                                         {# Waivers #}
                                         {% if bibjson.waiver_url %}
-                                            <p>&rarr;There is a <a href="{{ bibjson.waiver_url }}" target="_blank" rel="noopener">waiver policy</a> for these charges.</p>
+                                            <p>There is a <a href="{{ bibjson.waiver_url }}" target="_blank" rel="noopener">waiver policy</a> for these charges.</p>
                                         {% elif bibjson.apc or bibjson.has_other_charges and not bibjson.waiver_url %}
-                                            <p>&rarr;There is <strong>no waiver policy</strong> for these charges.</p>
+                                            <p>There is <strong>no waiver policy</strong> for these charges.</p>
                                         {% endif %}
                                     {% endif %}
                                 </div>

--- a/portality/templates/doaj/toc.html
+++ b/portality/templates/doaj/toc.html
@@ -172,22 +172,21 @@
                                         <p>
                                             {# APCs #}
                                             {% if bibjson.apc %}
-                                                The highest fee charged by this journal is <strong class="label label--large">{{ bibjson.apc[0].get("price", "price unknown") }} {{ bibjson.apc[0].get("currency", " currency unknown") }}</strong> as {% if bibjson.apc_url%}<a href="{{ bibjson.apc_url }}" target="_blank" rel="noopener">{% endif %}publication fees{% if bibjson.apc_url%}</a>{% endif %} (article processing charges or APCs)
+                                                The highest fee charged by this journal is <strong class="label label--large">{{ bibjson.apc[0].get("price", "price unknown") }} {{ bibjson.apc[0].get("currency", " currency unknown") }}</strong> as {% if bibjson.apc_url%}<a href="{{ bibjson.apc_url }}" target="_blank" rel="noopener">{% endif %}publication fees{% if bibjson.apc_url%}</a>{% endif %} (article processing charges or APCs).
 
                                                 {% if bibjson.apc|length > 1 %}
-                                                    In other currencies the APC is
+                                                    In other currencies the APC is:
                                                     {% for apc in bibjson.apc %}
                                                         {% if not loop.first %}
                                                             {{ apc.get("price") }} {{ apc.get("currency") }}
                                                         {% endif %}
-                                                        {% if not loop.last %},{% endif %}
+                                                        {% if not loop.first and not loop.last %}, {% endif %}
                                                     {% endfor %}
                                                 {% endif %}
                                             {% else %}
                                                 There are <strong class="label label--large">no publication fees</strong> (<a href="{{ bibjson.apc_url }}" target="_blank" rel="noopener">article processing charges or APCs</a>) to publish with this journal{% if bibjson.has_other_charges %}{% else %}.{% endif %}
                                             {% endif %}
 
-                                            {# Other charges #}
                                             {% if bibjson.has_other_charges and bibjson.apc %}
                                                 and there are
                                                 {% if bibjson.other_charges_url %}<a href="{{ bibjson.other_charges_url }}" target="_blank" rel="noopener">{% endif %}
@@ -195,7 +194,7 @@
                                                 but there are
                                                 {% if bibjson.other_charges_url %}<a href="{{ bibjson.other_charges_url }}" target="_blank" rel="noopener">{% endif %}
                                             {% endif %}
-                                            other charges{% if bibjson.other_charges_url %}</a>.{% endif %}
+                                            {% if bibjson.other_charges_url %} other charges</a>.{% endif %}
                                                 </p>
                                         {# Waivers #}
                                         {% if bibjson.waiver_url %}


### PR DESCRIPTION
Patch for issue raised by Judith: https://github.com/DOAJ/doajPM/issues/2988

Fixed display:
![multiple APCs](https://user-images.githubusercontent.com/8298769/123673878-de0b9000-d838-11eb-8678-8529c9f6250c.png)

![image](https://user-images.githubusercontent.com/8298769/123674894-0942af00-d83a-11eb-8294-47130c8537f0.png)

