### PR TITLE
modify the script to split the results into 2-3 files

### DIFF
--- a/portality/scripts/230609_find_articles_with_invalid_issns.py
+++ b/portality/scripts/230609_find_articles_with_invalid_issns.py
@@ -16,15 +16,27 @@ IN_DOAJ = {
 
 if __name__ == "__main__":
 
-    import argparse
+    # import argparse
+    #
+    # parser = argparse.ArgumentParser()
+    # parser.add_argument("-o", "--out", help="output file path", required=True)
+    # args = parser.parse_args()
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-o", "--out", help="output file path", required=True)
-    args = parser.parse_args()
+    out = "out"
 
-    with open(args.out, "w", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(["ID", "PISSN", "EISSN", "Journals found with article's PISSN", "In doaj?", "Journals found with article's EISSN", "In doaj?", "Error"])
+    # with open(args.out+"notfound.csv", "w", encoding="utf-8") as f_notfound, open(args.out+"-identical.csv", "w", encoding="utf-8") as f_identical, open(args.out+"-others.csv", "w", encoding="utf-8") as f_others:
+    with open(out+"_notfound.csv", "w", encoding="utf-8") as f_notfound, open(out+"_identical.csv", "w", encoding="utf-8") as f_identical, open(out+"_others.csv", "w", encoding="utf-8") as f_others:
+        writer_notfound = csv.writer(f_notfound)
+        writer_notfound.writerow(["ID", "PISSN", "EISSN", "Journals found with article's PISSN", "In doaj?",
+                         "Journals found with article's EISSN", "In doaj?", "Error"])
+
+        writer_identical = csv.writer(f_identical)
+        writer_identical.writerow(["ID", "PISSN", "EISSN", "Journals found with article's PISSN", "In doaj?",
+                         "Journals found with article's EISSN", "In doaj?", "Error"])
+
+        writer_others = csv.writer(f_others)
+        writer_others.writerow(["ID", "PISSN", "EISSN", "Journals found with article's PISSN", "In doaj?",
+                         "Journals found with article's EISSN", "In doaj?", "Error"])
 
         for a in models.Article.iterate(q=IN_DOAJ, page_size=100, keepalive='5m'):
             article = models.Article(_source=a)
@@ -54,4 +66,9 @@ if __name__ == "__main__":
                             j_e_in_doaj.append(jobj.is_in_doaj())
                         else:
                             j_e_in_doaj.append("n/a")
-                writer.writerow([id, pissn, eissn, j_p, j_p_in_doaj, j_e, j_e_in_doaj, str(e)])
+                if (str(e) == "The Print and Online ISSNs supplied are identical. If you supply 2 ISSNs they must be different."):
+                    writer_identical.writerow([id, pissn, eissn, j_p, j_p_in_doaj, j_e, j_e_in_doaj, "Identical ISSNs"])
+                elif (str(e) == "ISSNs provided don't match any journal."):
+                    writer_notfound.writerow([id, pissn, eissn, j_p, j_p_in_doaj, j_e, j_e_in_doaj, "No matching journal found."])
+                else:
+                    writer_others.writerow([id, pissn, eissn, j_p, j_p_in_doaj, j_e, j_e_in_doaj, str(e)])


### PR DESCRIPTION
Run with:

`DOAJENV=production python portality/scripts/230609_find_articles_with_invalid_issns.py -o ~/20231106_3570_invalid_issns`