### PR TITLE
reapply required validator to publisher field in all contexts

### DIFF
--- a/portality/forms/application_forms.py
+++ b/portality/forms/application_forms.py
@@ -515,14 +515,20 @@ class FieldDefinitions:
                 ]
             },
             "public": {
-                "validate": [{"different_to": {"field": "institution_name",
-                                               "message": "The Publisher's name and Other organisation's name cannot be the same."}}]
+                "validate": [
+                    {"required": {"message": "Enter the name of the journal's publisher"}},
+                    {"different_to": {"field": "institution_name",
+                                               "message": "The Publisher's name and Other organisation's name cannot be the same."}}
+                ]
                 # ~~^-> DifferetTo:FormValidator~~
 
             },
             "update_request": {
-                "validate": [{"different_to": {"field": "institution_name",
-                                               "message": "The Publisher's name and Other organisation's name cannot be the same."}}]
+                "validate": [
+                    {"required": {"message": "Enter the name of the journal's publisher"}},
+                    {"different_to": {"field": "institution_name",
+                                               "message": "The Publisher's name and Other organisation's name cannot be the same."}}
+                ]
                 # ~~^-> DifferetTo:FormValidator~~
 
             },


### PR DESCRIPTION
# Erroneously removed required validator on publisher field is reapplied

*Please don't delete any sections when completing this PR template; instead enter **N/A** for checkboxes or sections which are not applicable, unless otherwise stated below*

See https://github.com/DOAJ/doajPM/issues/3927

A validator was removed in some context in error, this re-adds the validator


