### PR TITLE
add an 'admin' journal csv service and cli to produe the journal csv …

### DIFF
--- a/portality/bll/services/journal.py
+++ b/portality/bll/services/journal.py
@@ -161,6 +161,13 @@ class JournalService(object):
         return url, action_register
 
     def admin_csv(self, file_path, account_sub_length=8):
+        """
+        ~~AdminJournalCSV:Feature->JournalCSV:Feature~~
+        
+        :param file_path:
+        :param account_sub_length:
+        :return:
+        """
         # create a closure for substituting owners for consistently used random strings
         unmap = {}
 

--- a/portality/scripts/admin_journalcsv.py
+++ b/portality/scripts/admin_journalcsv.py
@@ -1,0 +1,25 @@
+from portality.core import app
+from portality.bll import DOAJ
+
+
+if __name__ == "__main__":
+    if app.config.get("SCRIPTS_READ_ONLY_MODE", False):
+        print("System is in READ-ONLY mode, script cannot run")
+        exit()
+
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--out", help="output file for admin csv")
+    args = parser.parse_args()
+
+    journalService = DOAJ.journalService()
+    journalService.admin_csv(args.out)
+
+
+
+
+
+
+
+

--- a/portality/scripts/admin_journalcsv.py
+++ b/portality/scripts/admin_journalcsv.py
@@ -1,3 +1,4 @@
+# ~~AdminJournalCSV:CLI~~
 from portality.core import app
 from portality.bll import DOAJ
 
@@ -13,6 +14,7 @@ if __name__ == "__main__":
     parser.add_argument("-o", "--out", help="output file for admin csv")
     args = parser.parse_args()
 
+    # ~~-> Journal:Service~~
     journalService = DOAJ.journalService()
     journalService.admin_csv(args.out)
 


### PR DESCRIPTION
…with additional obfuscated owner id information

https://github.com/DOAJ/doajPM/issues/3022

Once this is merged and deployed, @Steven-Eardley could you run the script

```
python portaliyt/scripts/admin_journalcsv.py -o [output file path]
```

and attach it to the original issue