### PR TITLE
Hotfix/20211115 1528 issue3037

### DIFF
--- a/docs/system/S3.md
+++ b/docs/system/S3.md
@@ -2,6 +2,119 @@
 
 [comment] <>: (~~S3:Documentation->S3:Technology~~)
 
+## Harvester Background Job Logs
+
+<!-- BackgroundJobs:Feature -->
+
+1. create a bucket in S3 called "doaj-harvester".  During the creation, ensure that you set all the public access limitations to "True" (i.e. Block all public access)
+
+2. Create the following policy (IAM > Policies > Create Policy > JSON):
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutAnalyticsConfiguration",
+                "s3:GetObjectVersionTagging",
+                "s3:CreateBucket",
+                "s3:ReplicateObject",
+                "s3:GetObjectAcl",
+                "s3:DeleteBucketWebsite",
+                "s3:PutLifecycleConfiguration",
+                "s3:GetObjectVersionAcl",
+                "s3:PutObjectTagging",
+                "s3:DeleteObject",
+                "s3:DeleteObjectTagging",
+                "s3:GetBucketWebsite",
+                "s3:PutReplicationConfiguration",
+                "s3:DeleteObjectVersionTagging",
+                "s3:GetBucketNotification",
+                "s3:PutBucketCORS",
+                "s3:GetReplicationConfiguration",
+                "s3:ListMultipartUploadParts",
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:PutBucketNotification",
+                "s3:PutBucketLogging",
+                "s3:GetAnalyticsConfiguration",
+                "s3:GetObjectVersionForReplication",
+                "s3:GetLifecycleConfiguration",
+                "s3:ListBucketByTags",
+                "s3:GetInventoryConfiguration",
+                "s3:GetBucketTagging",
+                "s3:PutAccelerateConfiguration",
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLogging",
+                "s3:ListBucketVersions",
+                "s3:ReplicateTags",
+                "s3:RestoreObject",
+                "s3:ListBucket",
+                "s3:GetAccelerateConfiguration",
+                "s3:GetBucketPolicy",
+                "s3:PutEncryptionConfiguration",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetObjectVersionTorrent",
+                "s3:AbortMultipartUpload",
+                "s3:PutBucketTagging",
+                "s3:GetBucketRequestPayment",
+                "s3:GetObjectTagging",
+                "s3:GetMetricsConfiguration",
+                "s3:DeleteBucket",
+                "s3:PutBucketVersioning",
+                "s3:ListBucketMultipartUploads",
+                "s3:PutMetricsConfiguration",
+                "s3:PutObjectVersionTagging",
+                "s3:GetBucketVersioning",
+                "s3:GetBucketAcl",
+                "s3:PutInventoryConfiguration",
+                "s3:GetObjectTorrent",
+                "s3:PutBucketWebsite",
+                "s3:PutBucketRequestPayment",
+                "s3:GetBucketCORS",
+                "s3:GetBucketLocation",
+                "s3:ReplicateDelete",
+                "s3:GetObjectVersion"
+            ],
+            "Resource": [
+                "arn:aws:s3:::doaj-harvester",
+                "arn:aws:s3:::doaj-harvester/*"
+            ]
+        }
+    ]
+}
+```
+
+Give it a sensible name like "doaj-harvester-policy"
+
+
+3. Create an S3 user on the IAM service with a suitable name (e.g. "doaj-harvester-client")
+
+Provide Programmatic access, there is no need to provide AWS Management Console access.
+
+Attach the policy created in the previous step
+
+
+4. Take a note of the access key and the secret access token (you can't access them again)
+
+
+5. Update your local configuration (do not put this in version control) with the following settings:
+
+```python
+STORE_S3_SCOPES = {
+    # ...
+    "harvester" : {
+        "aws_access_key_id" : "<access key>",
+        "aws_secret_access_key" : "<secret access token>"
+    }
+    # ...
+}
+```
+
+
 ## Public Data Dump
 
 [comment] <>: (~~->PublicDataDump:Feature~~)
@@ -151,8 +264,7 @@ STORE_S3_SCOPES = {
 
 Cached files includes regularly generated content such as the Journal CSV.
 
-1. Create a bucket in S3 called "doaj-data-cache".  During the creation, ensure that you set all the public access limitations to "False" 
-
+1. Create a bucket in S3 called "doaj-data-cache".  During the creation, ensure that you set all the public access limitations to "False"
 (i.e. permit public access)
 
 2. Go to the bucket configuration, under Permissions > Bucket Policy and enter the following policy:

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -180,6 +180,11 @@ STORE_S3_SCOPES = {
     "public_data_dump" : {
         "aws_access_key_id" : "put this in your dev/test/production.cfg",
         "aws_secret_access_key" : "put this in your dev/test/production.cfg"
+    },
+    # Used to store harvester run logs to S3
+    "harvester" : {
+        "aws_access_key_id" : "put this in your dev/test/production.cfg",
+        "aws_secret_access_key" : "put this in your dev/test/production.cfg"
     }
 }
 

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -163,6 +163,7 @@ STORE_TMP_WRITE_BUFFER_SIZE = 16777216
 STORE_ANON_DATA_CONTAINER = "doaj-anon-data-placeholder"
 STORE_CACHE_CONTAINER = "doaj-data-cache-placeholder"
 STORE_PUBLIC_DATA_DUMP_CONTAINER = "doaj-data-dump-placeholder"
+STORE_HARVESTER_CONTAINER = "doaj-harvester"
 
 # S3 credentials for relevant scopes
 # ~~->S3:Technology~~


### PR DESCRIPTION
For https://github.com/DOAJ/doajPM/issues/3037

This fixes a bug with the background job recording logs from the harvester run when those logs are large.  Essentially ES complains that the audit messages are too large, which is due to a mapping issue.  Fixing the mapping would be an alternative option, but the logs are very large and there's not a lot of value having them stored in ES, so this hotfix moves the meat of the logging out to a file and puts that file in S3 at the end of the harvester run.

In order to deploy this to production, some additional steps on S3 are required.  See the file `docs/system/S3.md` for the documentation on `Harvester Background Jobs Logs`.  I have already done the following steps:

1. Created a `doaj-harvester` bucket
2. Created the access policy `doaj-harvester-policy`

Before this runs in production again we need to:

3. Create an S3 user `doaj-harvester-client` with the appropriate access policy (I have created a test user `doaj-richard-harvester-client` but we should not re-use that if possible, to sandbox dev from production)
4. Note the access token
5. Update the `production.cfg` with the new S3 scope for the harvester

