### PR TITLE
add testdrive feature as a stand-alone commit

### DIFF
--- a/doajtest/testdrive/factory.py
+++ b/doajtest/testdrive/factory.py
@@ -1,0 +1,25 @@
+from portality.lib import plugin
+import random
+import string
+
+
+class TestDrive():
+    def create_random_str(self, n_char=10):
+        s = string.ascii_letters + string.digits
+        return ''.join(random.choices(s, k=n_char))
+
+    def setup(self) -> dict:
+        return {"status": "not implemented"}
+
+    def teardown(self, setup_params) -> dict:
+        return {"status": "not implemented"}
+
+
+class TestFactory():
+    @classmethod
+    def get(cls, test_id):
+        modname = test_id
+        classname = test_id.replace("_", " ").title().replace(" ", "")
+        classpath = "doajtest.testdrive." + modname + "." + classname
+        klazz = plugin.load_class(classpath)
+        return klazz()

--- a/doajtest/testdrive/todo_associate.py
+++ b/doajtest/testdrive/todo_associate.py
@@ -1,0 +1,104 @@
+from portality import constants
+from doajtest.testdrive.factory import TestDrive
+from doajtest.fixtures.v2.applications import ApplicationFixtureFactory
+from portality.lib import dates
+from portality import models
+from datetime import datetime
+
+
+class TodoAssociate(TestDrive):
+
+    def setup(self) -> dict:
+        un = self.create_random_str()
+        pw = self.create_random_str()
+        acc = models.Account.make_account(un + "@example.com", un, "TodoAssociate " + un, [constants.ROLE_ASSOCIATE_EDITOR])
+        acc.set_password(pw)
+        acc.save()
+
+        gn = "TodoAssociate Group " + un
+        eg = models.EditorGroup(**{
+            "name": gn
+        })
+        eg.add_associate(acc.id)
+        eg.save()
+
+        apps = build_applications(un)
+
+        return {
+            "account": {
+                "username": acc.id,
+                "password": pw
+            },
+            "editor_group": {
+                "id": eg.id,
+                "name": eg.name
+            },
+            "applications": apps
+        }
+
+    def teardown(self, params) -> dict:
+        models.Account.remove_by_id(params["account"]["username"])
+        models.EditorGroup.remove_by_id(params["editor_group"]["id"])
+        for nature, details in params["applications"].items():
+            for detail in details:
+                models.Application.remove_by_id(detail["id"])
+        return {"status": "success"}
+
+
+def build_applications(un):
+    w = 7 * 24 * 60 * 60
+
+    apps = {}
+
+    app = build_application(un + " Stalled Application", 3 * w, 3 * w,
+                                 constants.APPLICATION_STATUS_IN_PROGRESS, editor=un)
+    app.save()
+    apps["stalled"] = [{
+        "id": app.id,
+        "title": un + " Stalled Application"
+    }]
+
+    app = build_application(un + " Old Application", 6 * w, 6 * w, constants.APPLICATION_STATUS_IN_PROGRESS,
+                                 editor=un)
+    app.save()
+    apps["old"] = [{
+        "id": app.id,
+        "title": un + " Old Application"
+    }]
+
+    app = build_application(un + " Pending Application", 1 * w, 1 * w, constants.APPLICATION_STATUS_PENDING,
+                                 editor=un)
+    app.save()
+    apps["pending"] = [{
+        "id": app.id,
+        "title": un + " Pending Application"
+    }]
+
+    app = build_application(un + " All Other Applications", 2 * w, 2 * w,
+                                 constants.APPLICATION_STATUS_IN_PROGRESS, editor=un)
+    app.save()
+    apps["all"] = [{
+        "id": app.id,
+        "title": un + " All Other Applications"
+    }]
+
+    return apps
+
+
+def build_application(title, lmu_diff, cd_diff, status, editor=None):
+    source = ApplicationFixtureFactory.make_application_source()
+    ap = models.Application(**source)
+    ap.bibjson().title = title
+    ap.remove_current_journal()
+    ap.remove_related_journal()
+    ap.application_type = constants.APPLICATION_TYPE_NEW_APPLICATION
+    ap.set_id(ap.makeid())
+    ap.set_last_manual_update(dates.before(datetime.utcnow(), lmu_diff))
+    ap.set_created(dates.before(datetime.utcnow(), cd_diff))
+    ap.set_application_status(status)
+
+    if editor is not None:
+        ap.set_editor(editor)
+
+    ap.save()
+    return ap

