### PR TITLE
Fix OpenURL query bug

### DIFF
--- a/doajtest/unit/test_openurl.py
+++ b/doajtest/unit/test_openurl.py
@@ -88,6 +88,11 @@ class TestOpenURL(DoajTestCase):
         param_pissn = j_matching.bibjson().first_pissn
         param_title = j_matching.bibjson().title
 
+        art_source = ArticleFixtureFactory.make_article_source(eissn=param_eissn, pissn=param_pissn)
+        art_source["bibjson"]["journal"]["volume"] = "1"
+        art = models.Article(**art_source)
+        art.save(blocking=True)
+
         j_nonmatching = models.Journal(**j_nonmatching_source)
         j_nonmatching.set_in_doaj(True)
         param_different_title = "A new title not the same as the old title"
@@ -107,10 +112,11 @@ class TestOpenURL(DoajTestCase):
                                             pissn=param_pissn,
                                             eissn=param_eissn,
                                             jtitle=param_title,
-                                            genre='journal'))
+                                            genre='journal',
+                                            volume="1"))
 
                 assert resp.status_code == 302
-                assert resp.location == url_for('doaj.toc', identifier=j_matching.id, _external=True)
+                assert resp.location == url_for('doaj.toc', identifier=j_matching.id, volume=1, _external=True)
 
                 # A query without genre to show it's the default
                 resp = t_client.get(url_for('openurl.openurl',

--- a/portality/models/openurl.py
+++ b/portality/models/openurl.py
@@ -41,6 +41,8 @@ class OpenURLRequest(object):
     This is the only schema the DOAJ supports.
     """
 
+    # ~~API:Feature~~
+
     def __init__(self, **kwargs):
 
         # Initialise the OpenURLRequest object with empty attributes
@@ -142,6 +144,7 @@ class OpenURLRequest(object):
                 jtoc_url = url_for("doaj.toc", identifier=ident)
             return jtoc_url
 
+        #~~->Article:Page~~
         elif results.get('hits', {}).get('hits', [{}])[0].get('_source', {}).get('es_type') == 'article':
             return url_for("doaj.article_page", identifier=results['hits']['hits'][0]['_id'])
 

--- a/portality/models/openurl.py
+++ b/portality/models/openurl.py
@@ -131,7 +131,7 @@ class OpenURLRequest(object):
                 if vol_iss_results == None:
                     # we were asked for a vol/issue, but weren't given the correct information to get it.
                     return None
-                elif vol_iss_results['hits']['total'] > 0:
+                elif vol_iss_results['hits']['total']['value'] > 0:
                     # construct the toc url using the ident, plus volume and issue
                     jtoc_url = url_for("doaj.toc", identifier=ident, volume=self.volume, issue=self.issue)
                 else:

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -342,6 +342,7 @@ def toc(identifier=None, volume=None, issue=None):
                            toc_issns=journal.bibjson().issns())
 
 
+#~~->Article:Page~~
 @blueprint.route("/article/<identifier>")
 def article_page(identifier=None):
     # identifier must be the article id


### PR DESCRIPTION
Fix OpenURL query bug

[See #3339](https://github.com/DOAJ/doajPM/issues/3339)

Fixes the query and modifies the UTs so it checks the query with volume param.

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [x] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area

## Basic PR Checklist

- [x] FeatureMap annotations have been added
- [x] Unit tests have been added/modified
- [ ] **N/A** Functional tests have been added/modified
- [x] Code has been run manually in development, and functional tests followed locally
- [x] No deprecated methods are used
- [x] No magic strings/numbers - all strings are in `constants` or `messages` files
- [x] ES queries are wrapped in a Query object rather than inlined in the code
- [x] Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
- [ ] **N/A** If needed, migration has been created and tested locally
- [ ] **N/A** Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
- [ ] **N/A** Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
    - [ ]  **N/A** Core model documentation: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - [ ] **N/A** Events and consumers documentation: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
- [ ] **N/A** There has been a recent merge up from `develop` (or other base branch)

## Testing

**N/A**

## Deployment

**N/A**

### Configuration changes

**N/A**

### Scripts

**N/A**

### Migrations

**N/A**

### Monitoring

**N/A**

### New Infrastructure

**N/A**

### Continuous Integration

**N/A**


