### PR TITLE
Allow scrolling in menu on mobile

### DIFF
--- a/cms/sass/layout/_secondary-nav.scss
+++ b/cms/sass/layout/_secondary-nav.scss
@@ -25,7 +25,7 @@
 
   .secondary-nav > .container {
     z-index: 3000;
-    position: fixed;
+    position: absolute;
     width: 100%;
     background-color: $light-grey;
   }


### PR DESCRIPTION
Need to test it out with various people, not sure if this is the right approach. The big downside to doing this is that, though it allows people to "scroll" down the menu on mobile, it will also require them to go back to the top of the page to tap the "MENU" item to close it again. This isn’t clear, nor intuitive. 

We could ensure that the MENU button changes to "CLOSE" and the hamburger icon to an X, but it requires a minor change in the JS. 

See DOAJ/doajPM#3003