### PR TITLE
Disable plausible custom events

### DIFF
--- a/portality/lib/plausible.py
+++ b/portality/lib/plausible.py
@@ -1,5 +1,4 @@
-""" Plausible Analytics
-"""
+# ~~ PlausibleAnalytics:ExternalService~~
 import json
 import logging
 import os

--- a/portality/lib/plausible.py
+++ b/portality/lib/plausible.py
@@ -3,15 +3,18 @@
 import json
 import logging
 import os
+import requests
+
 from functools import wraps
 from threading import Thread
-
-import requests
 
 from portality.core import app
 from flask import request
 
 logger = logging.getLogger(__name__)
+
+# Keep track of when this is misconfigured so we don't spam the logs with skip messages
+_failstate = False
 
 
 def create_logfile(log_dir=None):
@@ -31,7 +34,10 @@ def send_event(goal: str, on_completed=None, **props_kwargs):
 
     plausible_api_url = app.config.get('PLAUSIBLE_API_URL', '')
     if not app.config.get('PLAUSIBLE_URL', '') and not plausible_api_url:
-        logger.warning('skip send_event, PLAUSIBLE_URL undefined')
+        global _failstate
+        if not _failstate:
+            logger.warning('skip send_event, PLAUSIBLE_URL undefined')
+            _failstate = True
         return
 
     # prepare request payload

--- a/production.cfg
+++ b/production.cfg
@@ -47,3 +47,6 @@ LOGIN_VIA_ACCOUNT_ID = True
 READ_ONLY_MODE = False
 # This puts the cron jobs into READ_ONLY mode
 SCRIPTS_READ_ONLY_MODE = False
+
+# 2022-09-14 issue #3369 disable Plausible custom events
+PLAUSIBLE_API_URL = None


### PR DESCRIPTION
# Turn off custom events

See https://github.com/DOAJ/doajPM/issues/3369

Turns off custom events (only) sent via API to Plausible, by removing the config key in production. Also change the logging so it only writes once that it's unconfigured.

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area

## Basic PR Checklist

- [x] FeatureMap annotations have been added
- [ ] Unit tests have been added/modified
- [ ] Functional tests have been added/modified
- [ ] Code has been run manually in development, and functional tests followed locally
- [x] No deprecated methods are used
- [ ] No magic strings/numbers - all strings are in `constants` or `messages` files
- [ ] ES queries are wrapped in a Query object rather than inlined in the code
- [ ] Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
- [ ] If needed, migration has been created and tested locally
- [ ] Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
- [ ] Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
    - [ ] Core model documentation: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - [ ] Events and consumers documentation: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
- [ ] There has been a recent merge up from `develop` (or other base branch)

## Testing

List the Functional Tests that must be run to confirm this feature

Due to limited credentials, we'll probably have to send this live to see the effect.



## Deployment

What deployment considerations are there? (delete any sections you don't need)

### Configuration changes

Blanks the plausible API URL in `production.cfg` - included in this PR, nothing else needed.


