### PR TITLE
change how the public data dump is generated, cached and delivered to…

### DIFF
--- a/doajtest/mocks/model_Cache.py
+++ b/doajtest/mocks/model_Cache.py
@@ -27,10 +27,11 @@ class InMemoryCache(object):
         pass
 
     @classmethod
-    def cache_public_data_dump(cls, article_url, article_size, journal_url, journal_size):
+    def cache_public_data_dump(cls, article_container, article_filename, article_url, article_size,
+                                    journal_container, journal_filename, journal_url, journal_size):
         cls.__memory__["public_data_dump"] = {
-            "article": {"url" : article_url, "size" : article_size},
-            "journal": {"url" : journal_url, "size" : journal_size}
+            "article": {"container": article_container, "filename": article_filename, "url" : article_url, "size" : article_size},
+            "journal": {"container": journal_container, "filename": journal_filename, "url" : journal_url, "size" : journal_size}
         }
 
     @classmethod

--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -1417,7 +1417,7 @@ class TestModels(DoajTestCase):
 
         models.Cache.cache_sitemap("sitemap.xml")
 
-        models.Cache.cache_public_data_dump("http://example.com/article", 100, "http://example.com/journal", 200)
+        models.Cache.cache_public_data_dump("ac", "af", "http://example.com/article", 100, "jc", "jf", "http://example.com/journal", 200)
         
         time.sleep(1)
 
@@ -1432,10 +1432,17 @@ class TestModels(DoajTestCase):
 
         assert models.Cache.get_latest_sitemap() == "sitemap.xml"
 
-        assert models.Cache.get_public_data_dump().get("article").get("url") == "http://example.com/article"
-        assert models.Cache.get_public_data_dump().get("article").get("size") == 100
-        assert models.Cache.get_public_data_dump().get("journal").get("url") == "http://example.com/journal"
-        assert models.Cache.get_public_data_dump().get("journal").get("size") == 200
+        article_data = models.Cache.get_public_data_dump().get("article")
+        assert article_data.get("url") == "http://example.com/article"
+        assert article_data.get("size") == 100
+        assert article_data.get("container") == "ac"
+        assert article_data.get("filename") == "af"
+
+        journal_data = models.Cache.get_public_data_dump().get("journal")
+        assert journal_data.get("url") == "http://example.com/journal"
+        assert journal_data.get("size") == 200
+        assert journal_data.get("container") == "jc"
+        assert journal_data.get("filename") == "jf"
 
     def test_32_journal_like_object_discovery(self):
         """ Check that the JournalLikeObject can retrieve the correct results for Journals and Applications """

--- a/portality/constants.py
+++ b/portality/constants.py
@@ -65,6 +65,7 @@ PROCESS__QUICK_REJECT = "quick_reject"
 
 # Role
 ROLE_ASSOCIATE_EDITOR = 'associate_editor'
+ROLE_PUBLIC_DATA_DUMP = "public_data_dump"
 
 CRON_NEVER = {"month": "2", "day": "31", "day_of_week": "*", "hour": "*", "minute": "*"}
 
@@ -83,3 +84,7 @@ BGJOB_QUEUE_ID_UNKNOWN = 'unknown'
 # Background monitor status
 BG_STATUS_STABLE = 'stable'
 BG_STATUS_UNSTABLE = 'unstable'
+
+
+# Storage scopes
+STORE__SCOPE__PUBLIC_DATA_DUMP = "public_data_dump"

--- a/portality/models/cache.py
+++ b/portality/models/cache.py
@@ -69,10 +69,21 @@ class Cache(DomainObject):
         return rec.get("filename")
 
     @classmethod
-    def cache_public_data_dump(cls, article_url, article_size, journal_url, journal_size):
+    def cache_public_data_dump(cls, article_container, article_filename, article_url, article_size,
+                                    journal_container, journal_filename, journal_url, journal_size):
         cobj = cls(**{
-            "article": { "url" : article_url, "size" : article_size },
-            "journal": { "url" : journal_url, "size" : journal_size }
+            "article": {
+                "container": article_container,
+                "filename": article_filename,
+                "url" : article_url,
+                "size" : article_size
+            },
+            "journal": {
+                "container": journal_container,
+                "filename": journal_filename,
+                "url" : journal_url,
+                "size" : journal_size
+            }
         })
         cobj.set_id("public_data_dump")
         cobj.save()

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -164,10 +164,15 @@ REPORTS_BASE_DIR = "/home/cloo/reports/"
 # File store
 # ~~->FileStore:Feature~~
 
