### PR TITLE
Feature/3400 accordion accessibility

### DIFF
--- a/portality/static/js/doaj.fieldrender.edges.js
+++ b/portality/static/js/doaj.fieldrender.edges.js
@@ -645,7 +645,7 @@ $.extend(true, doaj, {
                     toggle = '<span data-feather="chevron-down" aria-hidden="true"></span>';
                 }
                 var placeholder = 'Search ' + this.component.nodeCount + ' subjects';
-                var frag = '<div class="accordion"><h3 class="label label--secondary filter__heading" id="' + toggleId + '"><button class="aria-button" aria-expanded="false">' + this.title + toggle + '</button></h3>\
+                var frag = '<div class="accordion"><h3 class="label label--secondary filter__heading"><button class="aria-button" aria-expanded="false" aria-controls="' + resultsId + '" id="' + toggleId + '">' + this.title + toggle + '</button></h3>\
                     <div class="filter__body collapse" style="height: 0px" id="' + resultsId + '">\
                         <label for="' + searchId + '" class="sr-only">' + placeholder + '</label>\
                         <input type="text" name="' + searchId + '" id="' + searchId + '" class="filter__search" placeholder="' + placeholder + '">\
@@ -1832,7 +1832,7 @@ $.extend(true, doaj, {
                 if (this.togglable) {
                     toggle = '<span data-feather="chevron-down" aria-hidden="true"></span>';
                 }
-                var frag = '<div class="accordion"><h3 class="label label--secondary filter__heading" id="' + toggleId + '"><button class="aria-button" aria-expanded="false">' + this.component.display + toggle + '</button></h3>\
+                var frag = '<div class="accordion"><h3 class="label label--secondary filter__heading"><button class="aria-button" aria-expanded="false" aria-controls="' + resultsId + '" id="' + toggleId + '">' + this.component.display + toggle + '</button></h3>\
                     <div class="filter__body collapse"  style="height: 0px" id="' + resultsId + '">\
                         <ul class="filter__choices">{{FILTERS}}</ul>\
                     </div></div>';
@@ -1887,6 +1887,7 @@ $.extend(true, doaj, {
 
                     results.addClass("in").attr("aria-expanded", "true").css({"height": ""});
                     toggle.removeClass("collapsed").attr("aria-expanded", "true");
+
                 } else {
                     //var i = toggle.find("i");
                     //for (var j = 0; j < closeBits.length; j++) {
@@ -1894,7 +1895,7 @@ $.extend(true, doaj, {
                     // }
                     //for (var j = 0; j < openBits.length; j++) {
                     //   i.addClass(openBits[j]);
-                    //}
+                    //}s
                     //results.hide();
 
                     results.removeClass("in").attr("aria-expanded", "false").css({"height" : "0px"});
@@ -2083,15 +2084,14 @@ $.extend(true, doaj, {
                 if (this.togglable) {
                     toggle = '<span data-feather="chevron-down" aria-hidden="true"></span>';
                 }
-                var frag = '<div class="accordion"><h3 class="label label--secondary filter__heading" id="' + toggleId + '"><button class="aria-button" aria-expanded="false">' + this.component.display + toggle + '</button></h3>\
+                var frag = '<div class="accordion"><h3 class="label label--secondary filter__heading"><button class="aria-button" aria-expanded="false" aria-controls="' + resultsId + '" id="' + toggleId + '">' + this.component.display + toggle + '</button></h3>\
                     <div class="filter__body collapse" style="height: 0px" id="' + resultsId + '">\
                         <ul class="filter__choices">{{FILTERS}}</ul>\
                     </div></div>';
 
                 // substitute in the component parts
                 frag = frag.replace(/{{FILTERS}}/g, filterFrag + results);
-
-                // now render it into the page
+                // now render it into the pages
                 ts.context.html(frag);
                 feather.replace();
 


### PR DESCRIPTION
Make sure collapsible facets in the search page are accessible for screenreaders announcing the state of the accordion ("collapsed" and "expanded")

*Please don't delete any sections when completing this PR template; instead enter **N/A** for checkboxes or sections which are not applicable, unless otherwise stated below*

**important** based on `hotfix/3402_facets_accessibility_rerelease`, should be released later

[See #3400](https://github.com/DOAJ/doajPM/issues/3400)

`aria-expanded` needs to be added to the interactive element (i.e. `button`) rather than `h3`

## Categorisation

This PR...(or other base branch)
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [x] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Basic PR Checklist

Instructions for developers:
* For each checklist item, if it is N/A to your PR check the N/A box
* For each item that you have done and confirmed for yourself, check Developer box (including if you have checked the N/A box)

Instructions for reviewers:
* For each checklist item that has been confirmed by the Developer, check the Reviewer box if you agree
* For multiple reviewers, feel free to add your own checkbox with your github username next to it if that helps with review tracking

### Code Style

- No deprecated methods are used
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- No magic strings/numbers - all strings are in `constants` or `messages` files
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- ES queries are wrapped in a Query object rather than inlined in the code
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Cleaned up commented out code, etc
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer

- Urls are constructed with `url_for` not hard-coded
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
### Testing

- Unit tests have been added/modified
  - [ ] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Functional tests have been added/modified
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer
  
- Code has been run manually in development, and functional tests followed locally
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer

- Have CSS/style changes been implemented?  If they are of a global scope (e.g. on base HTML elements) have the downstream impacts of the change in other areas of the system been considered?
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

### Documentation

- FeatureMap annotations have been added
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- The docs for this branch have been generated and pushed to the doc site (see docs/README.md for details)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer


### Release Readiness

- If needed, migration has been created and tested locally
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- There has been a recent merge up from `hotfix/3402_facets_accessibility_rerelease` .  List the dates of the merges up from develop below
  - 24/09/2023 from 


## Testing

List the Functional Tests that must be run to confirm this feature

1. doajtest/testbook/public_site/public_search.yml




## Deployment

What deployment considerations are there? (delete any sections you don't need)

### Configuration changes

What configuration changes are included in this PR, and do we need to set specific values for production

### Scripts

What scripts need to be run from the PR (e.g. if this is a report generating feature), and when (once, regularly, etc).

### Migrations

What migrations need to be run to deploy this

### Monitoring

What additional monitoring is required of the application as a result of this feature

### New Infrastructure

What new infrastructure does this PR require (e.g. new services that need to run on the back-end).

### Continuous Integration

What CI changes are required for this


