### PR TITLE
isolang_2letter_lax along the same lines as currency_code_lax to allo…

### DIFF
--- a/doajtest/unit/api_tests/test_apiv3_crud_application.py
+++ b/doajtest/unit/api_tests/test_apiv3_crud_application.py
@@ -915,3 +915,70 @@ class TestCrudApplication(DoajTestCase):
                                      data=json.dumps(data))
                 assert resp.status_code == 400, resp.status_code
                 assert resp.json['error'].startswith("Field 'title' is required but not present at '[root]bibjson.'")
+
+    def test_19_applications_language_validator(self):
+        """ Ensure we get the correct validation messages via the API """
+        account = models.Account()
+        account.set_id("test")
+        account.set_name("Tester")
+        account.set_email("test@test.com")
+        account.set_role(["publisher", "api"])
+        api_key = account.generate_api_key()
+        account.save(blocking=True)
+
+        data = ApplicationFixtureFactory.incoming_application()
+
+        # Invalid language error comes from the model
+        data['bibjson']['language'][0] = 'mumbling quietly'
+        with self.assertRaises(Api400Error) as e2:
+            ApplicationsCrudApi.create(data, account=account)
+        assert str(e2.exception).startswith("Coerce with '<function to_isolang.")
+
+        # If you make a new application via tha API route a bad currency is caught by the model too:
+        with self.app_test.test_request_context():
+            with self.app_test.test_client() as t_client:
+                resp = t_client.post(url_for('api_v3.create_application') + f'?api_key={api_key}',
+                                     data=json.dumps(data))
+                assert resp.status_code == 400, resp.status_code
+                assert resp.json['error'].startswith("Coerce with '<function to_isolang.")
+
+        # But an outgoing application with the same problem is ok (we can read but not write these to the index)
+        assert data['bibjson']['language'][0] == 'mumbling quietly'
+        out_A = OutgoingApplication(data)
+        assert out_A.verify_against_struct() is None  # None means there's no verification errors
+
+        # An application already in the index can only be updated with a valid currency by API
+        grandfathered_app = ApplicationFixtureFactory.make_application_source()
+        del grandfathered_app['admin']['current_journal']
+        del grandfathered_app['admin']['related_journal']
+        grandfathered_app['admin']['application_type'] = 'new_application'
+        grandfathered_app['bibjson']['language'][0] = 'an old language we dont recognise'
+        grandfathered_app['admin']['owner'] = account.id
+        appl = models.Application(**grandfathered_app)
+        appl_id = appl.id
+        appl.save(blocking=True)
+
+        with self.app_test.test_request_context():
+            with self.app_test.test_client() as t_client:
+                resp = t_client.get(url_for('api_v3.retrieve_application', application_id=appl_id) + f'?api_key={api_key}',
+                                     data=json.dumps(data))
+                assert resp.status_code == 200, resp.status_code
+
+        retrieved_app = resp.json
+        assert retrieved_app['bibjson']['language'][0] == 'an old language we dont recognise'
+
+        # The same application is rejected when sent with the same invalid currency
+        with self.app_test.test_request_context():
+            with self.app_test.test_client() as t_client:
+                resp = t_client.put(url_for('api_v3.update_application', application_id=appl_id) + f'?api_key={api_key}',
+                                     data=json.dumps(retrieved_app))
+                assert resp.status_code == 400, resp.status_code
+                assert resp.json['error'].startswith("Coerce with '<function to_isolang.")
+
+        # Updated currency is fine
+        retrieved_app['bibjson']['language'][0] = 'EN'
+        with self.app_test.test_request_context():
+            with self.app_test.test_client() as t_client:
+                resp = t_client.put(url_for('api_v3.update_application', application_id=appl_id) + f'?api_key={api_key}',
+                                     data=json.dumps(retrieved_app))
+                assert resp.status_code == 204, resp.status_code

--- a/doajtest/unit/test_models.py
+++ b/doajtest/unit/test_models.py
@@ -1628,6 +1628,20 @@ class TestModels(DoajTestCase):
         a2 = models.Application(**asource)
         assert a2.bibjson().apc.pop() == {'currency': 'bananas', 'price': 2}
 
+    def test_38_language_lax(self):
+        """ Check we can open a journal / application model with an invalid currency but can't save it """
+        asource = ApplicationFixtureFactory.make_application_source()
+
+        # FARSI exists in the index as legacy data, but we usually accept it as Persian. It's supposed to be a code.
+        asource['bibjson']['language'] = ['FARSI']
+        a = models.Application(**asource)
+        assert a.bibjson().language_name() == ['FARSI']
+
+        # We could actually put complete nonsense in here if we wanted
+        asource['bibjson']['language'][0] = 'interpretive dance'
+        a2 = models.Application(**asource)
+        assert a2.bibjson().language.pop() == 'interpretive dance'
+
 
 class TestAccount(DoajTestCase):
     def test_get_name_safe(self):

