### PR TITLE
Feature/3218 editorial todo  editor  UI bits

### DIFF
--- a/portality/static/js/dashboard.js
+++ b/portality/static/js/dashboard.js
@@ -93,7 +93,7 @@ doaj.dashboard.renderGroupInfo = function(data) {
         if (data.editors[ed]) {
             let isEd = "";
             if (i === 0) {  // first one in the list is always the editor
-                isEd = " (Ed.)"
+                isEd = " (Editor)"
             }
             editorListFrag += `<li>
                 <a href="mailto:${data.editors[ed].email}" target="_blank" class="label tag" title="Send an email to ${ed}">${ed}${isEd}</a>

--- a/portality/templates/application_form/_contact.html
+++ b/portality/templates/application_form/_contact.html
@@ -1,7 +1,13 @@
 {% if obj.owner %}
     {% set account = obj.owner_account %}
-    <ul class="tags">
-        <li class="tag"><a href="mailto:{{account.email}}"><span data-feather="mail" aria-hidden="true"></span> {{account.name}}</a>
-            (<a href="{{ url_for("account.username", username=account.id) }}">{{ account.id }}</a>)</li>
-    </ul>
+    {% if account.id == current_user.id %}
+        <ul class="tags">
+            <li class="tag"><span>Assigned to you</span></li>
+        </ul>
+    {% else %}
+        <ul class="tags">
+            <li class="tag"><a href="mailto:{{account.email}}"><span data-feather="mail" aria-hidden="true"></span> {{account.name}}</a>
+                (<a href="{{ url_for("account.username", username=account.id) }}">{{ account.id }}</a>)</li>
+        </ul>
+    {% endif %}
 {% endif %}

--- a/portality/templates/dashboard/_todo.html
+++ b/portality/templates/dashboard/_todo.html
@@ -76,46 +76,42 @@
 
 <section>
     {% if todos|length == 0 %}
-    <div class="flex-center">
-      <p class="card col-md-6">
-          <span class="type-03">
+        <div class="flex-center">
+          <p class="card col-md-6">
+              <span class="type-03">
 
-              {% if current_user.has_role("admin") %}
-                {% set source = search_query_source(
-                    term=[
-                        {"admin.editor.exact" : current_user.id},
-                        {"index.application_type.exact" : "new application"}
-                    ],
-                    sort=[{"admin.date_applied": {"order": "asc"}}]
-                 )
-                %}
-                All priority tasks have been done. Check your <a href="{{ url_for('admin.suggestions') }}?source={{ source }}">queue</a> for more open applications
-              {% elif current_user.has_role("editor") %}
-                  {% set source = search_query_source(
-                    term=[
-                        {"index.application_type.exact" : "new application"}
-                    ],
-                    sort=[{"admin.date_applied": {"order": "asc"}}]
-                 )
-                  %}
-                  All priority tasks have been done. Check your <a href="{{ url_for('editor.group_suggestions') }}?source={{ source }}">queue</a> for more open applications. If you need more applications to be assigned to your group, contact your Managing Editor.
-              {% elif current_user.has_role("associate_editor") %}
-                  {% set source = search_query_source(
-                    term=[
-                        {"index.application_type.exact" : "new application"}
-                    ],
-                    sort=[{"admin.date_applied": {"order": "asc"}}]
-                 )
-                  %}
-                  All priority tasks have been done. Check your <a href="{{ url_for('editor.associate_suggestions') }}?source={{ source }}">queue</a> for more open applications. If you need more to be assigned to you, contact your Editor or Managing Editor.
-              {% endif %}
-          </span>
-      </p>
-    </div>
-    {% else %}
-    <h2 class="type-04">
-      You have <strong>{{ todos|length }}{% if todos|length >= config.get("TODO_LIST_SIZE")%}+{% endif %}</strong> applications in your priority list:
-    </h2>
+                  {% if current_user.has_role("admin") %}
+                    {% set source = search_query_source(
+                        term=[
+                            {"admin.editor.exact" : current_user.id},
+                            {"index.application_type.exact" : "new application"}
+                        ],
+                        sort=[{"admin.date_applied": {"order": "asc"}}]
+                     )
+                    %}
+                    All priority tasks have been done. Check your <a href="{{ url_for('admin.suggestions') }}?source={{ source }}">queue</a> for more open applications
+                  {% elif current_user.has_role("editor") %}
+                      {% set source = search_query_source(
+                        term=[
+                            {"index.application_type.exact" : "new application"}
+                        ],
+                        sort=[{"admin.date_applied": {"order": "asc"}}]
+                     )
+                      %}
+                      All priority tasks have been done. Check your <a href="{{ url_for('editor.group_suggestions') }}?source={{ source }}">queue</a> for more open applications. If you need more applications to be assigned to your group, contact your Managing Editor.
+                  {% elif current_user.has_role("associate_editor") %}
+                      {% set source = search_query_source(
+                        term=[
+                            {"index.application_type.exact" : "new application"}
+                        ],
+                        sort=[{"admin.date_applied": {"order": "asc"}}]
+                     )
+                      %}
+                      All priority tasks have been done. Check your <a href="{{ url_for('editor.associate_suggestions') }}?source={{ source }}">queue</a> for more open applications. If you need more to be assigned to you, contact your Editor or Managing Editor.
+                  {% endif %}
+              </span>
+          </p>
+        </div>
     {% endif %}
     <ol class="todo-list">
       {% for todo in todos %}

--- a/portality/templates/editor/nav.html
+++ b/portality/templates/editor/nav.html
@@ -4,11 +4,13 @@
 {% set ass_apps = url_for('editor.associate_suggestions') %}
 {% set ass_journals = url_for('editor.associate_journals') %}
 
+<!-- tab removed for https://github.com/DOAJ/doajPM/issues/3422 -->
+<!-- (ass_journals, "Journals assigned to you", None, "book-open") -->
 {% set tabs = [
     (index, "Dashboard", None, "list"),
     (group_apps, "Your group’s applications", "list_group_suggestions", "users"),
     (group_journals, "Your group’s journals", "list_group_journals", "book"),
-    (ass_apps, "Applications assigned to you", None, "file-text"),
+    (ass_apps, "Applications assigned to you", None, "file-text")
     ]
 %}
 

--- a/portality/templates/editor/nav.html
+++ b/portality/templates/editor/nav.html
@@ -9,7 +9,6 @@
     (group_apps, "Your group’s applications", "list_group_suggestions", "users"),
     (group_journals, "Your group’s journals", "list_group_journals", "book"),
     (ass_apps, "Applications assigned to you", None, "file-text"),
-    (ass_journals, "Journals assigned to you", None, "book-open")
     ]
 %}
 


### PR DESCRIPTION
Implemented changes requested in the following to do: https://github.com/DOAJ/doajPM/issues/3422#issue-1463035183

- [x] for all roles, when an application is assigned to you (as an individual, rather than a group), change the username label to just say 'Assigned to you'. @amdomanska 
- [x] Remove the text at the top: 'You have 7 applications in your priority list:' @amdomanska
- [x] spell out 'Editor' and 'Managing Editor' in full: 'ED.' and 'MAN. ED.' won't mean anything to non-English speakers. @amdomanska 
**I found only `ED.` in the group info section, the tag at the top of the dashboard has those words spell out. @richard-jones Am I missing something?**
- [x] remove 'Journals Assigned to you' from the side nav. Volunteers only ever work on applications. @amdomanska 
**This is only about the editor dashboard, right? @richard-jones**
