### PR TITLE
Add chunking to sitemap generator, manually add new sitemap indexes t…

### DIFF
--- a/deploy/robots-production.txt
+++ b/deploy/robots-production.txt
@@ -1,4 +1,6 @@
-Sitemap: https://doaj.org/sitemap.xml
+Sitemap: https://doaj.org/sitemap_index_0.xml
+Sitemap: https://doaj.org/sitemap_index_1.xml
+Sitemap: https://doaj.org/sitemap_index_2.xml
 
 User-agent: *
 Disallow: /search/

--- a/doajtest/mocks/models_Cache.py
+++ b/doajtest/mocks/models_Cache.py
@@ -41,6 +41,23 @@ class InMemoryCache(object):
         return cls.__memory__["sitemap"]
 
     @classmethod
+    def cache_sitemap_indexes(cls, urls):
+        """Cache multiple sitemap index URLs"""
+        for idx, url in enumerate(urls):
+            cls.__memory__[f"sitemap_index_{idx}"] = {
+                "filename": url
+            }
+
+    @classmethod
+    def get_sitemap_index(cls, n):
+        """Get a specific sitemap index URL"""
+        key = f"sitemap_index_{n}"
+        cached = cls.__memory__.get(key)
+        if cached is None:
+            return None
+        return cached.get("filename")
+
+    @classmethod
     def cache_public_data_dump(cls, article_url, article_size, journal_url, journal_size):
         cls.__memory__["public_data_dump"] = {
             "article": {"url" : article_url, "size" : article_size},

--- a/portality/models/cache.py
+++ b/portality/models/cache.py
@@ -85,6 +85,24 @@ class Cache(DomainObject):
         return rec.get("filename")
 
     @classmethod
+    def cache_sitemap_indexes(cls, urls):
+        """Cache multiple sitemap index URLs"""
+        for idx, url in enumerate(urls):
+            cobj = cls(**{
+                "filename": url
+            })
+            cobj.set_id(f"sitemap_index_{idx}")
+            cobj.save()
+
+    @classmethod
+    def get_sitemap_index(cls, n):
+        """Get a specific sitemap index URL"""
+        rec = cls.pull(f"sitemap_index_{n}")
+        if rec is None:
+            return None
+        return rec.get("filename")
+
+    @classmethod
     def cache_public_data_dump(cls, article_container, article_filename, article_url, article_size,
                                     journal_container, journal_filename, journal_url, journal_size):
         cobj = cls(**{

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -1118,6 +1118,9 @@ JOURNAL_HISTORY_DIR = os.path.join(ROOT_DIR, "history", "journal")
 # approximate rate of change of the Table of Contents for journals
 TOC_CHANGEFREQ = "monthly"
 
+# Maximum number of sitemap entries per index file before splitting into chunks (50K entries, 50MB size is actual limit)
+SITEMAP_INDEX_MAX_ENTRIES = 90
+
 ##################################################
 # News feed settings
 # ~~->News:Feature~~


### PR DESCRIPTION
…o robots

* Issue: https://github.com/DOAJ/doajPM/issues/4152

---

# Generate 3 sitemap files

This will generate a number of index files according the setting `SITEMAP_INDEX_MAX_ENTRIES` and add them to the cache, rather than a single `sitemap.xml` file as the index. Things to note:

* The existing `sitemap` cache entry remains, and `get_latest_sitemap()` doesn't work correctly because it doesn't know about multiple indexes.
* I've manually added the new sitemap indexes to robots-production.txt.
* The naming scheme differs and might be confusing - where we previously had `sitemap.xml` (the index) and `sitemap0...n.xml` as the individual sitemaps, we now have `sitemap_index_0.xml` and `sitemap0.xml` etc. They're a bit clearer now only if you set `SITEMAP_INDEX_MAX_ENTRIES` low enough for multiple indexes to be created.
* We _could_ properly support the old `sitemap.xml` single route (and correctly cache as latest) if we use an index-of-indexes approach. TODO: check this actually fits the protocol - I've only ever seen it referred to as having multiple indexes.

Also, I had trouble testing this when I was using localstore - something in the sitemap / cache code seems to expect it to be S3 no matter which `STORE_IMPL` is set.

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [ ] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [ ] Migation has been created and tested
* [ ] There is a recent merge from `develop`

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section should be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [ ] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [ ] Migation has been created and tested
* [ ] There is a recent merge from `develop`

## Testing

* Generate the sitemap, check the background task log makes sense. You must have articles in the index. (dev anon import is fine)
* access via /sitemap.xml to see the index referring to sitemap0.xml, sitemap1.xml etc all in one file
* Set SITEMAP_INDEX_MAX_ENTRIES to 1
* re-run background job and check output
* Access the new sitemap indexes via /sitemap_index_0.xml 

## Deployment

Robots.txt has been updated so Google should try to read the new indexes, and not the old sitemap.

### Configuration changes

What configuration changes are included in this PR, and do we need to set specific values for production

### Scripts

What scripts need to be run from the PR (e.g. if this is a report generating feature), and when (once, regularly, etc).

### Migrations

What migrations need to be run to deploy this

### Monitoring

What additional monitoring is required of the application as a result of this feature

### New Infrastructure

What new infrastructure does this PR require (e.g. new services that need to run on the back-end).

### Continuous Integration

What CI changes are required for this
