### PR TITLE
CSV with user accounts and OA Start date

### DIFF
--- a/portality/bll/services/journal.py
+++ b/portality/bll/services/journal.py
@@ -185,8 +185,12 @@ class JournalService(object):
             else:
                 return [("Owner", o)]
 
+        def oa_start(j):
+            oa = j.bibjson().oa_start
+            return [("OA Start", oa)]
+
         with open(file_path, "w", encoding="utf-8") as f:
-            self._make_journals_csv(f, usernames)
+            self._make_journals_csv(f, [usernames, oa_start])
 
     def _make_journals_csv(self, file_object, additional_columns=None):
         """
@@ -206,8 +210,7 @@ class JournalService(object):
                 ("DOAJ Seal", YES_NO.get(journal.has_seal(), "")),
                 # ("Tick: Accepted after March 2014", YES_NO.get(journal.is_ticked(), "")),
                 ("Added on Date", journal.created_date),
-                ("Last updated Date", journal.last_manual_update),
-                ("OA Start Date", journal.bibjson().oa_start)
+                ("Last updated Date", journal.last_manual_update)
             ]
             return kvs
 
@@ -238,7 +241,8 @@ class JournalService(object):
             article_kvs = _get_article_kvs(j)
             additionals = []
             if additional_columns is not None:
-                additionals = additional_columns(j)
+                for col in additional_columns:
+                    additionals += col(j)
             cols[issn] = kvs + meta_kvs + article_kvs + additionals
 
             # Get the toc URL separately from the meta kvs because it needs to be inserted earlier in the CSV
@@ -254,6 +258,7 @@ class JournalService(object):
             if qs is None:
                 qs = [q for q, _ in cols[i]]
                 csvwriter.writerow(qs)
+                print(qs)
             vs = [v for _, v in cols[i]]
             csvwriter.writerow(vs)
 

--- a/portality/bll/services/journal.py
+++ b/portality/bll/services/journal.py
@@ -160,12 +160,13 @@ class JournalService(object):
         models.Cache.cache_csv(url)
         return url, action_register
 
-    def admin_csv(self, file_path, account_sub_length=8, obscure_accounts="true"):
+    def admin_csv(self, file_path, account_sub_length=8, obscure_accounts=True):
         """
         ~~AdminJournalCSV:Feature->JournalCSV:Feature~~
         
         :param file_path:
         :param account_sub_length:
+        :param obscure_accounts:
         :return:
         """
         # create a closure for substituting owners for consistently used random strings
@@ -173,7 +174,7 @@ class JournalService(object):
 
         def usernames(j):
             o = j.owner
-            if (obscure_accounts == "true"):
+            if obscure_accounts:
                 sub = None
                 if o in unmap:
                     sub = unmap[o]

--- a/portality/bll/services/journal.py
+++ b/portality/bll/services/journal.py
@@ -175,7 +175,6 @@ class JournalService(object):
         def usernames(j):
             o = j.owner
             if obscure_accounts:
-                sub = None
                 if o in unmap:
                     sub = unmap[o]
                 else:

--- a/portality/bll/services/journal.py
+++ b/portality/bll/services/journal.py
@@ -258,7 +258,6 @@ class JournalService(object):
             if qs is None:
                 qs = [q for q, _ in cols[i]]
                 csvwriter.writerow(qs)
-                print(qs)
             vs = [v for _, v in cols[i]]
             csvwriter.writerow(vs)
 

--- a/portality/scripts/admin_journalcsv.py
+++ b/portality/scripts/admin_journalcsv.py
@@ -17,7 +17,6 @@ if __name__ == "__main__":
 
     # ~~-> Journal:Service~~
     journalService = DOAJ.journalService()
-    cols = ["oa_start"]
     journalService.admin_csv(file_path=args.out, obscure_accounts=args.do_not_obscure_accs)
 
 

--- a/portality/scripts/admin_journalcsv.py
+++ b/portality/scripts/admin_journalcsv.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
 
     # ~~-> Journal:Service~~
     journalService = DOAJ.journalService()
+    cols = ["oa_start"]
     journalService.admin_csv(file_path=args.out, obscure_accounts=args.do_not_obscure_accs)
 
 

--- a/portality/scripts/admin_journalcsv.py
+++ b/portality/scripts/admin_journalcsv.py
@@ -12,11 +12,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-o", "--out", help="output file for admin csv")
+    parser.add_argument("-a", "--obscure_accounts", help="true if accounts should be obscured", default="true")
     args = parser.parse_args()
 
     # ~~-> Journal:Service~~
     journalService = DOAJ.journalService()
-    journalService.admin_csv(args.out)
+    journalService.admin_csv(file_path=args.out, obscure_accounts=args.obscure_accounts)
 
 
 

--- a/portality/scripts/admin_journalcsv.py
+++ b/portality/scripts/admin_journalcsv.py
@@ -12,12 +12,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-o", "--out", help="output file for admin csv")
-    parser.add_argument("-a", "--obscure_accounts", help="true if accounts should be obscured", default="true")
+    parser.add_argument("-a", "--do_not_obscure_accs", help="set this flag if the accounts should not be obscured", action='store_false')
     args = parser.parse_args()
 
     # ~~-> Journal:Service~~
     journalService = DOAJ.journalService()
-    journalService.admin_csv(file_path=args.out, obscure_accounts=args.obscure_accounts)
+    journalService.admin_csv(file_path=args.out, obscure_accounts=args.do_not_obscure_accs)
 
 
 


### PR DESCRIPTION
for https://github.com/DOAJ/doajPM/issues/3092
`admin_journalcsv.py` should be run with `-a' flag to NOT obcure the accounts. Without the flag the script works as it used to - it DOES obscure the accounts.