### PR TITLE
add track total hits to oaipmg records query

### DIFF
--- a/doajtest/functional/oaipmh_client_test.py
+++ b/doajtest/functional/oaipmh_client_test.py
@@ -49,7 +49,8 @@ def harvest(base_url, verb="ListRecords", metadata_prefix="oai_dc", rate_limit=0
     rtel = xml.find(".//" + NS + "resumptionToken")
     if rtel is not None:
         if rtel.text is not None and rtel.text != "":
-            print("\tresumption token", rtel.text, "cursor", rtel.get("cursor") + "/" + rtel.get("completeListSize"))
+            print("\tresumption token", rtel.text)
+            print("\tcursor", rtel.get("cursor") + "/" + rtel.get("completeListSize"))
             print("\tresults received: ", len(idents))
             return rtel.text
         else:

--- a/portality/models/oaipmh.py
+++ b/portality/models/oaipmh.py
@@ -37,6 +37,7 @@ class OAIPMHRecord(object):
     }
 
     records = {
+        "track_total_hits": True,
         "query": {
             "bool": {
                 "must": [


### PR DESCRIPTION
# Title <- provide a title for the PR

*Please don't delete any sections when completing this PR template; instead enter **N/A** for checkboxes or sections which are not applicable, unless otherwise stated below*

[See #3355](https://github.com/DOAJ/doajPM/issues/3355)

Describe the scope/purpose of the PR here in as much detail as you like

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [x] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area

## Basic PR Checklist

- [x] **N/A** FeatureMap annotations have been added
- [x] **N/A** Unit tests have been added/modified
- [x] Functional tests have been added/modified
- [x] Code has been run manually in development, and functional tests followed locally
- [s] No deprecated methods are used
- [s] No magic strings/numbers - all strings are in `constants` or `messages` files
- [x] ES queries are wrapped in a Query object rather than inlined in the code
- [x] Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
- [x] If needed, migration has been created and tested locally
- [x] **N/A** Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
- [x] Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
    - [x] Core model documentation: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - [x] Events and consumers documentation: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
- [x] There has been a recent merge up from `develop` (or other base branch)

## Testing

List the Functional Tests that must be run to confirm this feature

1. Run OAI harvester with `doajtest/functional/oaipmh_test_client.py` and check that the total size of results set does not change.

## Deployment

**N/A**
### Configuration changes

**N/A**
### Scripts

**N/A**
### Migrations

**N/A**
### Monitoring

**N/A**
### New Infrastructure

**N/A**
### Continuous Integration

**N/A**

