### PR TITLE
Display the date in the article page in '%b %Y' (eg. Jul 2021) format

### DIFF
--- a/portality/templates/doaj/article.html
+++ b/portality/templates/doaj/article.html
@@ -84,7 +84,7 @@
             <header class="container">
                 <p class="label">
                     <a href="{{url_for('doaj.toc', identifier=journal.toc_id)}}">{{jtitle}}</a>
-                    ({{ bibjson.get_publication_date(date_format="%Y-%m-%d") }})
+                    ({{ bibjson.get_publication_date(date_format="%b %Y") }})
                 </p>
 
                 <h1>


### PR DESCRIPTION
https://github.com/DOAJ/doajPM/issues/3019#issuecomment-895808218