### PR TITLE
use patch_history_dir to avoid edit same dir when multiprocessing

### DIFF
--- a/doajtest/helpers.py
+++ b/doajtest/helpers.py
@@ -113,7 +113,7 @@ class DoajTestCase(TestCase):
             "STORE_IMPL": "portality.store.StoreLocal",
             "STORE_LOCAL": paths.rel2abs(__file__, "..", "tmp", "store", "main", cls.__name__.lower()),
             "STORE_TMP_DIR": paths.rel2abs(__file__, "..", "tmp", "store", "tmp", cls.__name__.lower()),
-            "STORE_CACHE_CONTAINER": "doaj-data-cache-placeholder" + cls.__name__.lower(),
+            "STORE_CACHE_CONTAINER": "doaj-data-cache-placeholder" + '-' + cls.__name__.lower(),
             "ES_RETRY_HARD_LIMIT": 0,
             "ES_BLOCK_WAIT_OVERRIDE": 0.1,
             "ELASTIC_SEARCH_DB": app.config.get('ELASTIC_SEARCH_TEST_DB'),

--- a/doajtest/helpers.py
+++ b/doajtest/helpers.py
@@ -1,3 +1,6 @@
+import tempfile
+from pathlib import Path
+
 from flask_login import login_user
 
 from unittest import TestCase
@@ -245,3 +248,42 @@ def deep_sort(obj):
         _sorted = obj
 
     return _sorted
+
+
+def patch_history_dir(dir_key):
+    def _wrapper(fn):
+
+        @functools.wraps(fn)
+        def new_fn(*args, **kwargs):
+            # define hist_class
+            if dir_key == 'ARTICLE_HISTORY_DIR':
+                from portality.models import ArticleHistory
+                hist_class = ArticleHistory
+            elif dir_key == 'JOURNAL_HISTORY_DIR':
+                from portality.models import JournalHistory
+                hist_class = JournalHistory
+            else:
+                raise ValueError(f'unknown dir_key [{dir_key}]')
+
+            # setup new path
+            org_config_val = DoajTestCase.app_test.config[dir_key]
+            org_hist_dir = hist_class.SAVE_BASE_DIRECTORY
+            _new_path = Path(tempfile.NamedTemporaryFile().name)
+            _new_path.mkdir(parents=True, exist_ok=True)
+            hist_class.SAVE_BASE_DIRECTORY = _new_path.as_posix()
+            DoajTestCase.app_test.config[dir_key] = _new_path.as_posix()
+
+            # run fn
+            result = fn(*args, **kwargs)
+
+            # reset / cleanup
+            shutil.rmtree(_new_path)
+            hist_class.SAVE_BASE_DIRECTORY = org_hist_dir
+            DoajTestCase.app_test.config[dir_key] = org_config_val
+
+            return result
+
+        return new_fn
+
+    return _wrapper
+

--- a/doajtest/helpers.py
+++ b/doajtest/helpers.py
@@ -113,13 +113,15 @@ class DoajTestCase(TestCase):
             "STORE_IMPL": "portality.store.StoreLocal",
             "STORE_LOCAL": paths.rel2abs(__file__, "..", "tmp", "store", "main", cls.__name__.lower()),
             "STORE_TMP_DIR": paths.rel2abs(__file__, "..", "tmp", "store", "tmp", cls.__name__.lower()),
+            "STORE_CACHE_CONTAINER": "doaj-data-cache-placeholder" + cls.__name__.lower(),
             "ES_RETRY_HARD_LIMIT": 0,
             "ES_BLOCK_WAIT_OVERRIDE": 0.1,
             "ELASTIC_SEARCH_DB": app.config.get('ELASTIC_SEARCH_TEST_DB'),
             'ELASTIC_SEARCH_DB_PREFIX': core.app.config['ELASTIC_SEARCH_TEST_DB_PREFIX'] + cls.__name__.lower() + '-',
             "FEATURES": app.config['VALID_FEATURES'],
             'ENABLE_EMAIL': False,
