### PR TITLE
update bg monitoring settings for mission critical monitoring changes

### DIFF
--- a/portality/settings.py
+++ b/portality/settings.py
@@ -443,8 +443,7 @@ HUEY_SCHEDULE = {
     "old_data_cleanup": {"month": "*", "day": "12", "day_of_week": "*", "hour": "6", "minute": "30"},
     "monitor_bgjobs": {"month": "*", "day": "*/6", "day_of_week": "*", "hour": "10", "minute": "0"},
     "find_discontinued_soon": {"month": "*", "day": "*", "day_of_week": "*", "hour": "0", "minute": "3"},
-    "datalog_journal_added_update": {"month": "*", "day": "*", "day_of_week": "*", "hour": "*", "minute": "*/30"},
-    "article_bulk_create": {"month": "*", "day": "*", "day_of_week": "*", "hour": "*", "minute": "20"},
+    "datalog_journal_added_update": {"month": "*", "day": "*", "day_of_week": "*", "hour": "*", "minute": "*/30"}
 }
 
 # Standard schedule for PDD (#3970)
@@ -1414,17 +1413,36 @@ BG_MONITOR_LAST_COMPLETED = {
 
 # Default monitoring config for background job types which are not enumerated in BG_MONITOR_ERRORS_CONFIG below
 BG_MONITOR_DEFAULT_CONFIG = {
+    ## default values for queued config
+
+    # the total number of items that are allowed to be in `queued` state at the same time.
+    # Any more than this and the result is flagged
     'total': 2,
+
+    # The age of the oldest record allowed to be in the `queued` state.
+    # If the oldest queued item was created before this, the result is flagged
     'oldest': 1200,
+
+    ## default values for error config
+
+    # The time period over which to check for errors, from now to now - check_sec
+    'check_sec': 3600,
+
+    # The number of errors allowed in the check period before the result is flagged
+    'allowed_num_err': 0
 }
 
 # Configures the monitoring period and the allowed number of errors in that period before a queue is marked
 # as unstable
 BG_MONITOR_ERRORS_CONFIG = {
     # Main queue
-    'journal_csv': {
-        'check_sec': 3600,  # 1 hour, time period between scheduled runs
+    'article_bulk_create': {
+        'check_sec': 86400,  # 1 day
         'allowed_num_err': 0,
+    },
+    'journal_csv': {
+        'check_sec': 10800,  # 3 hours
+        'allowed_num_err': 1,
     },
     'ingest_articles': {
         'check_sec': 86400,
@@ -1432,12 +1450,20 @@ BG_MONITOR_ERRORS_CONFIG = {
     },
 
     # Long running
+    'anon_export': {
+        'check_sec': 604800,    # a week
+        'allowed_num_err': 0
+    },
+    'article_cleanup_sync': {
+        'check_sec': 604800,    # a week
+        'allowed_num_err': 0
+    },
     'harvest': {
         'check_sec': 86400,
         'allowed_num_err': 0,
     },
     'public_data_dump': {
-        'check_sec': 86400 * 7,
+        'check_sec': 604800,
         'allowed_num_err': 0
     }
 }
@@ -1446,16 +1472,36 @@ BG_MONITOR_ERRORS_CONFIG = {
 # before the queue is marked as unstable.  This is provided by type, so we can monitor all types separately
 BG_MONITOR_QUEUED_CONFIG = {
     # Main queue
-    'journal_csv': {
-        'total': 2,
-        'oldest': 1200,     # 20 mins
+    'article_bulk_create': {
+        'total': 3,
+        'oldest': 600
     },
     'ingest_articles': {
-        'total': 250,
-        'oldest': 86400
+        'total': 10,
+        'oldest': 600
+    },
+    'journal_bulk_edit': {
+        'total': 2,
+        'oldest': 600
+    },
+    'journal_csv': {
+        'total': 1,
+        'oldest': 600,     # 20 mins
+    },
+    'set_in_doaj': {
+        'total': 2,
+        'oldest': 600
+    },
+    'suggestion_bulk_edit': {
+        'total': 2,
+        'oldest': 600
     },
 
     # Long running
+    'anon_export': {
+        'total': 1,
+        'oldest': 1200
+    },
     'harvest': {
         'total': 1,
         'oldest': 86400


### PR DESCRIPTION
* Issue: https://github.com/DOAJ/doajPM/issues/3959

---

# update bg monitoring settings for mission critical monitoring changes

Applies tighter monitoring constraints on the background jobs, as per this spreadsheet: https://docs.google.com/spreadsheets/d/1XWq-7R9hZmZsBA27eOgs9cO-SfJnLEE0dW50DVtKhpI/edit?gid=543591434#gid=543591434

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [x] affects the monitoring

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [x] Code meets acceptance criteria from issue
* [x] Unit tests are written and all pass
* [x] User Test Scripts (if required) are written and have been run through
* [x] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [x] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [x] Migation has been created and tested
* [x] There is a recent merge from `develop`

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section should be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [ ] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [ ] Migation has been created and tested
* [ ] There is a recent merge from `develop`

## Testing

This tightens the monitoring on a number of bg jobs, so would be good to validate that this won't cause any major surge in unnecessary reporting.

Probably need to send it live and then adjust.

## Deployment


### Configuration changes

Adds new values in:

* BG_MONITOR_QUEUED_CONFIG
* BG_MONITOR_ERRORS_CONFIG
* BG_MONITOR_DEFAULT_CONFIG

### Monitoring

This may trigger new types of "unstable" alerts in the background jobs reporting, so we should ensure that those alerts come through