--- a/portality/api/current/data_objects/application.py
+++ b/portality/api/current/data_objects/application.py
@@ -66,6 +66,10 @@ INCOMING_APPLICATION_REQUIREMENTS = {
 
     "structs": {
         "bibjson": {
+            "lists": {
+                # override for lax language enforcement in the core, making it strict for incoming applications
+                "language": {"contains": "field", "coerce": "isolang_2letter_strict"}
+            },
             "required": [
                 "copyright",
                 "deposit_policy",

--- a/portality/forms/application_forms.py
+++ b/portality/forms/application_forms.py
@@ -2930,7 +2930,7 @@ PYTHON_FUNCTIONS = {
             "no_script_tag": NoScriptTagBuilder.wtforms,
             "year": YearBuilder.wtforms,
             "current_iso_currency": CurrentISOCurrencyBuilder.wtforms,
-            "current_iso_language": CurrentISOLanguageBuilder
+            "current_iso_language": CurrentISOLanguageBuilder.wtforms
         }
     }
 }

--- a/portality/forms/application_forms.py
+++ b/portality/forms/application_forms.py
@@ -37,7 +37,8 @@ from portality.forms.validate import (
     OwnerExists,
     NoScriptTag,
     Year,
-    CurrentISOCurrency
+    CurrentISOCurrency,
+    CurrentISOLanguage
 )
 from portality.lib import dates
 from portality.lib.formulaic import Formulaic, WTFormsBuilder, FormulaicContext, FormulaicField
@@ -422,7 +423,8 @@ class FieldDefinitions:
             "initial": 5
         },
         "validate": [
-            {"required": {"message": "Enter <strong>at least one</strong> language"}}
+            {"required": {"message": "Enter <strong>at least one</strong> language"}},
+            "current_iso_language"
         ],
         "widgets": [
             {"select": {}},
@@ -2855,6 +2857,16 @@ class CurrentISOCurrencyBuilder:
     def wtforms(field, settings):
         return CurrentISOCurrency(settings.get("message"))
 
+
+class CurrentISOLanguageBuilder:
+    @staticmethod
+    def render(settings, html_attrs):
+        pass
+
+    @staticmethod
+    def wtforms(field, settings):
+        return CurrentISOLanguage(settings.get("message"))
+
 #########################################################
 # Crosswalks
 #########################################################
@@ -2917,7 +2929,8 @@ PYTHON_FUNCTIONS = {
             "owner_exists" : OwnerExistsBuilder.wtforms,
             "no_script_tag": NoScriptTagBuilder.wtforms,
             "year": YearBuilder.wtforms,
-            "current_iso_currency": CurrentISOCurrencyBuilder.wtforms
+            "current_iso_currency": CurrentISOCurrencyBuilder.wtforms,
+            "current_iso_language": CurrentISOLanguageBuilder
         }
     }
 }

--- a/portality/forms/validate.py
+++ b/portality/forms/validate.py
@@ -12,6 +12,7 @@ from portality.models import Journal, EditorGroup, Account
 from datetime import datetime
 from portality import regex
 from portality.datasets import get_currency_code
+from portality.lib import isolang
 
 
 class MultiFieldValidator(object):
@@ -640,5 +641,18 @@ class CurrentISOCurrency(object):
     def __call__(self, form, field):
         if field.data is not None and field.data != '':
             check = get_currency_code(field.data, fail_if_not_found=True)
+            if check is None:
+                raise validators.ValidationError(self.message)
+
+
+class CurrentISOLanguage(object):
+    def __init__(self, message=None):
+        if not message:
+            message = "Language is not in the currently supported ISO list"
+        self.message = message
+
+    def __call__(self, form, field):
+        if field.data is not None and field.data != '':
+            check = isolang.find(field.data)
             if check is None:
                 raise validators.ValidationError(self.message)

--- a/portality/lib/coerce.py
+++ b/portality/lib/coerce.py
@@ -24,7 +24,7 @@ def date_str(in_format=None, out_format=None):
     return datify
 
 
-def to_isolang(output_format=None):
+def to_isolang(output_format=None, fail_if_not_found=True):
     """
     :param output_format: format from input source to putput.  Must be one of:
         * alpha3
@@ -33,6 +33,7 @@ def to_isolang(output_format=None):
         * name
         * fr
     Can be a list in order of preference, too
+    :param fail_if_not_found: Whether to raise ValueError if there's no match or return the input unchanged
     ~~-> Languages:Data~~
     :return:
     """
@@ -49,8 +50,15 @@ def to_isolang(output_format=None):
         if val is None:
             return None
         l = dataset.find(val)
+
+        # If we didn't find the language, either raise an error or return the provided value
         if l is None:
-            raise ValueError("Unable to find iso code for language {x}".format(x=val))
+            if fail_if_not_found is True:
+                raise ValueError("Unable to find iso code for language {x}".format(x=val))
+            else:
+                return val
+
+        # Retrieve the correct output format from a successful match
         for f in output_format:
             v = l.get(f)
             if v is None or v == "":
@@ -64,6 +72,7 @@ def to_currency_code(fail_if_not_found=True):
     """
     ~~-> Currencies:Data~~
     :param val:
+    :param fail_if_not_found:
     :return:
     """
     def codify(val):
