### PR TITLE
add _statuses_not_requiring_validation to editor application

### DIFF
--- a/portality/forms/application_processors.py
+++ b/portality/forms/application_processors.py
@@ -524,6 +524,19 @@ class EditorApplication(ApplicationProcessor):
     ~~EditorApplication:FormProcessor~~
     """
 
+    def validate(self):
+        _statuses_not_requiring_validation = ['rejected', 'pending', 'in progress', 'on hold']
+        self.pre_validate()
+        # make use of the ability to disable validation, otherwise, let it run
+        valid = super(EditorApplication, self).validate()
+
+        if self.form is not None:
+            if self.form.application_status.data in _statuses_not_requiring_validation and not valid:
+                self.resetDefaults(self.form)
+                return True
+
+        return valid
+
     def pre_validate(self):
         # Call to super sets all the basic disabled fields
         super(EditorApplication, self).pre_validate()

--- a/portality/forms/application_processors.py
+++ b/portality/forms/application_processors.py
@@ -525,7 +525,7 @@ class EditorApplication(ApplicationProcessor):
     """
 
     def validate(self):
-        _statuses_not_requiring_validation = ['rejected', 'pending', 'in progress', 'on hold']
+        _statuses_not_requiring_validation = ['pending', 'in progress']
         self.pre_validate()
         # make use of the ability to disable validation, otherwise, let it run
         valid = super(EditorApplication, self).validate()


### PR DESCRIPTION
for https://github.com/DOAJ/doajPM/issues/3114

It should be possible to save the invalid application for statuses that do not require validation by associated editors.