### PR TITLE
Redicrection from /publishers to /guide/apply

### DIFF
--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -616,7 +616,7 @@ def old_faq():
 
 @blueprint.route("/publishers")
 def publishers():
-    return render_template("layouts/static_page.html")
+    return redirect(url_for("doaj.guide", **request.args), code=308)
 
 
 # Redirects necessitated by new templates


### PR DESCRIPTION
Redicrection from /publishers to /guide/apply

*Please don't delete any sections when completing this PR template; instead enter **N/A** for checkboxes or sections which are not applicable, unless otherwise stated below*

[See #2644](https://github.com/DOAJ/doajPM/issues/2644)

Makes sure that the `/publishers` endpoint redirects to `/apply/guide` endpoint with redirection code 308.

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [x] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area

## Basic PR Checklist

- [ ] **N/A** FeatureMap annotations have been added
- [ ] **N/A** Unit tests have been added/modified
- [ ] **N/A** Functional tests have been added/modified
- [x] Code has been run manually in development, and functional tests followed locally
- [ ] **N/A** No deprecated methods are used
- [x]No magic strings/numbers - all strings are in `constants` or `messages` files
- [ ] **N/A** ES queries are wrapped in a Query object rather than inlined in the code
- [ ] **N/A** Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
- [ ] **N/A** If needed, migration has been created and tested locally
- [ ] **N/A** Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
- [ ] **N/A** Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
    - [ ] **N/A** Core model documentation: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - [ ] **N/A** Events and consumers documentation: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
- [ ] **N/A** There has been a recent merge up from `develop` (or other base branch)

## Testing

List the Functional Tests that must be run to confirm this feature

1. Go to /publishers endpoint, confirm the user is redirected to /apply/guide/

## Deployment

 **N/A**

### Configuration changes

 **N/A**

### Scripts

 **N/A**

### Migrations

 **N/A**

### Monitoring

 **N/A**

### New Infrastructure

 **N/A**

### Continuous Integration

 **N/A**


