### PR TITLE
Ensure all header nav dropdowns don’t disappear when hovering above them 

### DIFF
--- a/portality/templates/layouts/sidenav.html
+++ b/portality/templates/layouts/sidenav.html
@@ -1,5 +1,5 @@
 
-<main class="container">
+<main class="container page-content">
     <div class="row">
 
         <div class="col-md-4 col-md-push-8">
@@ -32,7 +32,7 @@
         </div>
 
         <div class="col-md-8 col-md-pull-4">
-            <section class="page-content">
+            <section>
                 {% if page.section %}<p class="label">{{ page.section }}</p>{% endif %}
                 <h1>{{ page.title }}</h1>
 


### PR DESCRIPTION
`.page-content` should accompany `.container` class on `<main>`

Otherwise, the dropdown menu isn’t clickable on hover!

See DOAJ/doajPM#3264