@@ -129,7 +138,8 @@ COERCE_MAP = {
     "utcdatetimemicros" : date_str(out_format=FMT_DATETIME_MS_STD),
     "bigenddate" : date_str(out_format=FMT_DATE_STD),
     "isolang": to_isolang(),
-    "isolang_2letter": to_isolang(output_format="alpha2"),
+    "isolang_2letter_strict": to_isolang(output_format="alpha2", fail_if_not_found=True),
+    "isolang_2letter_lax": to_isolang(output_format="alpha2", fail_if_not_found=False),
     "country_code": to_country_code,
     "issn" : to_issn,
     "currency_code_strict": to_currency_code(fail_if_not_found=True),

--- a/portality/models/v2/shared_structs.py
+++ b/portality/models/v2/shared_structs.py
@@ -17,7 +17,7 @@ JOURNAL_BIBJSON = {
             "lists" : {
                 "is_replaced_by" : {"coerce" : "issn", "contains" : "field", "set__allow_coerce_failure" : True},
                 "keywords" : {"contains" : "field", "coerce" : "unicode_lower"},
-                "language" : {"contains" : "field", "coerce" : "isolang_2letter"},
+                "language" : {"contains" : "field", "coerce" : "isolang_2letter_lax"},
                 "license" : {"contains" : "object"},
                 "replaces" : {"contains" : "field", "coerce" : "issn", "set__allow_coerce_failure" : True},
                 "subject" : {"contains" : "object"}

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -526,7 +526,17 @@ DATAOBJ_TO_MAPPING_DEFAULTS = {
             }
         }
     },
-    "isolang_2letter": {
+    "isolang_2letter_strict": {
+        "type": "text",
+        "fields": {
+            "exact": {
+                "type": "keyword",
+#                "index": False,
+                "store": True
+            }
+        }
+    },
+    "isolang_2letter_lax": {
         "type": "text",
         "fields": {
             "exact": {
@@ -546,7 +556,7 @@ DATAOBJ_TO_MAPPING_DEFAULTS = {
             }
         }
     },
-    "currency_code": {
+    "currency_code_strict": {
         "type": "text",
         "fields": {
             "exact": {


### PR DESCRIPTION
…w for old data in the index

# isolang_2letter_lax

See https://github.com/DOAJ/doajPM/issues/3598

This is a treatment of to_isolang similar to that of currency_code_lax - due to there being the string `FARSI` in the index instead of the code for the language 'Persian'.

Effects will be:
* You can now open the records with language FARSI
* You can run the anon export without coerce errors

Data will still be validated in  forms and API, using the CurrentISOLanguage validator.

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [x] affects the public site
- [x] affects the editorial area
- [x] affects the publisher area
- [ ] affects the monitoring

## Basic PR Checklist

Instructions for developers:
* For each checklist item, if it is N/A to your PR check the N/A box
* For each item that you have done and confirmed for yourself, check Developer box (including if you have checked the N/A box)

Instructions for reviewers:
* For each checklist item that has been confirmed by the Developer, check the Reviewer box if you agree
* For multiple reviewers, feel free to add your own checkbox with your github username next to it if that helps with review tracking

### Code Style

- No deprecated methods are used
  - [ ] N/A
  - [x] Developer
  - [x] Reviewer

- No magic strings/numbers - all strings are in `constants` or `messages` files
  - [ ] N/A
  - [x] Developer
  - [x] Reviewer
  
- ES queries are wrapped in a Query object rather than inlined in the code
  - [x] N/A
  - [ ] Developer
  - [x] Reviewer
  
- Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
  - [ ] N/A
  - [x] Developer
  - [x] Reviewer
  
- Cleaned up commented out code, etc
  - [ ] N/A
  - [x] Developer
  - [x] Reviewer

### Testing

- Unit tests have been added/modified
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer
  
- Functional tests have been added/modified
  - [x] N/A
  - [ ] Developer
  - [x] Reviewer
  
- Code has been run manually in development, and functional tests followed locally
  - [ ] N/A
  - [ ] Developer
  - [x] Reviewer

### Documentation

- FeatureMap annotations have been added
  - [x] N/A
  - [ ] Developer
  - [x] Reviewer
  
- Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
  - [x] N/A
  - [ ] Developer
  - [x] Reviewer
  
- Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
  - [x] N/A
  - [ ] Developer
  - [x] Reviewer

- Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
  - [x] N/A
  - [ ] Developer
  - [x] Reviewer
  
- The docs for this branch have been generated and pushed to the doc site (see docs/README.md for details)
  - [x] N/A
  - [ ] Developer
  - [x] Reviewer


### Release Readiness

- If needed, migration has been created and tested locally
  - [x] N/A
  - [ ] Developer
  - [x] Reviewer

- Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer

- There has been a recent merge up from `develop` (or other base branch).  List the dates of the merges up from develop below
  - [date of merge up]


## Testing

List the Functional Tests that must be run to confirm this feature

Application form run-through

## Deployment

What deployment considerations are there? (delete any sections you don't need)

### Configuration changes

Changes to settings.py for new mapping, not overridden in production so we should be fine.

### Scripts

n/a

### Migrations

n/a


