### PR TITLE
Move config for dates library to prevent circular import

### DIFF
--- a/doajtest/unit/test_circular_import.py
+++ b/doajtest/unit/test_circular_import.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+
+class TestCircularImport(TestCase):
+
+    def test_import__anon_import(self):
+        from portality.scripts import anon_import  # noqa
+
+    def test_import__core(self):
+        from portality import core  # noqa
+
+    def test_import__app(self):
+        from portality import app  # noqa

--- a/portality/lib/dates.py
+++ b/portality/lib/dates.py
@@ -4,9 +4,36 @@ import math
 from datetime import datetime, timedelta
 from random import randint
 
-from portality.core import app
+# Extracted from settings.py to prevent circular import
+config = {
+    # when dates.format is called without a format argument, what format to use?
+    'DEFAULT_DATE_FORMAT': "%Y-%m-%dT%H:%M:%SZ",
 
-FMT_DATETIME_STD = app.config.get('DEFAULT_DATE_FORMAT', '%Y-%m-%dT%H:%M:%SZ')
+    # date formats that we know about, and should try, in order, when parsing
+    'DATE_FORMATS': [
+        "%Y-%m-%dT%H:%M:%S.%fZ",   # e.g. 2010-01-01T00:00:00.000Z
+        "%Y-%m-%dT%H:%M:%SZ",   # e.g. 2014-09-23T11:30:45Z
+        "%Y-%m-%d",             # e.g. 2014-09-23
+        "%d/%m/%y",             # e.g. 29/02/80
+        "%d/%m/%Y",             # e.g. 29/02/1980
+        "%d-%m-%Y",             # e.g. 01-01-2015
+        "%Y.%m.%d",             # e.g. 2014.09.12
+        "%d.%m.%Y",             # e.g. 12.9.2014
+        "%d.%m.%y",             # e.g. 12.9.14
+        "%d %B %Y",             # e.g. 21 June 2014
+        "%d-%b-%Y",             # e.g. 31-Jul-13
+        "%d-%b-%y",             # e.g. 31-Jul-2013
+        "%b-%y",                # e.g. Aug-13
+        "%B %Y",                # e.g. February 2014
+        "%Y"                    # e.g. 1978
+    ],
+
+    # The last_manual_update field was initialised to this value. Used to label as 'never'.
+    'DEFAULT_TIMESTAMP': "1970-01-01T00:00:00Z",
+}
+
+
+FMT_DATETIME_STD = config.get('DEFAULT_DATE_FORMAT', '%Y-%m-%dT%H:%M:%SZ')
 FMT_DATETIME_A = '%Y-%m-%d %H:%M:%S'
 FMT_DATETIME_MS_STD = '%Y-%m-%dT%H:%M:%S.%fZ'
 FMT_DATETIME_SHORT = '%Y%m%d_%H%M'
@@ -22,7 +49,7 @@ FMT_DATE_YMDOT = '%Y.%m'
 FMT_TIME_SHORT = '%H%M'
 FMT_YEAR = '%Y'
 
-DEFAULT_TIMESTAMP_VAL = app.config.get('DEFAULT_TIMESTAMP', '1970-01-01T00:00:00Z')
+DEFAULT_TIMESTAMP_VAL = config.get('DEFAULT_TIMESTAMP', '1970-01-01T00:00:00Z')
 
 
 def parse(s, format=None, guess=True) -> datetime:
@@ -35,7 +62,7 @@ def parse(s, format=None, guess=True) -> datetime:
             if not guess:
                 raise e
 
-    for f in app.config.get("DATE_FORMATS", []):
+    for f in config.get("DATE_FORMATS", []):
         try:
             return datetime.strptime(s, f)
         except ValueError as e:

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -1046,32 +1046,7 @@ BITLY_OAUTH_TOKEN = ""
 
 ###############################################
 # Date handling
-#
-# when dates.format is called without a format argument, what format to use?
-# FIXME: this is actually wrong - should really use the timezone correctly
-DEFAULT_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-
-# date formats that we know about, and should try, in order, when parsing
-DATE_FORMATS = [
-    "%Y-%m-%dT%H:%M:%S.%fZ",   # e.g. 2010-01-01T00:00:00.000Z
-    "%Y-%m-%dT%H:%M:%SZ",   # e.g. 2014-09-23T11:30:45Z
-    "%Y-%m-%d",             # e.g. 2014-09-23
-    "%d/%m/%y",             # e.g. 29/02/80
-    "%d/%m/%Y",             # e.g. 29/02/1980
-    "%d-%m-%Y",             # e.g. 01-01-2015
-    "%Y.%m.%d",             # e.g. 2014.09.12
-    "%d.%m.%Y",             # e.g. 12.9.2014
-    "%d.%m.%y",             # e.g. 12.9.14
-    "%d %B %Y",             # e.g. 21 June 2014
-    "%d-%b-%Y",             # e.g. 31-Jul-13
-    "%d-%b-%y",             # e.g. 31-Jul-2013
-    "%b-%y",                # e.g. Aug-13
-    "%B %Y",                # e.g. February 2014
-    "%Y"                    # e.g. 1978
-]
-
-# The last_manual_update field was initialised to this value. Used to label as 'never'.
-DEFAULT_TIMESTAMP = "1970-01-01T00:00:00Z"
+# See portality.lib.dates   - moved to prevent circular import
 
 #################################################
 # API configuration


### PR DESCRIPTION
# Fix circular import from `portality.dates`

See https://github.com/DOAJ/doajPM/issues/506 https://github.com/DOAJ/doajPM/issues/1724

Move config for dates library, because it was causing a circular import with `portality.core` when loading the application config. I'm not 100% sure this is the right approach - we could separate out the `dates` config instead if we prefer. Circularity occurs in `core.py`:

```python
def setup_jinja(app):
    # ...
    app.jinja_env.globals['dates'] = dates
```

because `dates` needs configuration keys before `app` is fully available

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Basic PR Checklist

Instructions for developers:
* For each checklist item, if it is N/A to your PR check the N/A box
* For each item that you have done and confirmed for yourself, check Developer box (including if you have checked the N/A box)

Instructions for reviewers:
* For each checklist item that has been confirmed by the Developer, check the Reviewer box if you agree
* For multiple reviewers, feel free to add your own checkbox with your github username next to it if that helps with review tracking

### Code Style

- No deprecated methods are used
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer

- No magic strings/numbers - all strings are in `constants` or `messages` files
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- ES queries are wrapped in a Query object rather than inlined in the code
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Cleaned up commented out code, etc
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer

### Testing

- Unit tests have been added/modified
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Functional tests have been added/modified
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Code has been run manually in development, and functional tests followed locally
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer

### Documentation

- FeatureMap annotations have been added
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer

- Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- The docs for this branch have been generated and pushed to the doc site (see docs/README.md for details)
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer


### Release Readiness

- If needed, migration has been created and tested locally
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer

- Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer

- There has been a recent merge up from `develop` (or other base branch).  List the dates of the merges up from develop below
  - [date of merge up]


## Testing

List the Functional Tests that must be run to confirm this feature

1. ...
2. ...



## Deployment

What deployment considerations are there? (delete any sections you don't need)

### Configuration changes

What configuration changes are included in this PR, and do we need to set specific values for production

### Scripts

What scripts need to be run from the PR (e.g. if this is a report generating feature), and when (once, regularly, etc).

### Migrations

What migrations need to be run to deploy this

### Monitoring

What additional monitoring is required of the application as a result of this feature

### New Infrastructure

What new infrastructure does this PR require (e.g. new services that need to run on the back-end).

### Continuous Integration

What CI changes are required for this


