### PR TITLE
Increase number of results for publishers countries facet to 200 

### DIFF
--- a/portality/static/js/edges/public.journal.edge.js
+++ b/portality/static/js/edges/public.journal.edge.js
@@ -169,7 +169,7 @@ $.extend(true, doaj, {
                     category: "facet",
                     field: "index.country.exact",
                     display: "Publishers' countries",
-                    size: 100,
+                    size: 200,
                     syncCounts: false,
                     lifecycle: "update",
                     updateType: "fresh",


### PR DESCRIPTION
There are 195 countries in the World as of 31/07/2023 - increase the facets result to 200 to exceed this number.

[#3488](https://github.com/DOAJ/doajPM/issues/3488)