### PR TITLE
HOTFIX: open journal link in a new window

### DIFF
--- a/portality/templates/application_form/editorial_form_body.html
+++ b/portality/templates/application_form/editorial_form_body.html
@@ -5,8 +5,7 @@
 {% import "application_form/_application_warning_msg.html" as _msg %}
 {% if obj and (obj.es_type == 'journal' and obj.is_in_doaj()) %}
     {{ _msg.build_journal_withdrawn_deleted_msg(obj) }}
-    <a class="button button--tertiary" href="{{ url_for('doaj.toc', identifier=obj.id) }}">See this
-        journal in DOAJ</a>
+    <a class="button button--tertiary" href="{{ url_for('doaj.toc', identifier=obj.id) }}" target="_blank">See this journal in DOAJ</a>
 {% endif %}
 
 


### PR DESCRIPTION
# Open journal link in a new window

See https://github.com/DOAJ/doajPM/issues/3855

Link from app/journal form to public DOAJ opens a new window (the reverse navigation does not)



