### PR TITLE
fixes a display bug with the readonly application form.  This changes…

### DIFF
--- a/portality/static/js/application_form.js
+++ b/portality/static/js/application_form.js
@@ -278,10 +278,13 @@ doaj.af.TabbedApplicationForm = class extends doaj.af.BaseApplicationForm {
         }
         this.updateStepIndicator();
 
+        // note that we use `this.currentTab` as the below code is going to
+        // execute asynchronously, and we want to make sure that it shows
+        // the actual correct tab
         $('html').animate({
             scrollTop: 0
         }, 500, () => {
-            $(this.tabs[n]).show();
+            $(this.tabs[this.currentTab]).show();
             $(".nextBtn").blur()
         })
     };
@@ -650,6 +653,8 @@ doaj.af.ReadOnlyApplicationForm = class extends doaj.af.TabbedApplicationForm {
         super(params);
         this.editSectionsFromReview = false;
         this.showTab(this.tabs.length - 1);
+        $(".prevBtn").hide();
+        $(".af-pager").hide();
     }
 };
 

--- a/portality/templates/application_form/01-oa-compliance/index.html
+++ b/portality/templates/application_form/01-oa-compliance/index.html
@@ -1,5 +1,5 @@
 
-{% if not notabs %}<p class="label">Page 1 of {{ FORM | length + 1}}</p>{% endif %}
+{% if not notabs %}<p class="label af-pager">Page 1 of {{ FORM | length + 1}}</p>{% endif %}
 <h1><span data-feather="unlock"></span> Open access compliance</h1>
 
 {% if formulaic_context.name == "public" %}

--- a/portality/templates/application_form/02-about/index.html
+++ b/portality/templates/application_form/02-about/index.html
@@ -1,6 +1,6 @@
 {% if not notabs %}
 <p class="prevBtn label label--secondary" role="button" style="cursor: pointer;">&larr; Back</p>
-<p class="label">Page 2 of {{ FORM | length + 1}}</p>
+<p class="label af-pager">Page 2 of {{ FORM | length + 1}}</p>
 {% endif %}
 
 <h1><span data-feather="edit-3"></span> About the journal</h1>

--- a/portality/templates/application_form/03-copyright-licensing/index.html
+++ b/portality/templates/application_form/03-copyright-licensing/index.html
@@ -1,6 +1,6 @@
 {% if not notabs %}
 <p class="prevBtn label label--secondary" role="button" style="cursor: pointer;">&larr; Back</p>
-<p class="label">Page 3 of {{ FORM | length + 1}}</p>
+<p class="label af-pager">Page 3 of {{ FORM | length + 1}}</p>
 {% endif %}
 
 <h1>© Copyright & licensing</h1>

--- a/portality/templates/application_form/04-editorial/index.html
+++ b/portality/templates/application_form/04-editorial/index.html
@@ -1,6 +1,6 @@
 {% if not notabs %}
 <p class="prevBtn label label--secondary" role="button" style="cursor: pointer;">&larr; Back</p>
-<p class="label">Page 4 of {{ FORM | length + 1}}</p>
+<p class="label af-pager">Page 4 of {{ FORM | length + 1}}</p>
 {% endif %}
 
 <h1><span data-feather="user-check"></span> Editorial</h1>

--- a/portality/templates/application_form/05-business-model/index.html
+++ b/portality/templates/application_form/05-business-model/index.html
@@ -1,6 +1,6 @@
 {% if not notabs %}
 <p class="prevBtn label label--secondary" role="button" style="cursor: pointer;">&larr; Back</p>
-<p class="label">Page 5 of {{ FORM | length + 1}}</p>
+<p class="label af-pager">Page 5 of {{ FORM | length + 1}}</p>
 {% endif %}
 
 <h1><span data-feather="dollar-sign"></span>Business Model</h1>

--- a/portality/templates/application_form/06-best-practice/index.html
+++ b/portality/templates/application_form/06-best-practice/index.html
@@ -1,6 +1,6 @@
 {% if not notabs %}
 <p class="prevBtn label label--secondary" role="button" style="cursor: pointer;">&larr; Back</p>
-<p class="label">Page 6 of {{ FORM | length + 1}}</p>
+<p class="label af-pager">Page 6 of {{ FORM | length + 1}}</p>
 {% endif %}
 
 <h1><span data-feather="archive"></span> Best practice</h1>

--- a/portality/templates/application_form/07-review/index.html
+++ b/portality/templates/application_form/07-review/index.html
@@ -1,6 +1,6 @@
 {% if not notabs %}
 <p class="prevBtn label label--secondary" role="button" style="cursor: pointer;">&larr; Back</p>
-<p class="label">Page 7 of {{ FORM | length + 1}}</p>
+<p class="label af-pager">Page 7 of {{ FORM | length + 1}}</p>
 {% endif %}
 
 {% set t = { "val": 0} %}


### PR DESCRIPTION
… the tab display feature to only show the single latest selected tab, to get rid of some problems arising from asynchronous calls to change tab display via jquery animate.  Also generally tidies up the 'summary table only' view

HOTFIX for https://github.com/DOAJ/doajPM/issues/3097