### PR TITLE
Reduce logging via config and reinstate journalcsv schedule

### DIFF
--- a/portality/settings.py
+++ b/portality/settings.py
@@ -423,11 +423,14 @@ HUEY_EAGER = False
 # Crontab for never running a job - February 31st (use to disable tasks)
 CRON_NEVER = {"month": "2", "day": "31", "day_of_week": "*", "hour": "*", "minute": "*"}
 
+# Additional Logging for scheduled JournalCSV
+EXTRA_JOURNALCSV_LOGGING = False
+
 #  Crontab schedules must be for unique times to avoid delays due to perceived race conditions
 HUEY_SCHEDULE = {
     "sitemap": {"month": "*", "day": "*", "day_of_week": "*", "hour": "8", "minute": "0"},
     "reporting": {"month": "*", "day": "1", "day_of_week": "*", "hour": "0", "minute": "0"},
-    "journal_csv": CRON_NEVER,  # {"month": "*", "day": "*", "day_of_week": "*", "hour": "*", "minute": "20"},
+    "journal_csv": {"month": "*", "day": "*", "day_of_week": "*", "hour": "*", "minute": "20"},
     "read_news": {"month": "*", "day": "*", "day_of_week": "*", "hour": "*", "minute": "30"},
     "article_cleanup_sync": {"month": "*", "day": "2", "day_of_week": "*", "hour": "0", "minute": "0"},
     "async_workflow_notifications": {"month": "*", "day": "*", "day_of_week": "1", "hour": "5", "minute": "0"},

--- a/portality/tasks/journal_csv.py
+++ b/portality/tasks/journal_csv.py
@@ -19,12 +19,18 @@ class JournalCSVBackgroundTask(BackgroundTask):
         def logger(msg):
             self.background_job.add_audit_message(msg)
 
+        _l = logger if app.config.get('EXTRA_JOURNALCSV_LOGGING', False) else None
+
         job = self.background_job
 
         journalService = DOAJ.journalService()
-        url, action_register = journalService.csv(logger=logger)
-        # for ar in action_register:
-        #     job.add_audit_message(ar)
+        url, action_register = journalService.csv(logger=_l)
+
+        # Log directly to the task if we don't have extra logging configured
+        if _l is None:
+            for ar in action_register:
+                job.add_audit_message(ar)
+
         job.add_audit_message("CSV generated; will be served from {y}".format(y=url))
 
     def cleanup(self):


### PR DESCRIPTION
# Reinstate Scheduled Journalcsv

See https://github.com/DOAJ/doajPM/issues/3726

Just rescheduling the journalcsv

## Categorisation

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [x] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Basic PR Checklist

Instructions for developers:
* For each checklist item, if it is N/A to your PR check the N/A box
* For each item that you have done and confirmed for yourself, check Developer box (including if you have checked the N/A box)

Instructions for reviewers:
* For each checklist item that has been confirmed by the Developer, check the Reviewer box if you agree
* For multiple reviewers, feel free to add your own checkbox with your github username next to it if that helps with review tracking

### Code Style

- No deprecated methods are used
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer

- No magic strings/numbers - all strings are in `constants` or `messages` files
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer
  
- ES queries are wrapped in a Query object rather than inlined in the code
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer
  
- Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer
  
- Cleaned up commented out code, etc
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer

- Urls are constructed with `url_for` not hard-coded
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer
### Testing

- Unit tests have been added/modified
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Functional tests have been added/modified
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Code has been run manually in development, and functional tests followed locally
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer

- Have CSS/style changes been implemented?  If they are of a global scope (e.g. on base HTML elements) have the downstream impacts of the change in other areas of the system been considered?
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

### Documentation

- FeatureMap annotations have been added
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Documentation updates - if needed - have been identified and prepared for inclusion into main documentation (e.g. added and highlighted/commented as appropriate to this PR)
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer
  
- The docs for this branch have been generated and pushed to the doc site (see docs/README.md for details)
  - [ ] N/A
  - [x] Developer
  - [ ] Reviewer


### Release Readiness

- If needed, migration has been created and tested locally
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- Release sheet has been created, and completed as far as is possible https://docs.google.com/spreadsheets/d/1Bqx23J1MwXzjrmAygbqlU3YHxN1Wf7zkkRv14eTVLZQ/edit
  - [x] N/A
  - [ ] Developer
  - [ ] Reviewer

- There has been a recent merge up from `develop` (or other base branch).  List the dates of the merges up from develop below
  -  2023-10-23


## Testing

List the Functional Tests that must be run to confirm this feature

1. ...
2. ...



## Deployment

What deployment considerations are there? (delete any sections you don't need)

### Configuration changes
New config key in `settings.py` - defaulted to `False` in the main file - changes not needed unless we'd like to see the logs.

### Scripts

What scripts need to be run from the PR (e.g. if this is a report generating feature), and when (once, regularly, etc).

### Migrations

What migrations need to be run to deploy this

### Monitoring

What additional monitoring is required of the application as a result of this feature

### New Infrastructure

What new infrastructure does this PR require (e.g. new services that need to run on the back-end).

### Continuous Integration

What CI changes are required for this


