### PR TITLE
fix sort options to use .exact field

### DIFF
--- a/portality/static/js/edges/admin.editor_groups.edge.js
+++ b/portality/static/js/edges/admin.editor_groups.edge.js
@@ -75,8 +75,8 @@ $.extend(true, doaj, {
                     sortOptions: [
                         {'display':'Created Date','field':'created_date'},
                         {'display':'Last Modified Date','field':'last_updated'},
-                        {'display':'Managing Editor ID','field':'maned'},
-                        {'display':'Editor ID','field':'editor'},
+                        {'display':'Managing Editor ID','field':'maned.exact'},
+                        {'display':'Editor ID','field':'editor.exact'},
                         {'display':'Group Name','field':'name.exact'}
                     ],
                     fieldOptions: [

--- a/portality/static/js/edges/admin.users.edge.js
+++ b/portality/static/js/edges/admin.users.edge.js
@@ -66,8 +66,8 @@ $.extend(true, doaj, {
                     sortOptions: [
                         {'display':'Created Date','field':'created_date'},
                         {'display':'Last Modified Date','field':'last_updated'},
-                        {'display':'User ID','field':'id'},
-                        {'display':'Email address','field':'email'}
+                        {'display':'User ID','field':'id.exact'},
+                        {'display':'Email address','field':'email.exact'}
                     ],
                     fieldOptions: [
                         {'display':'User ID','field':'id'},


### PR DESCRIPTION
# Fix sort options on user and editor group search

For: https://github.com/DOAJ/doajPM/issues/3651

Sort options on the user and editor group page were not using the `.exact` field, and as a result were causing ES errors which doesn't like to sort over analysed index fields.

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [x] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Basic PR Checklist

Instructions for developers:
* For each checklist item, if it is N/A to your PR check the N/A box
* For each item that you have done and confirmed for yourself, check Developer box (including if you have checked the N/A box)

Instructions for reviewers:
* For each checklist item that has been confirmed by the Developer, check the Reviewer box if you agree
* For multiple reviewers, feel free to add your own checkbox with your github username next to it if that helps with review tracking

### Code Style

- No deprecated methods are used
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- No magic strings/numbers - all strings are in `constants` or `messages` files
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- ES queries are wrapped in a Query object rather than inlined in the code
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Cleaned up commented out code, etc
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

### Testing

- Unit tests have been added/modified
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Functional tests have been added/modified
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Code has been run manually in development, and functional tests followed locally
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer

### Documentation

- FeatureMap annotations have been added
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- The docs for this branch have been generated and pushed to the doc site (see docs/README.md for details)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer


### Release Readiness

- If needed, migration has been created and tested locally
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- There has been a recent merge up from `develop` (or other base branch).  List the dates of the merges up from develop below
  - 2023-06-21


## Testing

Go to the user search in admin area and confirm that you can sort by all string-like fields

Do the same for the editor group search


## Deployment

What deployment considerations are there? - None


