### PR TITLE
HOTFIX: don't add unnecessary space if no dir present

### DIFF
--- a/portality/static/js/doaj.fieldrender.edges.js
+++ b/portality/static/js/doaj.fieldrender.edges.js
@@ -3506,7 +3506,9 @@ $.extend(true, doaj, {
                         if (dir === undefined) {
                             dir = "";
                         }
-                        dir = " " + dir;
+                        if (dir !== "") {
+                            dir = " " + dir;
+                        }
                         sortOptions += '<option value="' + field + '' + dir + '">' + edges.escapeHtml(display) + '</option>';
                     }
 


### PR DESCRIPTION
# Don't add unnecessary space if no dir present

See https://github.com/DOAJ/doajPM/issues/3847

Relevance searching was not being displayed correctly in any of the public searches.  This is because an errant space was being added to the name of the sort field `_score `.  This prevents the code from erroneously adding that space when it is not needed.