-            "FAKER_SEED": 1
+            "FAKER_SEED": 1,
+            'CMS_BUILD_ASSETS_ON_STARTUP': False
         })
 
         main_queue.always_eager = True

--- a/doajtest/unit/test_bll_application_unreject_application.py
+++ b/doajtest/unit/test_bll_application_unreject_application.py
@@ -8,6 +8,7 @@ from portality.bll import exceptions
 from portality.models import Application, Account, Journal
 from portality.lib.paths import rel2abs
 from portality import constants
+from datetime import datetime, timedelta
 
 import time
 
@@ -136,6 +137,9 @@ class TestBLLApplicationUnrejectApplication(DoajTestCase):
                 assert len(journal.related_applications) == 0
 
                 if manual_update:
-                    assert application.last_updated == application.last_manual_update, "Expected last manual update to be {}, but got {} instead".format(application.last_updated, application.last_manual_update)
+                    # fixme: millisecond timestamps would help us here, or last_manual_update shouldn't generate its own date
+                    lu = datetime.strptime(application.last_updated, "%Y-%m-%dT%H:%M:%SZ")
+                    lmu = datetime.strptime(application.last_manual_update, "%Y-%m-%dT%H:%M:%SZ")
+                    assert lmu - lu <= timedelta(seconds=1)
                 else:
                     assert application.last_manual_update == "1970-01-01T00:00:00Z"

--- a/doajtest/unit/test_fc_maned_app_review.py
+++ b/doajtest/unit/test_fc_maned_app_review.py
@@ -6,7 +6,7 @@ from werkzeug.datastructures import MultiDict
 
 from portality import constants
 from doajtest.fixtures import JournalFixtureFactory, ApplicationFixtureFactory, AccountFixtureFactory
-from doajtest.helpers import DoajTestCase
+from doajtest.helpers import DoajTestCase, patch_history_dir
 from portality import lcc
 from portality import models
 from portality.forms.application_forms import ApplicationFormFactory
@@ -138,6 +138,7 @@ class TestManEdAppReview(DoajTestCase):
 
         ctx.pop()
 
+    @patch_history_dir('JOURNAL_HISTORY_DIR')
     def test_02_update_request(self):
         acc = models.Account()
         acc.set_id("richard")

--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -1,15 +1,16 @@
 import json
 import time
 
+from doajtest.fixtures import ApplicationFixtureFactory, JournalFixtureFactory, ArticleFixtureFactory, \
+    BibJSONFixtureFactory, ProvenanceFixtureFactory, BackgroundFixtureFactory, AccountFixtureFactory
+from doajtest.helpers import DoajTestCase, patch_history_dir
 from portality import constants
-from doajtest.fixtures import ApplicationFixtureFactory, JournalFixtureFactory, ArticleFixtureFactory, BibJSONFixtureFactory, ProvenanceFixtureFactory, BackgroundFixtureFactory, AccountFixtureFactory
-from doajtest.helpers import DoajTestCase
 from portality import models
 from portality.lib import dataobj
-from portality.models import shared_structs
 from portality.lib import seamless
-
+from portality.models import shared_structs
 from portality.models.v1.bibjson import GenericBibJSON
+
 
 class TestModels(DoajTestCase):
 
@@ -379,6 +380,7 @@ class TestModels(DoajTestCase):
         s = models.Suggestion.pull(s.id)
         assert s.owner == "another_new_owner"
 
+    @patch_history_dir("ARTICLE_HISTORY_DIR")
     def test_06_article_deletes(self):
         # populate the index with some articles
         for i in range(5):
@@ -419,6 +421,8 @@ class TestModels(DoajTestCase):
         assert len(models.Article.all()) == 2
         assert len(self.list_today_article_history_files()) == 3
 
+    @patch_history_dir("ARTICLE_HISTORY_DIR")
+    @patch_history_dir('JOURNAL_HISTORY_DIR')
     def test_07_journal_deletes(self):
         # tests the various methods that are key to journal deletes
 
