### PR TITLE
Restore edit data icon on static pages

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -168,6 +168,8 @@ Each static Markdown page includes YAML front matter at the top of the document 
   - if `false` you can omit this
 - `meta_description`:
   - A description for the page that will appear in the header metadata in the resulting HTML
+- `data`:
+  - set to true if `.yml` file with data exists to add the `db` icon to the page for admins
 
   
 ### Including other templates into the text

--- a/cms/pages/about/advisory-board-council.md
+++ b/cms/pages/about/advisory-board-council.md
@@ -5,5 +5,6 @@ title: Foundation Board & Advisory Board
 section: About
 toc: true
 featuremap: ~~AdvisoryBoardCouncil:Fragment->AdvisoryBoardCouncilData:Template~~
+data: true
 
 ---

--- a/cms/pages/about/ambassadors.md
+++ b/cms/pages/about/ambassadors.md
@@ -26,6 +26,7 @@ manual_toc_tokens: |
         "name": "Ambassadors"
       }
   ]
+data: true
 ---
 
 DOAJ has 13 active Ambassadors who work with local communities around the world. Ambassadors work within Low- or Middle-Income Countries (LMICs) to raise DOAJ's profile through local outreach and engagement activities. They advocate for good practices in open access and publishing, assist with information about applying to DOAJ, and conduct training and events on behalf of DOAJ. 

--- a/cms/pages/about/volunteers.md
+++ b/cms/pages/about/volunteers.md
@@ -6,6 +6,7 @@ toc: true
 highlight: true
 include: /public/includes/_volunteers.html
 featuremap: ~~Volunteers:Fragment->VolunteersData:Template~~
+data: true
 
 ---
 

--- a/portality/templates-v2/public/layouts/static-page.html
+++ b/portality/templates-v2/public/layouts/static-page.html
@@ -17,12 +17,12 @@
         <a class="admin-edit" href="{{ config.get("CMS_EDIT_BASE_URL") }}/pages{{ page.frag.split(".")|first }}.md" target="_blank" rel="noopener"><span class="sr-only">Edit text content</span><span data-feather="edit-3" aria-hidden="true"></span></a>
 
         {# FIXME: this is not the nicest way to detect if a page uses data, but I don't have an alternative right now #}
-        {% if page.include and page.include.startswith("/data/") %}
-            <a class="admin-edit" href="{{ config.get("CMS_EDIT_BASE_URL") }}{{ page.include.split(".")|first }}.yml" target="_blank" rel="noopener"><span class="sr-only">Edit data content</span><span data-feather="database" aria-hidden="true"></span></a>
+        {% if page.include and page.data %}
+            <a class="admin-edit" href="{{ config.get("CMS_EDIT_BASE_URL") }}/data/{{  page.include.split('/')[-1].replace('.html', '').lstrip('_') }}.yml" target="_blank" rel="noopener"><span class="sr-only">Edit data content</span><span data-feather="database" aria-hidden="true"></span></a>
         {% endif %}
 
-        {% if page.preface and page.preface.startswith("/data/") %}
-            <a class="admin-edit" href="{{ config.get("CMS_EDIT_BASE_URL") }}{{ page.preface.split(".")|first }}.yml" target="_blank" rel="noopener"><span class="sr-only">Edit data content</span><span data-feather="database" aria-hidden="true"></span></a>
+        {% if page.preface and page.preface.data %}
+            <a class="admin-edit" href="{{ config.get("CMS_EDIT_BASE_URL") }}/data/{{  page.preface.split('/')[-1].replace('.html', '').lstrip('_') }}.yml" target="_blank" rel="noopener"><span class="sr-only">Edit data content</span><span data-feather="database" aria-hidden="true"></span></a>
         {% endif %}
     {% endif %}
 


### PR DESCRIPTION
* Issue: [#4002](https://github.com/DOAJ/doajPM/issues/4002)

---

# Restore Edit Data icon on static pages

This PR introduces `data` element to pages YAML front matter that indicates whether the page contains any data in `cms/data` folder in `.md` file. By setting `data: true` in appropriate .md file it is possible to add the Edit Data button to the static page.

Icon is added to:
Advisory Board Council, Ambassadors and Volunteers

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [ ] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [ ] Migation has been created and tested
* [ ] There is a recent merge from `develop`

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section should be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [ ] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [ ] Migation has been created and tested
* [ ] There is a recent merge from `develop`

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run by reviewers*

## Deployment

What deployment considerations are there? (delete any sections you don't need)

### Configuration changes

What configuration changes are included in this PR, and do we need to set specific values for production

### Scripts

What scripts need to be run from the PR (e.g. if this is a report generating feature), and when (once, regularly, etc).

### Migrations

What migrations need to be run to deploy this

### Monitoring

What additional monitoring is required of the application as a result of this feature

### New Infrastructure

What new infrastructure does this PR require (e.g. new services that need to run on the back-end).

### Continuous Integration

What CI changes are required for this
