### PR TITLE
reactivate autocomplete on publisher field

### DIFF
--- a/portality/forms/application_forms.py
+++ b/portality/forms/application_forms.py
@@ -169,18 +169,21 @@ class FieldDefinitions:
         "contexts": {
             "admin": {
                 "widgets": [
+                    "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             },
             "editor": {
                 "disabled": True,
                 "widgets": [
+                    "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             },
             "associate_editor": {
                 "disabled": True,
                 "widgets": [
+                    "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             },
@@ -212,16 +215,19 @@ class FieldDefinitions:
             },
             "admin": {
                 "widgets": [
+                    "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             },
             "associate_editor": {
                 "widgets": [
+                    "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             },
             "editor": {
                 "widgets": [
+                    "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             }
@@ -486,16 +492,22 @@ class FieldDefinitions:
             },
             "admin": {
                 "widgets": [
+                    "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
+                    {"autocomplete": {"type": "journal", "field": "bibjson.publisher.name.exact"}},
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             },
             "associate_editor": {
                 "widgets": [
+                    "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
+                    {"autocomplete": {"type": "journal", "field": "bibjson.publisher.name.exact"}},
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             },
             "editor": {
                 "widgets": [
+                    "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
+                    {"autocomplete": {"type": "journal", "field": "bibjson.publisher.name.exact"}},
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             }

--- a/portality/forms/application_forms.py
+++ b/portality/forms/application_forms.py
@@ -480,7 +480,7 @@ class FieldDefinitions:
         ],
         "widgets": [
             "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
-            {"autocomplete": {"type" : "journal", "field": "bibjson.publisher.name.exact"}},
+            {"autocomplete": {"type" : "journal", "field": "bibjson.publisher.name.exact"}}, # ~~^-> Autocomplete:FormWidget~~
             "full_contents" # ~~^->FullContents:FormWidget~~
         ],
         "help": {
@@ -493,21 +493,21 @@ class FieldDefinitions:
             "admin": {
                 "widgets": [
                     "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
-                    {"autocomplete": {"type": "journal", "field": "bibjson.publisher.name.exact"}},
+                    {"autocomplete": {"type": "journal", "field": "bibjson.publisher.name.exact"}}, # ~~^-> Autocomplete:FormWidget~~
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             },
             "associate_editor": {
                 "widgets": [
                     "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
-                    {"autocomplete": {"type": "journal", "field": "bibjson.publisher.name.exact"}},
+                    {"autocomplete": {"type": "journal", "field": "bibjson.publisher.name.exact"}}, # ~~^-> Autocomplete:FormWidget~~
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             },
             "editor": {
                 "widgets": [
                     "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
-                    {"autocomplete": {"type": "journal", "field": "bibjson.publisher.name.exact"}},
+                    {"autocomplete": {"type": "journal", "field": "bibjson.publisher.name.exact"}}, # ~~^-> Autocomplete:FormWidget~~
                     "click_to_copy",  # ~~^-> ClickToCopy:FormWidget~~
                 ]
             }
@@ -577,7 +577,7 @@ class FieldDefinitions:
         },
         "widgets": [
             "trim_whitespace",  # ~~^-> TrimWhitespace:FormWidget~~
-            {"autocomplete": {"type" : "journal", "field": "bibjson.institution.name.exact"}},
+            {"autocomplete": {"type" : "journal", "field": "bibjson.institution.name.exact"}}, # ~~^-> Autocomplete:FormWidget~~
             "full_contents" # ~~^->FullContents:FormWidget~~
         ]
     }
@@ -1651,7 +1651,7 @@ class FieldDefinitions:
             "owner_exists"
         ],
         "widgets": [
-            {"autocomplete": {"type" : "account", "field": "id", "include" : False}},
+            {"autocomplete": {"type" : "account", "field": "id", "include" : False}}, # ~~^-> Autocomplete:FormWidget~~
             "clickable_owner"
         ],
         "contexts" : {
@@ -1709,7 +1709,7 @@ class FieldDefinitions:
         "label": "Group",
         "input": "text",
         "widgets": [
-            {"autocomplete": {"type" : "editor_group", "field": "name", "include" : False}}
+            {"autocomplete": {"type" : "editor_group", "field": "name", "include" : False}} # ~~^-> Autocomplete:FormWidget~~
         ],
         "contexts" : {
             "editor" : {
@@ -1717,7 +1717,7 @@ class FieldDefinitions:
             },
             "admin" : {
                 "widgets" : [
-                    {"autocomplete": {"type": "editor_group", "field": "name", "include" : False}},
+                    {"autocomplete": {"type": "editor_group", "field": "name", "include" : False}}, # ~~^-> Autocomplete:FormWidget~~
                     {"load_editors" : {"field" : "editor"}}
                 ]
             }


### PR DESCRIPTION
# Reactivates deactivated autocomplete on publisher field

*Please don't delete any sections when completing this PR template; instead enter **N/A** for checkboxes or sections which are not applicable, unless otherwise stated below*

See https://github.com/DOAJ/doajPM/issues/3719

When the click-to-copy change was added, the autocomplete on the field was mistakenly removed, this re-adds it

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [x] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Basic PR Checklist

Instructions for developers:
* For each checklist item, if it is N/A to your PR check the N/A box
* For each item that you have done and confirmed for yourself, check Developer box (including if you have checked the N/A box)

Instructions for reviewers:
* For each checklist item that has been confirmed by the Developer, check the Reviewer box if you agree
* For multiple reviewers, feel free to add your own checkbox with your github username next to it if that helps with review tracking

### Code Style

- No deprecated methods are used
  - [ ] N/A
  - [x] Developer
  - [x] Reviewer

- No magic strings/numbers - all strings are in `constants` or `messages` files
  - [ ] N/A
  - [x] Developer
  - [x] Reviewer
  
- ES queries are wrapped in a Query object rather than inlined in the code
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
  - [ ] N/A
  - [x] Developer
  - [x] Reviewer
  
- Cleaned up commented out code, etc
  - [ ] N/A
  - [x] Developer
  - [x] Reviewer

- Urls are constructed with `url_for` not hard-coded
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
### Testing

- Unit tests have been added/modified
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Functional tests have been added/modified
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Code has been run manually in development, and functional tests followed locally
  - [ ] N/A
  - [x] Developer
  - [x] Reviewer

- Have CSS/style changes been implemented?  If they are of a global scope (e.g. on base HTML elements) have the downstream impacts of the change in other areas of the system been considered?
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

### Documentation

- FeatureMap annotations have been added
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- The docs for this branch have been generated and pushed to the doc site (see docs/README.md for details)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer


### Release Readiness

- If needed, migration has been created and tested locally
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- There has been a recent merge up from `develop` (or other base branch).  List the dates of the merges up from develop below
  - 2023-10-05


## Testing

To test this just confirm that the autocomplete is available on the publisher name field in the admin area



## Deployment

What deployment considerations are there? (delete any sections you don't need)

### Configuration changes

What configuration changes are included in this PR, and do we need to set specific values for production

### Scripts

What scripts need to be run from the PR (e.g. if this is a report generating feature), and when (once, regularly, etc).

### Migrations

What migrations need to be run to deploy this

### Monitoring

What additional monitoring is required of the application as a result of this feature

### New Infrastructure

What new infrastructure does this PR require (e.g. new services that need to run on the back-end).

### Continuous Integration

What CI changes are required for this


