### PR TITLE
Hotfix/3334 search links

### DIFF
--- a/portality/lib/edges.py
+++ b/portality/lib/edges.py
@@ -8,7 +8,7 @@ import json
 
 def make_url_query(**params):
     query = make_query_json(**params)
-    return parse.quote_plus(json.dumps(query))
+    return parse.quote_plus(query)
 
 
 def make_query_json(**params):
@@ -23,10 +23,11 @@ def make_query(**params):
 
 class GeneralSearchQuery(object):
     # ~~-> Edges:Query~~
-    def __init__(self, term=None, terms=None, query_string=None):
+    def __init__(self, term=None, terms=None, query_string=None, sort=None):
         self.terms = None if terms is None else terms if isinstance(terms, list) else [terms]
         self.term = None if term is None else term
         self.query_string = query_string
+        self.sort = sort
 
     def query(self):
         musts = []
@@ -50,4 +51,11 @@ class GeneralSearchQuery(object):
                 }
             }
 
-        return { "query" : query }
+        obj = {"query": query}
+        if self.sort:
+            if not isinstance(self.sort, list):
+                obj["sort"] = [self.sort]
+            else:
+                obj["sort"] = self.sort
+
+        return obj

--- a/portality/static/js/doaj.fieldrender.edges.js
+++ b/portality/static/js/doaj.fieldrender.edges.js
@@ -1041,13 +1041,14 @@ $.extend(true, doaj, {
             };
 
             this.setUISortField = function () {
+                let sb = this.component.sortBy
                 if (!this.component.sortBy) {
-                    return;
+                    sb = "_score";
                 }
                 // get the selector we need
                 var sortSelector = edges.css_class_selector(this.namespace, "sortby", this);
                 var el = this.component.jq(sortSelector);
-                el.val(this.component.sortBy);
+                el.val(sb);
             };
 
             this.setUISearchField = function () {

--- a/portality/static/js/edges/admin.journals.edge.js
+++ b/portality/static/js/edges/admin.journals.edge.js
@@ -104,7 +104,7 @@ $.extend(true, doaj, {
                     id: "has_editor_group",
                     category: "facet",
                     field: "index.has_editor_group.exact",
-                    display: "Has eeditor group?",
+                    display: "Has editor group?",
                     deactivateThreshold: 1,
                     renderer: edges.bs3.newRefiningANDTermSelectorRenderer({
                         controls: true,
@@ -502,6 +502,9 @@ $.extend(true, doaj, {
                 search_url: search_url,
                 manageUrl: true,
                 components: components,
+                openingQuery: es.newQuery({
+                    sort: [{field: "created_date", order: "desc"}]
+                }),
                 callbacks : {
                     "edges:query-fail" : function() {
                         alert("There was an unexpected error. Please reload the page and try again. If the issue persists please contact an administrator.");

--- a/portality/static/js/edges/associate.journals.edge.js
+++ b/portality/static/js/edges/associate.journals.edge.js
@@ -334,6 +334,9 @@ $.extend(true, doaj, {
                 search_url: search_url,
                 manageUrl: true,
                 components: components,
+                openingQuery: es.newQuery({
+                    sort: [{field: "created_date", order: "desc"}]
+                }),
                 callbacks : {
                     "edges:query-fail" : function() {
                         alert("There was an unexpected error.  Please reload the page and try again.  If the issue persists please contact an administrator.");

--- a/portality/static/js/edges/editor.groupjournals.edge.js
+++ b/portality/static/js/edges/editor.groupjournals.edge.js
@@ -391,6 +391,9 @@ $.extend(true, doaj, {
                 search_url: search_url,
                 manageUrl: true,
                 components: components,
+                openingQuery: es.newQuery({
+                    sort: [{field: "created_date", order: "desc"}]
+                }),
                 callbacks : {
                     "edges:query-fail" : function() {
                         alert("There was an unexpected error.  Please reload the page and try again.  If the issue persists please contact an administrator.");

--- a/portality/templates/layouts/dashboard_base.html
+++ b/portality/templates/layouts/dashboard_base.html
@@ -85,9 +85,18 @@
                 <ul class="inlined-list tags">
                   {% for eg in managed_groups %}
                   <li class="tag tag--tertiary">
-                    {% set source = search_query_source(terms=[{"admin.editor_group.exact" : [eg.name]}], term=[{"index.application_type.exact" : "new application"}]) %}
-                    <a href="{{ url_for('admin.suggestions') }}?source={{ source }}" title="See all applications"><strong>{{ eg.name }}</strong></a>
-                    <a href="{{ url_for('admin.index') }}?source={{ source }}" title="See all journals">(journals)
+                    {% set app_source = search_query_source(term=[
+                            {"admin.editor_group.exact" : eg.name},
+                            {"index.application_type.exact" : "new application"}
+                        ], sort=[{"admin.date_applied": {"order": "desc"}}]
+                    ) %}
+                    <a href="{{ url_for('admin.suggestions') }}?source={{ app_source }}" title="See all applications"><strong>{{ eg.name }}</strong></a>
+
+                    {% set j_source = search_query_source(term=[
+                        {"admin.editor_group.exact" : eg.name}
+                        ], sort=[{"created_date" : {"order": "desc"}}]
+                    ) %}
+                    <a href="{{ url_for('admin.index') }}?source={{ j_source }}" title="See all journals">(journals)
                     </a>
                   </li>
                   {% endfor %}


### PR DESCRIPTION
# Fix the search links on the editorial dashbaord

For: https://github.com/DOAJ/doajPM/issues/3334

This fixes a number of problems with the search links on the dashboard:

1. They were double escaped, so they wouldn't have worked anyway
2. They were not quite correct for the desired search
3. They did not specify a sort order
4. There was a display bug in the search that said the sort order was set, when in fact it wasn't

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [x] affects the editorial area
- [ ] affects the publisher area

## Basic PR Checklist

- [x] FeatureMap annotations have been added - **not required**
- [x] Unit tests have been added/modified - **not required**
- [x] Functional tests have been added/modified - **not required**
- [x] Code has been run manually in development, and functional tests followed locally
- [x] No deprecated methods are used
- [x] No magic strings/numbers - all strings are in `constants` or `messages` files
- [x] Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
- [x] If needed, migration has been created and tested locally - **not required**
- [x] Release sheet has been created, and completed as far as is possible - https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit#gid=459692363&range=A3 - pending formal release confirmation
- [x] Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR) - **not required**
    - [x] Core model documentation: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit - **not required**
    - [x] Events and consumers documentation: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit - **not required**

## Testing

List the Functional Tests that must be run to confirm this feature

1. All tests in https://docs.google.com/spreadsheets/d/1hOkzOP8kTKi0sDkQmZ7WNyMaWG8btzmiTo8kaED8FFQ/edit#gid=0

## Deployment

This is a code-only release, no other deployment considerations

