### PR TITLE
insert editors name into email instead of assosciate

### DIFF
--- a/portality/events/consumers/application_maned_ready_notify.py
+++ b/portality/events/consumers/application_maned_ready_notify.py
@@ -30,14 +30,15 @@ class ApplicationManedReadyNotify(EventConsumer):
         if not application.editor_group:
             return
 
-        editor = "unknown editor"
-        if application.editor:
-            editor = application.editor
 
         eg = models.EditorGroup.pull_by_key("name", application.editor_group)
         managing_editor = eg.maned
         if not managing_editor:
             return
+
+        editor = eg.editor
+        if not editor:
+            editor = "unknown editor"
 
         svc = DOAJ.notificationsService()
 

--- a/portality/events/consumers/application_maned_ready_notify.py
+++ b/portality/events/consumers/application_maned_ready_notify.py
@@ -47,7 +47,7 @@ class ApplicationManedReadyNotify(EventConsumer):
         notification.classification = constants.NOTIFICATION_CLASSIFICATION_STATUS_CHANGE
         notification.long = svc.long_notification(cls.ID).format(
             application_title=application.bibjson().title,
-            editor=editor
+            editor=eg.editor
         )
         notification.short = svc.short_notification(cls.ID)
 

--- a/portality/events/consumers/application_maned_ready_notify.py
+++ b/portality/events/consumers/application_maned_ready_notify.py
@@ -48,7 +48,7 @@ class ApplicationManedReadyNotify(EventConsumer):
         notification.classification = constants.NOTIFICATION_CLASSIFICATION_STATUS_CHANGE
         notification.long = svc.long_notification(cls.ID).format(
             application_title=application.bibjson().title,
-            editor=eg.editor
+            editor=editor
         )
         notification.short = svc.short_notification(cls.ID)
 


### PR DESCRIPTION
Email notification should insert Editor instead of AssEd

See https://github.com/DOAJ/doajPM/issues/3348

## Categorisation

This PR...
- [ ] **N/A** has scripts to run
- [ ] **N/A** has migrations to run
- [ ] **N/A** adds new infrastructure
- [ ] **N/A** changes the CI pipeline
- [ ] **N/A** affects the public site
- [x] affects the editorial area
- [ ] **N/A** affects the publisher area

## Basic PR Checklist

- [ ] **N/A** FeatureMap annotations have been added
- [ ] **N/A** Unit tests have been added/modified
- [ ] **N/A** Functional tests have been added/modified
- [x] Code has been run manually in development, and functional tests followed locally
- [x] No deprecated methods are used
- [x] No magic strings/numbers - all strings are in `constants` or `messages` files
- [ ] **N/A**  ES queries are wrapped in a Query object rather than inlined in the code
- [ ] **N/A** Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
- [ ] **N/A** If needed, migration has been created and tested locally
- [ ] **N/A** Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
- [ ] **N/A** Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
    - [ ] **N/A** Core model documentation: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - [ ] **N/A** Events and consumers documentation: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
- [x] There has been a recent merge up from `develop` (or other base branch)

## Testing

**N/A** 

## Deployment

**N/A** 

### Configuration changes

**N/A** 

### Scripts

**N/A** 

### Migrations

**N/A** 

### Monitoring

**N/A** 

### New Infrastructure

**N/A** 

### Continuous Integration

**N/A** 


