### PR TITLE
Hotfix/3059 crossref xml characters

### DIFF
--- a/portality/crosswalks/article_crossref_xml.py
+++ b/portality/crosswalks/article_crossref_xml.py
@@ -314,7 +314,11 @@ Example record:
 def _element(xml, field, namespace):
     el = xml.find(field, namespace)
     if el is not None:
-        string = etree.tostring(el).decode("utf-8")
+        # this converts the entire element to a string, so that we can handle the possibility of
+        # embedded html tags, etc.
+        # etree.tostring doesn't actually produce a string, but a byte array, so we must specify
+        # the encoding and THEN also decode it using that same encoding to get an actual string
+        string = etree.tostring(el, encoding="utf-8").decode("utf-8")
         start = string.index(">") + 1
         end = string.rindex('</')
         text = string[start:end]

--- a/portality/scripts/ingestarticles.py
+++ b/portality/scripts/ingestarticles.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     with open(args.file, "rb") as f:
-        fs = FileStorage(f, "testing.xml")
+        fs = FileStorage(f, "placeholder.xml")  # fake filename required to build the FIleStorage object
         job = IngestArticlesBackgroundTask.prepare(args.username, upload_file=fs, schema=args.schema)
         job = StdOutBackgroundJob(job)
         task = IngestArticlesBackgroundTask(job)

--- a/portality/scripts/ingestarticles.py
+++ b/portality/scripts/ingestarticles.py
@@ -9,17 +9,16 @@ if __name__ == "__main__":
         print("System is in READ-ONLY mode, script cannot run")
         exit()
 
-    user = app.config.get("SYSTEM_USERNAME")
-
     import argparse
     parser = argparse.ArgumentParser()
+    parser.add_argument("username", help="username to import as")
     parser.add_argument("file", help="XML file to import")
     parser.add_argument("schema", help="doaj or crossref")
     args = parser.parse_args()
 
-    with open(args.file) as f:
+    with open(args.file, "rb") as f:
         fs = FileStorage(f, "testing.xml")
-        job = IngestArticlesBackgroundTask.prepare(user, upload_file=fs, schema=args.schema)
+        job = IngestArticlesBackgroundTask.prepare(args.username, upload_file=fs, schema=args.schema)
         job = StdOutBackgroundJob(job)
         task = IngestArticlesBackgroundTask(job)
         BackgroundApi.execute(task)

--- a/portality/scripts/ingestarticles.py
+++ b/portality/scripts/ingestarticles.py
@@ -1,0 +1,25 @@
+from portality.core import app
+from portality.tasks.ingestarticles import IngestArticlesBackgroundTask
+from portality.background import BackgroundApi
+from portality.models.background import StdOutBackgroundJob
+from werkzeug import FileStorage
+
+if __name__ == "__main__":
+    if app.config.get("SCRIPTS_READ_ONLY_MODE", False):
+        print("System is in READ-ONLY mode, script cannot run")
+        exit()
+
+    user = app.config.get("SYSTEM_USERNAME")
+
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", help="XML file to import")
+    parser.add_argument("schema", help="doaj or crossref")
+    args = parser.parse_args()
+
+    with open(args.file) as f:
+        fs = FileStorage(f, "testing.xml")
+        job = IngestArticlesBackgroundTask.prepare(user, upload_file=fs, schema=args.schema)
+        job = StdOutBackgroundJob(job)
+        task = IngestArticlesBackgroundTask(job)
+        BackgroundApi.execute(task)


### PR DESCRIPTION
For: https://github.com/DOAJ/doajPM/issues/3059

Fixes a bug where unicode characters in crossref xml are converted to xml escape entities during import