### PR TITLE
Accessible radiobuttons and checkboxes

### DIFF
--- a/cms/sass/base/_general.scss
+++ b/cms/sass/base/_general.scss
@@ -261,7 +261,22 @@ select {
 
 input[type="checkbox"],
 input[type="radio"] {
-  display: none;
+  //display: none;
+
+  opacity: 0;
+  width: 0.8em;
+  height: 0.8em;
+  margin-left: -0.8rem;
+
+  &:focus  + label {
+    outline: dashed 2px lightgrey;
+    outline-offset: 1px;
+  }
+
+  &:focus:not(:focus-visible){
+    outline: none;
+  }
+
 
   + label {
     margin: 0 0 $spacing-03 0;

--- a/cms/sass/components/_filters.scss
+++ b/cms/sass/components/_filters.scss
@@ -50,6 +50,7 @@
   max-height: $spacing-07;
   height: auto;
   overflow-y: auto;
+  padding-top: $spacing-01;
   @include unstyled-list;
 
   li {

--- a/cms/sass/components/_form.scss
+++ b/cms/sass/components/_form.scss
@@ -45,10 +45,13 @@
     &[type="number"] {
       width: 25%;
     }
+    &[type="radio"], &[type="checkbox"] {
+      width: 0.8rem;
+    }
   }
 
   input[type="checkbox"] + label {
-    display: table;
+    display: unset;
   }
 
   input[type="checkbox"] + label,

--- a/doajtest/testbook/public_site/public_search.yml
+++ b/doajtest/testbook/public_site/public_search.yml
@@ -166,3 +166,11 @@ tests:
     results:
     - You are taken to the full text of this article on the Web. It opens in a new
       tab
+  - step: Click tab
+    results:
+      - focus is on the list of checkboxes
+    results:
+      - focus is clearly marked by the outline
+      - step: click spacebar to check the filter
+        results:
+          - filter is applied


### PR DESCRIPTION
# Make sure search facets are accessible for screenreader and keyboard users
2nd approach, it is important to make sure that changes are applied correctly everywhere across the service (including facets and application form).

*Please don't delete any sections when completing this PR template; instead enter **N/A** for checkboxes or sections which are not applicable, unless otherwise stated below*

[See 3402](https://github.com/DOAJ/doajPM/issues/3402)

Describe the scope/purpose of the PR here in as much detail as you like

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [x] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Basic PR Checklist

Instructions for developers:
* For each checklist item, if it is N/A to your PR check the N/A box
* For each item that you have done and confirmed for yourself, check Developer box (including if you have checked the N/A box)

Instructions for reviewers:
* For each checklist item that has been confirmed by the Developer, check the Reviewer box if you agree
* For multiple reviewers, feel free to add your own checkbox with your github username next to it if that helps with review tracking

### Code Style

- No deprecated methods are used
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- No magic strings/numbers - all strings are in `constants` or `messages` files
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- ES queries are wrapped in a Query object rather than inlined in the code
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Cleaned up commented out code, etc
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

### Testing

- Unit tests have been added/modified
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Functional tests have been added/modified
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer
  
- Code has been run manually in development, and functional tests followed locally
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

### Documentation

- FeatureMap annotations have been added
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- The docs for this branch have been generated and pushed to the doc site (see docs/README.md for details)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer


### Release Readiness

- If needed, migration has been created and tested locally
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- There has been a recent merge up from ~~`develop`~~ `[feature/3400_dropdown_facets_cofigured_for_screenreaders](https://github.com/DOAJ/doaj/tree/feature/3400_dropdown_facets_cofigured_for_screenreaders)` (or other base branch).  List the dates of the merges up from develop below
31/08/2023


## Testing

List the Functional Tests that must be run to confirm this feature

1. [Public Search](https://doaj.github.io/doaj-docs/feature/3402_facets_accessibility/testbook/index.html)
2. Have a look at the application form and other searches (both public and other) to make sure the checkboxes and radiobuttons are displayed correctly