### PR TITLE
show errors in cms data to admins

### DIFF
--- a/portality/core.py
+++ b/portality/core.py
@@ -314,10 +314,19 @@ def _load_data(app):
     datadir = os.path.join(app.config["BASE_FILE_PATH"], "..", "cms", "data")
     for datafile in os.listdir(datadir):
         with open(os.path.join(datadir, datafile)) as f:
-            data = yaml.load(f, Loader=yaml.FullLoader)
-        dataname = datafile.split(".")[0]
-        dataname = dataname.replace("-", "_")
-        app.jinja_env.globals["data"][dataname] = data
+
+            dataname = datafile.split(".")[0]
+            dataname = dataname.replace("-", "_")
+
+            try:
+                data = yaml.load(f, Loader=yaml.FullLoader)
+                app.jinja_env.globals["data"][dataname] = data
+            except yaml.error.MarkedYAMLError as e:
+                app.logger.error(e)
+                # Problem with loading our yaml - this should be reported to the frontend to allow admins to fix
+                if not "data_errors" in app.jinja_env.globals:
+                    app.jinja_env.globals["data_errors"] = {}
+                app.jinja_env.globals["data_errors"][dataname] = e
 
 
 ##################################################

--- a/portality/templates/layouts/static_page.html
+++ b/portality/templates/layouts/static_page.html
@@ -20,6 +20,23 @@
         {% if page.preface and page.preface.startswith("/data/") %}
             <a class="admin-edit" href="{{ config.get("CMS_EDIT_BASE_URL") }}{{ page.preface.split(".")|first }}.yml" target="_blank" rel="noopener"><span class="sr-only">Edit data content</span><span data-feather="database" aria-hidden="true"></span></a>
         {% endif %}
+
+        {# Admins will also be interested in any data errors - dump them out on the page here #}
+        {# FIXME: This is probably an even worse way to find data than the method above! #}
+        {% set datakey = page_frag.split('/')[2].split('.')[0] %}
+        {% if data_errors.get(datakey) %}
+            <div class="container">
+                <div class="flash_container">
+                  <h2 class="sr-only">Notifications</h2>
+                  <p class="alert alert--danger">
+                      <span data-feather="alert-octagon" aria-hidden="true"></span>
+                          <strong>DATA ERROR:</strong> {{ data_errors.get(datakey) }}
+                      <span class="flash_close alert__close" role="button">(Dismiss)</span>
+                  </p>
+                </div>
+            </div>
+        {% endif %}
+
     {% endif %}
 
     {% if page.layout %}


### PR DESCRIPTION
# Display data loading errors on static pages server

Not sure if this is the right approach here - but the server does currently go down (looping exception on application start) when the data is currently unparsable, whcih makes debugging the `static_pages` branch more challenging. Alert looks like so (visible only to admins):

![Screenshot from 2024-01-03 12-41-45](https://github.com/DOAJ/doaj/assets/1446355/a76b50ad-1a3e-481f-8951-d055789e3eac)