@@ -475,6 +479,7 @@ class TestModels(DoajTestCase):
         assert len(models.Journal.all()) == 4
         assert len(self.list_today_journal_history_files()) == 6    # Because all journals are snapshot at create time
 
+    @patch_history_dir('JOURNAL_HISTORY_DIR')
     def test_08_iterate(self):
         for jsrc in JournalFixtureFactory.make_many_journal_sources(count=99, in_doaj=True):
             j = models.Journal(**jsrc)

--- a/doajtest/unit/test_snapshot.py
+++ b/doajtest/unit/test_snapshot.py
@@ -1,7 +1,8 @@
-from doajtest.helpers import DoajTestCase
-from portality import models
-import time
 import json
+
+from doajtest.helpers import DoajTestCase, patch_history_dir
+from portality import models
+
 
 class TestSnapshot(DoajTestCase):
 
@@ -14,6 +15,7 @@ class TestSnapshot(DoajTestCase):
         # are cleaned up in the parent DoajTestCase class so they
         # don't have to be cleaned up in each test suite that causes .snapshot()
 
+    @patch_history_dir("ARTICLE_HISTORY_DIR")
     def test_01_snapshot(self):
         # make ourselves an example article
         a = models.Article()
@@ -25,12 +27,14 @@ class TestSnapshot(DoajTestCase):
         # snapshot it
         a.snapshot()
 
-        assert len(self.list_today_article_history_files()) == 1
-        with open(self.list_today_article_history_files()[0], 'r', encoding="utf-8") as i:
+        hist_files = self.list_today_article_history_files()
+        assert len(hist_files) == 1
+        with open(hist_files[0], 'r', encoding="utf-8") as i:
             hist = json.loads(i.read())
         assert hist
         assert hist.get("bibjson", {}).get("title") == "Example article with a fulltext url"
-    
+
+    @patch_history_dir("ARTICLE_HISTORY_DIR")
     def test_02_merge(self):
         # make ourselves an example article
         a = models.Article()
@@ -56,6 +60,7 @@ class TestSnapshot(DoajTestCase):
         assert hist
         assert hist.get("bibjson", {}).get("title") == "Example 2 article with a fulltext url"
 
+    @patch_history_dir('JOURNAL_HISTORY_DIR')
     def test_03_snapshot_journal(self):
         # make ourselves an example journal
         j = models.Journal()

--- a/doajtest/unit/test_tasks_sitemap.py
+++ b/doajtest/unit/test_tasks_sitemap.py
@@ -35,5 +35,5 @@ class TestSitemap(DoajTestCase):
         job = sitemap.SitemapBackgroundTask.prepare(user)
         task = sitemap.SitemapBackgroundTask(job)
         BackgroundApi.execute(task)
-        time.sleep(1)
+        time.sleep(1.5)
         assert len(self.mainStore.list(self.container_id)) == 1


### PR DESCRIPTION
For [2727](https://github.com/DOAJ/doajPM/issues/2727)

I found following 4 testcase fail when running with `pytest -n 4`

### how to run
```
cd $DOAJ_PROJ/doajtest/unit
$VENV_HOME/venv/doaj/bin/pytest -n4 --dist loadfile --full-trace --color=yes --code-highlight=yes -v  | tee /tmp/doaj_20220614_5.log
```

### summary of fail cases
```
=========================== short test summary info ============================
FAILED test_fc_maned_app_review.py::TestManEdAppReview::test_02_update_request
FAILED test_models.py::TestModels::test_06_article_deletes - assert 0 == 3
FAILED test_models.py::TestModels::test_07_journal_deletes - AssertionError: ...
FAILED test_models.py::TestModels::test_08_iterate - assert 0 == 99
```


The reason of fail is they need to update same folder when parallelise
```
ArticleHistory.SAVE_BASE_DIRECTORY
JournalHistory.SAVE_BASE_DIRECTORY
```


### Solution
The solution is added `patch_history_dir`  to create new folder for each test case
the result is all pass but not sure is it work very well in the future 



### Note
original branch `develop` have 19 fail case, you may need to skip those test case for testing this branch.


