### PR TITLE
Add preservation page to docs menu

### DIFF
--- a/cms/data/nav.yml
+++ b/cms/data/nav.yml
@@ -29,6 +29,8 @@ entries:
         route: doaj.xml               # ~~->XMLDocumentation:WebRoute~~
       - label: Metadata help
         route: doaj.faq               # ~~->FAQ:WebRoute~~
+      - label: Preservation
+        route: doaj.preservation      # ~~->Preservation:WebRoute~~
   - id: about
     label: About
     footer: true


### PR DESCRIPTION
Just a change in a static file to add the Preservation (/preservation) page to the Documentation dropdown menu.
https://github.com/DOAJ/doajPM/issues/3816