-# put this in your production.cfg, to store on S3:
+# put this in your production.cfg, to store everything on S3:
 # STORE_IMPL = "portality.store.StoreS3"
 
 STORE_IMPL = "portality.store.StoreLocal"
+STORE_SCOPE_IMPL = {
+# Enable this by scope in order to have different scopes store via different storage implementations
+#     constants.STORE__SCOPE__PUBLIC_DATA_DUMP: "portality.store.StoreS3"
+}
+
 STORE_TMP_IMPL = "portality.store.TempStore"
 
 STORE_LOCAL_DIR = paths.rel2abs(__file__, "..", "local_store", "main")
@@ -196,7 +201,7 @@ STORE_S3_SCOPES = {
         "aws_secret_access_key" : "put this in your dev/test/production.cfg"
     },
     # Used by the api_export script to dump data from the api
-    "public_data_dump" : {
+    constants.STORE__SCOPE__PUBLIC_DATA_DUMP : {
         "aws_access_key_id" : "put this in your dev/test/production.cfg",
         "aws_secret_access_key" : "put this in your dev/test/production.cfg"
     },
@@ -275,7 +280,16 @@ PASSWORD_RESET_TIMEOUT = 86400
 PASSWORD_CREATE_TIMEOUT = PASSWORD_RESET_TIMEOUT * 14
 
 #"api" top-level role is added to all acounts on creation; it can be revoked per account by removal of the role.
-TOP_LEVEL_ROLES = ["admin", "publisher", "editor", "associate_editor", "api", "ultra_bulk_delete", "preservation"]
+TOP_LEVEL_ROLES = [
+    "admin",
+    "publisher",
+    "editor",
+    "associate_editor",
+    "api",
+    "ultra_bulk_delete",
+    "preservation",
+    constants.ROLE_PUBLIC_DATA_DUMP
+]
 
 ROLE_MAP = {
     "editor": [
@@ -1354,3 +1368,8 @@ BG_MONITOR_QUEUED_CONFIG = {
     }
 }
 
+##################################################
+## Public data dump settings
+
+# how long should the temporary URL for public data dumps last
+PUBLIC_DATA_DUMP_URL_TIMEOUT = 3600

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -8,7 +8,7 @@ from flask import Blueprint, request, make_response
 from flask import render_template, abort, redirect, url_for, send_file, jsonify
 from flask_login import current_user, login_required
 
-import constants
+from portality import constants
 from portality import dao
 from portality import models
 from portality import store
@@ -29,9 +29,11 @@ def home():
     recent_journals = models.Journal.recent(max=16)
     return render_template('doaj/index.html', news=news, recent_journals=recent_journals)
 
+
 @blueprint.route('/login/')
 def login():
     return redirect(url_for('account.login'))
+
 
 @blueprint.route("/cookie_consent")
 def cookie_consent():
@@ -550,9 +552,11 @@ def volunteers():
 def team():
     return render_template("layouts/static_page.html", page_frag="/about/team.html")
 
+
 @blueprint.route("/preservation/")
 def preservation():
     return render_template("layouts/static_page.html", page_frag="/preservation/index.html")
+
 
 # LEGACY ROUTES
 @blueprint.route("/subjects")
@@ -574,6 +578,7 @@ def old_application():
 @blueprint.route("/oainfo")
 def bestpractice(cc=None):
     return redirect(url_for("doaj.transparency", **request.args), code=308)
+
 
 @blueprint.route("/membership")
 def membership():

--- a/portality/view/doaj.py
+++ b/portality/view/doaj.py
@@ -8,10 +8,12 @@ from flask import Blueprint, request, make_response
 from flask import render_template, abort, redirect, url_for, send_file, jsonify
 from flask_login import current_user, login_required
 
+import constants
 from portality import dao
 from portality import models
+from portality import store
 from portality.core import app
-from portality.decorators import ssl_required
+from portality.decorators import ssl_required, api_key_required
 from portality.forms.application_forms import JournalFormFactory
 from portality.lcc import lcc_jstree
 from portality.lib import plausible
@@ -186,30 +188,25 @@ def sitemap():
     return redirect(sitemap_url, code=307)
 
 
-# @blueprint.route("/public-data-dump")
-# def public_data_dump():
-#     data_dump = models.Cache.get_public_data_dump()
-#     show_article = data_dump.get("article", {}).get("url") is not None
-#     article_size = data_dump.get("article", {}).get("size")
-#     show_journal = data_dump.get("journal", {}).get("url") is not None
-#     journal_size = data_dump.get("journal", {}).get("size")
-#     return render_template("doaj/public_data_dump.html",
-#                            show_article=show_article,
-#                            article_size=article_size,
-#                            show_journal=show_journal,
-#                            journal_size=journal_size)
-
-
 @blueprint.route("/public-data-dump/<record_type>")
+@api_key_required
 def public_data_dump_redirect(record_type):
-    # temporarily disable redirects to the data dump
-    abort(503)
-    # store_url = models.Cache.get_public_data_dump().get(record_type, {}).get("url")
-    # if store_url is None:
-    #     abort(404)
-    # if store_url.startswith("/"):
-    #     store_url = "/store" + store_url
-    # return redirect(store_url, code=307)
+    if not current_user.has_role(constants.ROLE_PUBLIC_DATA_DUMP):
+        abort(404)
+
+    target_data = models.Cache.get_public_data_dump().get(record_type, {})
+    if target_data is None:
+        abort(404)
+
+    main_store = store.StoreFactory.get(constants.STORE__SCOPE__PUBLIC_DATA_DUMP)
+    store_url = main_store.temporary_url(target_data.get("container"),
+                                         target_data.get("filename"),
+                                         timeout=app.config.get("PUBLIC_DATA_DUMP_URL_TIMEOUT", 3600))
+
+    if store_url.startswith("/"):
+        store_url = "/store" + store_url
+
+    return redirect(store_url, code=307)
 
 
 @blueprint.route("/store/<container>/<filename>")


### PR DESCRIPTION
… support authenticated only access to users with appropriate permission via an s3 presigned url

# Make public data dump available for selected users

*Please don't delete any sections when completing this PR template; instead enter **N/A** for checkboxes or sections which are not applicable, unless otherwise stated below*

See https://github.com/DOAJ/doajPM/issues/3515

This PR makes the following changes:

1. Changes how the public data dump is recorded in the local (app) cache, to recall the bucket and filename
2. Generates presigned urls when accessing the public data dump files
3. Places the retrieval of the presigned urls behind an authenticated web route which requires the user to hold the "public_data_dump" role

## Categorisation

This PR...
- [x] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Basic PR Checklist

- [ ] FeatureMap annotations have been added
- [x] Unit tests have been added/modified
- [x] **N/A** Functional tests have been added/modified
- [x] Code has been run manually in development, and functional tests followed locally
- [x] No deprecated methods are used
- [x] No magic strings/numbers - all strings are in `constants` or `messages` files
- [x] ES queries are wrapped in a Query object rather than inlined in the code
- [x] Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
- [x] If needed, migration has been created and tested locally
- [x] Cleaned up commented out code, etc
- [x] Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit#gid=1699519703&range=A2
- [x] **NA** Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
    - [ ] **NA**  Core model documentation: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - [ ] **NA** Events and consumers documentation: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
- [x] There has been a recent merge up from `develop` (or other base branch)
- [x] **NA** The docs for this branch have been generated and pushed to the doc site (see docs/README.md for details)

## Testing

No specific test exists for this, and it exists in a temporary situation, waiting to be replaced with a fuller system.

To test, this could be placed on the test server, the public data dump regenerated, and then users with/without the appropriate role could attempt to access the files.


## Deployment

What deployment considerations are there? (delete any sections you don't need)

### Configuration changes

There are no configuration changes required to deploy, but be aware that this introduces an optional new configuration value for configuring the store:

```
STORE_SCOPE_IMPL = {
# Enable this by scope in order to have different scopes store via different storage implementations
#     constants.STORE__SCOPE__PUBLIC_DATA_DUMP: "portality.store.StoreS3"
}
```

This will not have any effect on the deployment or any existing code, but in the future it allows us to store some items locally and some items remotely, all within the same storage framework.

### Scripts

Before the data dumps can be accessed, they must be regenerated; the existing data dump record in the cache will not be able to resolve.

```
python portality/scripts/public_data_dump.py
```

### Migrations

**N/A**

### Monitoring

No additional monitoring, but we should be aware of the resource usage in S3 and ensure that it remains within the free bandwidth usage

### New Infrastructure

**N/A**

### Continuous Integration

**N/A**


