### PR TITLE
separate config for cms builds from debug config

### DIFF
--- a/portality/core.py
+++ b/portality/core.py
@@ -294,7 +294,7 @@ def build_statics(app):
     :param app:
     :return:
     """
-    if not app.config.get("DEBUG", False):
+    if not app.config.get("CMS_BUILD_ASSETS_ON_STARTUP", False):
         return
     from portality.cms import build_fragments, build_sass
 

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -20,6 +20,7 @@ DEBUG = False
 PORT = 5004
 SSL = True
 VALID_ENVIRONMENTS = ['dev', 'test', 'staging', 'production', 'harvester']
+CMS_BUILD_ASSETS_ON_STARTUP = False
 
 ####################################
 # Debug Mode


### PR DESCRIPTION
If you want CMS builds automatically at startup you now need to set

CMS_BUILD_ASSETS_ON_STARTUP = True

in dev.cfg