### PR TITLE
Remove top nav links to a group’s journals

### DIFF
--- a/portality/templates/layouts/dashboard_base.html
+++ b/portality/templates/layouts/dashboard_base.html
@@ -88,7 +88,7 @@
                     {% set app_source = search_query_source(term=[
                             {"admin.editor_group.exact" : eg.name},
                             {"index.application_type.exact" : "new application"}
-                        ], sort=[{"admin.date_applied": {"order": "desc"}}]
+                        ], sort=[{"admin.date_applied": {"order": "asc"}}]
                     ) %}
                     <a href="{{ url_for('admin.suggestions') }}?source={{ app_source }}" title="See all applications" class="tag tag--tertiary label"><span data-feather="users" aria-hidden="true"></span> <strong>{{ eg.name }}</strong></a>
                   </li>

--- a/portality/templates/layouts/dashboard_base.html
+++ b/portality/templates/layouts/dashboard_base.html
@@ -65,7 +65,7 @@
         {% if request.path == "/dashboard/" %}
         <div class="row">
           <header class="col-md-6 col-lg-4">
-            <p class="label tag"><small><a href="{{ url_for('account.username', username=current_user.id) }}">{{ current_user.id }} (Managing Editor)</a></small></p>{# TODO: insert role of user here #}
+            <p class="label tag"><small><a href="{{ url_for('account.username', username=current_user.id) }}"><span data-feather="user" aria-hidden="true"></span> {{ current_user.id }} (Managing Editor)</a></small></p>{# TODO: insert role of user here #}
             {% endif %}
             <h1>
               {% block page_title %}
@@ -84,20 +84,13 @@
               <dd>
                 <ul class="inlined-list tags">
                   {% for eg in managed_groups %}
-                  <li class="tag tag--tertiary">
+                  <li>
                     {% set app_source = search_query_source(term=[
                             {"admin.editor_group.exact" : eg.name},
                             {"index.application_type.exact" : "new application"}
                         ], sort=[{"admin.date_applied": {"order": "desc"}}]
                     ) %}
-                    <a href="{{ url_for('admin.suggestions') }}?source={{ app_source }}" title="See all applications"><strong>{{ eg.name }}</strong></a>
-
-                    {% set j_source = search_query_source(term=[
-                        {"admin.editor_group.exact" : eg.name}
-                        ], sort=[{"created_date" : {"order": "desc"}}]
-                    ) %}
-                    <a href="{{ url_for('admin.index') }}?source={{ j_source }}" title="See all journals">(journals)
-                    </a>
+                    <a href="{{ url_for('admin.suggestions') }}?source={{ app_source }}" title="See all applications" class="tag tag--tertiary label"><span data-feather="users" aria-hidden="true"></span> <strong>{{ eg.name }}</strong></a>
                   </li>
                   {% endfor %}
                 </ul>


### PR DESCRIPTION
# Remove top nav links to a group’s journals

Simple hotfix that removes an unused link that opens up all of a group’s journals in the search interface. None of the ManEds were using it and it just cluttered the interface. 

See DOAJ/doajPM#3334 — this was a request made as part of testing for this issue. See the comment thread here: https://doajplus.slack.com/archives/CMS19QQHZ/p1658937217312179

See DOAJ/doajPM#3323

See poll on https://doajplus.slack.com/archives/C0DA58K6G/p1658916843591229

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [x] affects the editorial area
- [ ] affects the publisher area

## Basic PR Checklist

- [ ] FeatureMap annotations have been added
- [ ] Unit tests have been added/modified
- [ ] Functional tests have been added/modified
- [ ] Code has been run manually in development, and functional tests followed locally
- [x] No deprecated methods are used
- [x] No magic strings/numbers - all strings are in `constants` or `messages` files
- [ ] Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
- [ ] If needed, migration has been created and tested locally
- [ ] Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
- [x] Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
    - [ ] Core model documentation: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - [ ] Events and consumers documentation: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit

