### PR TITLE
be able to mark notifications as seen according to some criteria

### DIFF
--- a/doajtest/functional/make_notifications.py
+++ b/doajtest/functional/make_notifications.py
@@ -1,5 +1,5 @@
 # ~~Notifications:FunctionalTest~~
-import models
+from portality import models
 from portality.events.consumers import application_assed_assigned_notify, \
     application_assed_inprogress_notify, \
     application_editor_completed_notify, \

--- a/portality/bll/services/notifications.py
+++ b/portality/bll/services/notifications.py
@@ -119,6 +119,6 @@ class NotificationsQuery(object):
                 q["query"]["bool"]["must"] = musts
             if len(must_nots) > 0:
                 q["query"]["bool"]["must_not"] = must_nots
-
+            return q
         else:
             return {"query": {"match_all": {}}}

--- a/portality/bll/services/notifications.py
+++ b/portality/bll/services/notifications.py
@@ -53,6 +53,7 @@ class NotificationsService(object):
         return top
 
     def notification_seen(self, account: models.Account, notification_id: str):
+        # ~~-> Notifications:Query ~~
         note = models.Notification.pull(notification_id)
         if not note:
             raise NoSuchObjectException(Messages.EXCEPTION_NOTIFICATION_NO_NOTIFICATION.format(n=notification_id))
@@ -93,6 +94,8 @@ class TopNotificationsQuery(object):
 
 
 class NotificationsQuery(object):
+    # ~~->$ Notifications:Query ~~
+    # ~~^-> Elasticsearch:Technology ~~
     def __init__(self, account_id=None, until=None, seen=None):
         self._account_id = account_id
         self._until = until

--- a/portality/bll/services/notifications.py
+++ b/portality/bll/services/notifications.py
@@ -4,6 +4,8 @@ from portality.core import app
 from portality import app_email
 from portality.ui.messages import Messages
 from portality.bll.exceptions import NoSuchObjectException, NoSuchPropertyException
+from datetime import datetime
+from portality.lib import dates
 
 
 class NotificationsService(object):
@@ -61,6 +63,13 @@ class NotificationsService(object):
             return True
         return False
 
+    def mark_all_as_seen(self, account: models.Account=None, until: datetime=None):
+        account_id = None if account is None else account.id
+        q = NotificationsQuery(account_id, until, False)
+        for notification in models.Notification.scroll(q.query()):
+            notification.set_seen()
+            notification.save()
+
 
 class TopNotificationsQuery(object):
     # ~~->$ TopNotifications:Query ~~
@@ -81,3 +90,35 @@ class TopNotificationsQuery(object):
             "sort": [{"created_date": {"order": "desc"}}],
             "size": self.size
         }
+
+
+class NotificationsQuery(object):
+    def __init__(self, account_id=None, until=None, seen=None):
+        self._account_id = account_id
+        self._until = until
+        self._seen = seen
+
+    def query(self):
+        musts = []
+        must_nots = []
+        if self._account_id:
+            musts.append({"term": {"who.exact": self._account_id}})
+
+        if self._until:
+            musts.append({"range": {"created_date": {"lte": dates.format(self._until, format="%Y-%m-%dT%H:%M:%S")}}})
+
+        if self._seen is not None:
+            if self._seen is True:
+                musts.append({"exists": {"field": "seen_date"}})
+            else:
+                must_nots.append({"exists": {"field": "seen_date"}})
+
+        if len(musts) > 0 or len(must_nots) > 0:
+            q = {"query": {"bool": {}}}
+            if len(musts) > 0:
+                q["query"]["bool"]["must"] = musts
+            if len(must_nots) > 0:
+                q["query"]["bool"]["must_not"] = must_nots
+
+        else:
+            return {"query": {"match_all": {}}}

--- a/portality/scripts/mark_notifications_seen.py
+++ b/portality/scripts/mark_notifications_seen.py
@@ -1,0 +1,19 @@
+from portality.lib import dates
+from portality.bll import DOAJ
+
+
+def mark_notifications_seen(until):
+    notifications_svc = DOAJ.notificationsService()
+    notifications_svc.mark_all_as_seen(until=until)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-u", "--until", help="mark all notifications before this as seen")
+    args = parser.parse_args()
+
+    until = dates.parse(args.until)
+
+    mark_notifications_seen(until)

--- a/portality/scripts/mark_notifications_seen.py
+++ b/portality/scripts/mark_notifications_seen.py
@@ -1,8 +1,10 @@
+# ~~ MarkNotificationsSeen:Script ~~
 from portality.lib import dates
 from portality.bll import DOAJ
 
 
 def mark_notifications_seen(until):
+    # ~~-> Notifications:Service ~~
     notifications_svc = DOAJ.notificationsService()
     notifications_svc.mark_all_as_seen(until=until)
 


### PR DESCRIPTION
# be able to mark notifications as seen according to some criteria

*Please don't delete any sections when completing this PR template; instead enter **N/A** for checkboxes or sections which are not applicable, unless otherwise stated below*

See https://github.com/DOAJ/doajPM/issues/3437

Core method to mark notifications as seen, and a script to trigger this.

## Categorisation

This PR...
- [x] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [x] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Basic PR Checklist

- [x] FeatureMap annotations have been added
- [x] **N/A** Unit tests have been added/modified - for a one off script run I have not written unit tests, but will do so in the follow up PR to make this a feature
- [x] **N/A** Functional tests have been added/modified
- [x] Code has been run manually in development, and functional tests followed locally
- [x] No deprecated methods are used
- [x] No magic strings/numbers - all strings are in `constants` or `messages` files
- [x] ES queries are wrapped in a Query object rather than inlined in the code
- [x] Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
- [x] **N/A** If needed, migration has been created and tested locally
- [x] Cleaned up commented out code, etc
- [x] **N/A** Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
- [x] **N/A** Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
    - [x] **N/A** Core model documentation: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - [x] **N/A** Events and consumers documentation: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
- [x] There has been a recent merge up from `develop` (or other base branch)
- [x] **N/A** The docs for this branch have been generated and pushed to the doc site (see docs/README.md for details)

## Testing

Just run the script on test to be sure

## Deployment

**N/A**

### Configuration changes

**N/A**

### Scripts

After release run this to clean up all the old notifications

```
python portality/scripts/mark_notifications_seen.py -u 2023-01-01
```

The `-u` argument tells the script to mark all notifications "until" that date (i.e. before it) as read.  Confirm with @dommitchell the actual desired date to go in here when it is run.

### Migrations


**N/A**

### Monitoring


**N/A**

### New Infrastructure


**N/A**

### Continuous Integration

**N/A**


