### PR TITLE
Remove an unnecessary test expression

### DIFF
--- a/portality/crosswalks/article_form.py
+++ b/portality/crosswalks/article_form.py
@@ -43,7 +43,7 @@ class ArticleFormXWalk(object):
 
         # keywords
         keywords = form.keywords.data
-        if keywords is not None:
+        if keywords is not None and len(keywords) > 0:
             if isinstance(keywords, str):
                 keywords = keywords.split(",")
             ks = [k.strip() for k in keywords]

--- a/portality/crosswalks/article_form.py
+++ b/portality/crosswalks/article_form.py
@@ -43,7 +43,7 @@ class ArticleFormXWalk(object):
 
         # keywords
         keywords = form.keywords.data
-        if keywords is not None and keywords is not []:
+        if keywords is not None:
             if isinstance(keywords, str):
                 keywords = keywords.split(",")
             ks = [k.strip() for k in keywords]


### PR DESCRIPTION
In file: article_form.py, method: form2obj, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not match with anything else. As a result, the identity check will have a logical short circuit. The first part of the test expression already tests for it. The second part is unnecessary.

I suggested that the logical operation should be reviewed. 