--- a/portality/app.py
+++ b/portality/app.py
@@ -47,6 +47,9 @@ from portality.view.status import blueprint as status
 from portality.lib.normalise import normalise_doi
 from portality.view.dashboard import blueprint as dashboard
 
+if app.config.get("DEBUG", False):
+    from portality.view.testdrive import blueprint as testdrive
+
 app.register_blueprint(account, url_prefix='/account') #~~->Account:Blueprint~~
 app.register_blueprint(admin, url_prefix='/admin') #~~-> Admin:Blueprint~~
 app.register_blueprint(publisher, url_prefix='/publisher') #~~-> Publisher:Blueprint~~
@@ -75,6 +78,9 @@ app.register_blueprint(oaipmh) # ~~-> OAIPMH:Blueprint~~
 app.register_blueprint(openurl) # ~~-> OpenURL:Blueprint~~
 app.register_blueprint(atom) # ~~-> Atom:Blueprint~~
 app.register_blueprint(doaj) # ~~-> DOAJ:Blueprint~~
+
+if app.config.get("DEBUG", False):
+    app.register_blueprint(testdrive, url_prefix="/testdrive") # ~~-> Testdrive:Feature ~~
 
 # initialise the index - don't put into if __name__ == '__main__' block,
 # because that does not run if gunicorn is loading the app, as opposed

--- a/portality/view/testdrive.py
+++ b/portality/view/testdrive.py
@@ -1,0 +1,39 @@
+from flask import Blueprint, make_response, abort, url_for, request
+from flask_login import current_user, login_required
+from doajtest.testdrive.factory import TestFactory
+from portality import util
+from portality.core import app
+import json
+from urllib import parse
+
+# ~~Testdrive:Blueprint->$Testdrive:Feature~~
+blueprint = Blueprint('testdrive', __name__)
+
+@blueprint.route('/<test_id>')
+@util.jsonp
+@login_required
+def testdrive(test_id):
+    # if not app.config.get("DEBUG", False):
+    #     abort(404)
+    test = TestFactory.get(test_id)
+    if not test:
+        abort(404)
+    params = test.setup()
+    teardown = app.config.get("BASE_URL") + url_for("testdrive.teardown", test_id=test_id) + "?d=" + parse.quote_plus(json.dumps(params))
+    params["teardown"] = teardown
+    resp = make_response(json.dumps(params))
+    resp.mimetype = "application/json"
+    return resp
+
+
+@blueprint.route("/<test_id>/teardown")
+@util.jsonp
+@login_required
+def teardown(test_id):
+    test = TestFactory.get(test_id)
+    if not test:
+        abort(404)
+    result = test.teardown(json.loads(request.values.get("d")))
+    resp = make_response(json.dumps(result))
+    resp.mimetype = "application/json"
+    return resp


### PR DESCRIPTION
# Adds Testdrive to the main application

*Please don't delete any sections when completing this PR template; instead enter **N/A** for checkboxes or sections which are not applicable, unless otherwise stated below*

See https://github.com/DOAJ/doajPM/issues/3665

This PR pulls testdrive out of the editorial dashboard branch, and makes it available to merge so that other developments can take advantage of it

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Basic PR Checklist

Instructions for developers:
* For each checklist item, if it is N/A to your PR check the N/A box
* For each item that you have done and confirmed for yourself, check Developer box (including if you have checked the N/A box)

Instructions for reviewers:
* For each checklist item that has been confirmed by the Developer, check the Reviewer box if you agree
* For multiple reviewers, feel free to add your own checkbox with your github username next to it if that helps with review tracking

### Code Style

- No deprecated methods are used
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer

- No magic strings/numbers - all strings are in `constants` or `messages` files
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer
  
- ES queries are wrapped in a Query object rather than inlined in the code
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer
  
- Cleaned up commented out code, etc
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer

### Testing

- Unit tests have been added/modified
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Functional tests have been added/modified
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Code has been run manually in development, and functional tests followed locally
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer

### Documentation

- FeatureMap annotations have been added
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer
  
- Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- The docs for this branch have been generated and pushed to the doc site (see docs/README.md for details)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer


### Release Readiness

- If needed, migration has been created and tested locally
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- There has been a recent merge up from `develop` (or other base branch).  List the dates of the merges up from develop below
  - 2023-07-04


## Testing

You can confirm that the test drive is working by running in DEBUG mode, and then hitting this url

http://localhost:5004/testdrive/todo_associate

If you then turn DEBUG mode off and do the same thing, you should get a 404



## Deployment

There are no deployment considerations.

Testdrive only activates when DEBUG mode is on.  Testdrive endpoints can only be triggered by an authenticated user (no role restriction is applied).

