### PR TITLE
Hotfix/2021 12 20 1349 issue3187

### DIFF
--- a/doajtest/unit/test_workflow_emails.py
+++ b/doajtest/unit/test_workflow_emails.py
@@ -188,7 +188,7 @@ class TestAsyncWorkflowEmails(DoajTestCase):
         assert_false(emails)
 
         # When we make the application unchanged for a period of time, we expect a message to be generated
-        [APPLICATION_SOURCE_2, APPLICATION_SOURCE_3] = ApplicationFixtureFactory.make_many_application_sources(count=2)
+        [APPLICATION_SOURCE_2, APPLICATION_SOURCE_3, APPLICATION_SOURCE_4] = ApplicationFixtureFactory.make_many_application_sources(count=3)
         comfortably_idle = app.config['ASSOC_ED_IDLE_DAYS'] + 1
         APPLICATION_SOURCE_2['last_manual_update'] = datetime.utcnow() - timedelta(days=comfortably_idle)
         application2 = models.Suggestion(**APPLICATION_SOURCE_2)
@@ -199,10 +199,16 @@ class TestAsyncWorkflowEmails(DoajTestCase):
         application3 = models.Suggestion(**APPLICATION_SOURCE_3)
         application3.save()
 
+        APPLICATION_SOURCE_4['last_manual_update'] = datetime.utcnow() - timedelta(weeks=extremely_idle)
+        APPLICATION_SOURCE_4["admin"]["application_status"] = constants.APPLICATION_STATUS_ACCEPTED
+        application4 = models.Suggestion(**APPLICATION_SOURCE_4)
+        application4.save()
+
         models.Suggestion.blockall([
             (application.id, application.last_updated),
             (application2.id, application2.last_updated),
-            (application3.id, application3.last_updated)
+            (application3.id, application3.last_updated),
+            (application4.id, application4.last_updated)
         ])
 
         async_workflow_notifications.associate_editor_notifications(emails)

--- a/portality/tasks/async_workflow_notifications.py
+++ b/portality/tasks/async_workflow_notifications.py
@@ -34,7 +34,8 @@ class AgeQuery(object):
                             }
                         }
                     ],
-                    "should": self._status_filters
+                    "should": self._status_filters,
+                    "minimum_should_match": 1
                 }
             },
             "size": 0,
@@ -74,7 +75,8 @@ class EdAppQuery(object):
                                     "field": "admin.editor"
                                 }
                             },
-                            "should": self._status_filters
+                            "should": self._status_filters,
+                            "minimum_should_match": 1
                         }
                     }
                 }
@@ -115,7 +117,8 @@ class EdAgeQuery(object):
                             }
                         }
                     ],
-                    "should": self._status_filters
+                    "should": self._status_filters,
+                    "minimum_should_match": 1
                 }
             },
             "size": 0,

--- a/portality/tasks/async_workflow_notifications.py
+++ b/portality/tasks/async_workflow_notifications.py
@@ -147,7 +147,8 @@ class AssEdAgeQuery(object):
                             }
                         }
                     },
-                    "should": self._status_filters
+                    "should": self._status_filters,
+                    "minimum_should_match" : 1
                 }
             },
             "size": 0,


### PR DESCRIPTION
The meaning of `should` in ES queries changed between the old and new versions, and now we need to explicitly declare `mimimum_should_match` if there is a `must` clause. 

I have checked the whole codebase, and these changes are the only ones that I believe are affected.