### PR TITLE
Move view note link and minimize the margin

### DIFF
--- a/cms/sass/layout/_editorial-panel.scss
+++ b/cms/sass/layout/_editorial-panel.scss
@@ -1,8 +1,10 @@
 .editorial-panel {
   margin-top: 0;
 
-  select, textarea, input {
-    width: 100%;
+  .form__question {
+    select, textarea, input {
+      width: 100%;
+    }
   }
 
   @media (min-width: 992px) {
@@ -13,10 +15,6 @@
     &__content {
       max-height: 70vh;
       overflow-y: scroll;
-    }
-
-    select, textarea, input, label, p {
-      width: 20vw;
     }
   }
 }

--- a/portality/static/js/formulaic.js
+++ b/portality/static/js/formulaic.js
@@ -1383,7 +1383,8 @@ var formulaic = {
                 var viewClass = edges.css_classes(this.ns, "view");
                 var closeClass = edges.css_classes(this.ns, "close");
 
-                this.divs = $("div[name='" + this.fieldDef["name"] + "__group']");
+                this.divs = $("div[name='" + this.fieldDef["name"] + "__group']").find("textarea");
+
                 for (var i = 0; i < this.divs.length; i++) {
                     var container = $(this.divs[i]);
                     var modalId = "modal-" + this.fieldDef["name"] + "-" + i;
@@ -1391,7 +1392,7 @@ var formulaic = {
                     var date = $("#" + this.fieldDef["name"] + "-" + i + "-note_date");
                     var note = $("#" + this.fieldDef["name"] + "-" + i + "-note");
 
-                    container.append(`<div><a href="#" class="` + viewClass + `">view note</a>
+                    $(`<div><a href="#" class="` + viewClass + `">view note</a>
                         <div class="modal" id="` + modalId + `" tabindex="-1" role="dialog" style="display: none; padding-right: 0px; overflow-y: scroll">
                             <div class="modal__dialog" role="document">
                                 <p class="label">NOTE</p>
@@ -1403,7 +1404,21 @@ var formulaic = {
                             </div>
                         </div>
                         </div>
-                    `);
+                    `).insertAfter(container);
+
+                    // container.append(`<div><a href="#" class="` + viewClass + `">view note</a>
+                    //     <div class="modal" id="` + modalId + `" tabindex="-1" role="dialog" style="display: none; padding-right: 0px; overflow-y: scroll">
+                    //         <div class="modal__dialog" role="document">
+                    //             <p class="label">NOTE</p>
+                    //             <h3 class="modal__title">
+                    //                 ` + date.val() + `
+                    //             </h3>
+                    //             ` + edges.escapeHtml(note.val()).replace(/\n/g, "<br/>") + `
+                    //             <br/><br/><button type="button" data-dismiss="modal" class="` + closeClass + `">Close</button>
+                    //         </div>
+                    //     </div>
+                    //     </div>
+                    // `);
                 }
 
                 var viewSelector = edges.css_class_selector(this.ns, "view");

--- a/portality/static/js/formulaic.js
+++ b/portality/static/js/formulaic.js
@@ -1405,20 +1405,6 @@ var formulaic = {
                         </div>
                         </div>
                     `).insertAfter(container);
-
-                    // container.append(`<div><a href="#" class="` + viewClass + `">view note</a>
-                    //     <div class="modal" id="` + modalId + `" tabindex="-1" role="dialog" style="display: none; padding-right: 0px; overflow-y: scroll">
-                    //         <div class="modal__dialog" role="document">
-                    //             <p class="label">NOTE</p>
-                    //             <h3 class="modal__title">
-                    //                 ` + date.val() + `
-                    //             </h3>
-                    //             ` + edges.escapeHtml(note.val()).replace(/\n/g, "<br/>") + `
-                    //             <br/><br/><button type="button" data-dismiss="modal" class="` + closeClass + `">Close</button>
-                    //         </div>
-                    //     </div>
-                    //     </div>
-                    // `);
                 }
 
                 var viewSelector = edges.css_class_selector(this.ns, "view");

--- a/portality/static/js/formulaic.js
+++ b/portality/static/js/formulaic.js
@@ -1391,7 +1391,7 @@ var formulaic = {
                     var date = $("#" + this.fieldDef["name"] + "-" + i + "-note_date");
                     var note = $("#" + this.fieldDef["name"] + "-" + i + "-note");
 
-                    $(`<button class="button button--cta ` + viewClass + `" style="margin: 0 1rem 1rem 0;">View note</button>
+                    $(`<button class="button ` + viewClass + `" style="margin: 0 1rem 1rem 0;">View note</button>
                         <div class="modal" id="` + modalId + `" tabindex="-1" role="dialog" style="display: none; padding-right: 0px; overflow-y: scroll">
                             <div class="modal__dialog" role="document">
                                 <p class="label">NOTE</p>
@@ -1444,7 +1444,7 @@ var formulaic = {
                 this.divs = $("div[name='" + this.fieldDef["name"] + "__group']");
                 for (var i = 0 ; i < this.divs.length; i++) {
                     var div = $(this.divs[i]);
-                    div.append($('<button type="button" data-id="' + i + '" id="remove_field__' + this.fieldDef["name"] + '--id_' + i + '" class="remove_field__button" style="display:none; margin: 0 1rem 1rem 0;">Remove</button>'));
+                    div.append($('<button type="button" data-id="' + i + '" id="remove_field__' + this.fieldDef["name"] + '--id_' + i + '" class="remove_field__button" style="display:none; margin: 0 0 1rem 0; border: 0; float: right;">Remove</button>'));
                     feather.replace();
                 }
 

--- a/portality/static/js/formulaic.js
+++ b/portality/static/js/formulaic.js
@@ -1382,7 +1382,7 @@ var formulaic = {
             this.init = function() {
                 var viewClass = edges.css_classes(this.ns, "view");
                 var closeClass = edges.css_classes(this.ns, "close");
-
+                var viewDivClass = edges.css_classes(this.ns, "viewDiv")
                 this.divs = $("div[name='" + this.fieldDef["name"] + "__group']").find("textarea");
 
                 for (var i = 0; i < this.divs.length; i++) {
@@ -1392,7 +1392,7 @@ var formulaic = {
                     var date = $("#" + this.fieldDef["name"] + "-" + i + "-note_date");
                     var note = $("#" + this.fieldDef["name"] + "-" + i + "-note");
 
-                    $(`<div><a href="#" class="` + viewClass + `">view note</a>
+                    $(`<div style="margin-top: -0.75rem"><a href="#" class="` + viewClass + `">view note</a>
                         <div class="modal" id="` + modalId + `" tabindex="-1" role="dialog" style="display: none; padding-right: 0px; overflow-y: scroll">
                             <div class="modal__dialog" role="document">
                                 <p class="label">NOTE</p>

--- a/portality/static/js/formulaic.js
+++ b/portality/static/js/formulaic.js
@@ -1392,7 +1392,7 @@ var formulaic = {
                     var date = $("#" + this.fieldDef["name"] + "-" + i + "-note_date");
                     var note = $("#" + this.fieldDef["name"] + "-" + i + "-note");
 
-                    $(`<div style="margin-top: -0.75rem"><a href="#" class="` + viewClass + `">view note</a>
+                    $(`<button class="button button--cta ` + viewClass + `" style="margin: 0 1rem 1rem 0;">View note</button>
                         <div class="modal" id="` + modalId + `" tabindex="-1" role="dialog" style="display: none; padding-right: 0px; overflow-y: scroll">
                             <div class="modal__dialog" role="document">
                                 <p class="label">NOTE</p>
@@ -1445,7 +1445,7 @@ var formulaic = {
                 this.divs = $("div[name='" + this.fieldDef["name"] + "__group']");
                 for (var i = 0 ; i < this.divs.length; i++) {
                     var div = $(this.divs[i]);
-                    div.append($('<button type="button" data-id="' + i + '" id="remove_field__' + this.fieldDef["name"] + '--id_' + i + '" class="remove_field__button" style="display:none"><span data-feather="x" aria-hidden="true"/> Remove</button>'));
+                    div.append($('<button type="button" data-id="' + i + '" id="remove_field__' + this.fieldDef["name"] + '--id_' + i + '" class="remove_field__button" style="display:none; margin: 0 1rem 1rem 0;">Remove</button>'));
                     feather.replace();
                 }
 
@@ -1567,7 +1567,7 @@ var formulaic = {
                     let f = this.fields[idx];
                     let s2_input = $($(f).select2());
                     $(f).on("focus", formulaic.widgets._select2_shift_focus);
-                    s2_input.after($('<button type="button" id="remove_field__' + f.name + '--id_' + idx + '" class="remove_field__button"><span data-feather="x" aria-hidden="true"/> Remove</button>'));
+                    s2_input.after($('<button type="button" id="remove_field__' + f.name + '--id_' + idx + '" class="remove_field__button">Remove</button> <span data-feather="x" aria-hidden="true"/>'));
                     if (idx !== 0) {
                         s2_input.attr("required", false);
                         s2_input.attr("data-parsley-validate-if-empty", "true");
@@ -1626,7 +1626,7 @@ var formulaic = {
                 for (var idx = 0; idx < this.fields.length; idx++) {
                     let f = this.fields[idx];
                     let jqf = $(f);
-                    jqf.after($('<button type="button" id="remove_field__' + f.name + '--id_' + idx + '" class="remove_field__button"><span data-feather="x" aria-hidden="true"/> Remove</button>'));
+                    jqf.after($('<button type="button" id="remove_field__' + f.name + '--id_' + idx + '" class="remove_field__button">Remove <span data-feather="x" aria-hidden="true"/></button>'));
                     if (idx !== 0) {
                         jqf.attr("required", false);
                         jqf.attr("data-parsley-validate-if-empty", "true");
@@ -1703,7 +1703,7 @@ var formulaic = {
 
                 for (var idx = 0; idx < this.divs.length; idx++) {
                     let div = $(this.divs[idx]);
-                    div.append($('<button type="button" id="remove_field__' + this.fieldDef["name"] + '--id_' + idx + '" class="remove_field__button"><span data-feather="x" aria-hidden="true"/> Remove</button>'));
+                    div.append($('<button type="button" id="remove_field__' + this.fieldDef["name"] + '--id_' + idx + '" class="remove_field__button">Remove <span data-feather="x" aria-hidden="true"/></button>'));
 
                     if (idx !== 0) {
                         let inputs = div.find(":input");

--- a/portality/static/js/formulaic.js
+++ b/portality/static/js/formulaic.js
@@ -1382,11 +1382,10 @@ var formulaic = {
             this.init = function() {
                 var viewClass = edges.css_classes(this.ns, "view");
                 var closeClass = edges.css_classes(this.ns, "close");
-                var viewDivClass = edges.css_classes(this.ns, "viewDiv")
-                this.divs = $("div[name='" + this.fieldDef["name"] + "__group']").find("textarea");
+                var textarea = $("div[name='" + this.fieldDef["name"] + "__group']").find("textarea");
 
-                for (var i = 0; i < this.divs.length; i++) {
-                    var container = $(this.divs[i]);
+                for (var i = 0; i < textarea.length; i++) {
+                    var container = $(textarea[i]);
                     var modalId = "modal-" + this.fieldDef["name"] + "-" + i;
 
                     var date = $("#" + this.fieldDef["name"] + "-" + i + "-note_date");


### PR DESCRIPTION
https://github.com/DOAJ/doajPM/issues/2904#issuecomment-998242478

![image](https://user-images.githubusercontent.com/8298769/147746061-4c0b30ea-406d-4f33-b560-444a9ffe5e67.png)

@richard-jones simple js change.

@sssoz not sure whether that's what was meant by "close up the space", let me know if not. Also - I couldn't find a good place to add the css (text area has in general margin-bottom: 0.75 so to close up the space I just added -0.75 to the "view note" link). Could you move the inline style to some better place? Or maybe it can stay like this?