### PR TITLE
Adjust text size where it was too small to read

### DIFF
--- a/cms/sass/base/_general.scss
+++ b/cms/sass/base/_general.scss
@@ -194,8 +194,6 @@ table {
 /* Aside */
 
 aside {
-  font-size: smaller;
-
   h2 {
     @include typescale-03;
   }

--- a/cms/sass/components/_search-results.scss
+++ b/cms/sass/components/_search-results.scss
@@ -4,6 +4,7 @@
   padding-left: 0;
   margin-left: 0;
   list-style: none;
+  font-size: 20px;
 
   @media (max-width: 768px) {
     font-size: 18px;
@@ -14,7 +15,6 @@
   display: block;
   padding: $spacing-04;
   margin-bottom: $spacing-04;
-  @include typescale-06;
 }
 
 .search-results__main {
@@ -68,12 +68,20 @@
 
   ul {
     @include unstyled-list;
+
+    &:last-of-type {
+      @media (max-width: 768px) {
+        padding-bottom: $spacing-03;
+        border-bottom: 1px solid rgba($dark-grey, 0.25);
+      }
+    }
   }
 }
 
 .search-results__aside {
   border: 0;
   color: $dark-grey;
+  @include typescale-06;
 
   ul {
     @include unstyled-list;

--- a/cms/sass/components/_select2.scss
+++ b/cms/sass/components/_select2.scss
@@ -137,4 +137,5 @@ $s2-size:  20px;
   background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 19C15.4183 19 19 15.4183 19 11C19 6.58172 15.4183 3 11 3C6.58172 3 3 6.58172 3 11C3 15.4183 6.58172 19 11 19Z' stroke='%23282624' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cpath d='M21 21L16.65 16.65' stroke='%23282624' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A") !important;
   background-size: $s2-size !important;
   background-position: right !important;
+  font-size: initial;
 }

--- a/cms/sass/components/_select2.scss
+++ b/cms/sass/components/_select2.scss
@@ -28,8 +28,12 @@ $s2-size:  20px;
     @include font-sans;
 
     .select2-search-choice {
-      @extend .tag;
-      margin: auto $spacing-02 $s2-space 0 !important;
+      margin: 0 $spacing-03 $s2-space 0;
+      padding: $spacing-01 $spacing-03;
+      border-radius: 9999px;
+      background: $warm-black;
+      color: $white;
+      text-decoration: none;
       border: 0;
       box-shadow: none;
       height: 30px;
@@ -125,7 +129,6 @@ $s2-size:  20px;
   background: $white;
   border-top: none;
   border-color: $warm-black !important;
-  font-size: smaller;
 }
 
 .select2-search input {


### PR DESCRIPTION
See DOAJ/doajPM#3336

After merging the PR https://github.com/DOAJ/doaj/pull/2116, some text became too small to read on some viewports. @jbarnsby was the first to report these issues in an email and on Slack (see https://doajplus.slack.com/archives/CKR01GFNU/p1659000714402229). 

I’ve pinpointed the problematic CSS which affected:
- All content marked up within an `<aside>`(it was set to `font-size: smaller` as a default rather than using classes to define this style)
- All Select2 "list" and "form" items, specifically the autocomplete fields and the multiselect/autocomplete combo fields. 
   - For example, subject, currency, language selects

Here are examples of the current look and what this PR proposes to change. They are not exhaustive; the #user-testing team will have to thoroughly check all of the text and especially form fields to ensure that it looks good, on both the public sites and the dashboards and publisher panels. 

## Screenshots & recordings 

### Public site — journal searching 

#### Current 

<img width="1075" alt="public-search-current" src="https://user-images.githubusercontent.com/6668406/182211063-a1add5a8-5ed8-4d59-b39f-c214aff44c9d.png">

#### Proposed change 

<img width="1072" alt="public-search-new" src="https://user-images.githubusercontent.com/6668406/182211058-f07077e7-4d47-4d94-925c-a6d21edd4925.png">

---

### Dashboard — Application review — Notes side panel

#### Current 

<img width="512" alt="application-review-sidepanel-current" src="https://user-images.githubusercontent.com/6668406/182211214-511bced6-ec83-4ba5-8303-635867cc9880.png">

#### Proposed change 

<img width="518" alt="application-review-sidepanel-new" src="https://user-images.githubusercontent.com/6668406/182211307-9110a01e-5baf-4590-b7a5-5595385943f5.png">

----

### Dashboard — Application review — Autocomplete field (Assign an editor group)

#### Current 

![application-review-autocomplete-current](https://user-images.githubusercontent.com/6668406/182211337-ad633601-b3cb-4449-a603-28131cb40e9c.gif)

#### Proposed change 

![application-review-autocomplete-new](https://user-images.githubusercontent.com/6668406/182211343-cdec427d-5f29-4ab4-8f39-7c40a243d4a5.gif)

----

### Dashboard — Application review — Multiselect/autocomplete combo field (Subject)

#### Current 

![application-review-subject-multiselect-autocomplete-current](https://user-images.githubusercontent.com/6668406/182211682-fcdc7503-3969-42b5-980d-cd53895544dc.gif)



![application-review-subject-multiselect-autocomplete-new](https://user-images.githubusercontent.com/6668406/182211676-4c1321aa-0d52-4ca2-b23f-fbc4b012843a.gif)

----

### Dashboard — Editor group profile

#### Current 

![editor-group-edit-current](https://user-images.githubusercontent.com/6668406/182211797-68aa6129-4561-47a5-b6b4-7ef596959e92.gif)

#### Proposed change 
![editor-group-edit-new](https://user-images.githubusercontent.com/6668406/182211792-601fee0d-5742-4f7e-ae89-1fbd45103d8d.gif)

----

## Categorisation

This PR...
- [x] has scripts to run — make sure CSS is recompiled and versioned
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [x] affects the public site
- [x] affects the editorial area
- [x] affects the publisher area

## Basic PR Checklist

- [ ] FeatureMap annotations have been added
- [ ] Unit tests have been added/modified
- [ ] Functional tests have been added/modified
- [ ] Code has been run manually in development, and functional tests followed locally
- [x] No deprecated methods are used
- [x] No magic strings/numbers - all strings are in `constants` or `messages` files
- [ ] Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
- [ ] If needed, migration has been created and tested locally
- [ ] Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
- [ ] Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
    - [ ] Core model documentation: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - [ ] Events and consumers documentation: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit