### PR TITLE
add script to analyse application/journal connections

### DIFF
--- a/portality/scripts/application_journal_integrity.py
+++ b/portality/scripts/application_journal_integrity.py
@@ -1,0 +1,40 @@
+from portality import models, constants
+import csv
+
+query = {
+    "query": {
+        "bool": {
+            "must": [
+                {
+                    "term": {
+                        "admin.application_status.exact": constants.APPLICATION_STATUS_ACCEPTED
+                    }
+                },
+                {
+                    "range": {
+                        "created_date": {
+                            "gte": "2018-08-01T00:00:00Z"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+with open("application_journal_integrity_report.csv", "w", encoding="utf-8") as f:
+    writer = csv.writer(f)
+    writer.writerow(["Application ID", "Created Date", "Last Updated", "Journal ID", "Issue"])
+
+    for application in models.Application.iterate_unstable(query):
+        rj = application.related_journal
+        if rj is None:
+            print([application.id, application.created_date, application.last_manual_update, "", "Accepted application has no related_journal"])
+            writer.writerow([application.id, application.created_date, application.last_manual_update, "", "Accepted application has no related_journal"])
+            continue
+
+        journal = models.Journal.pull(rj)
+        if journal is None:
+            print([application.id, application.created_date, application.last_manual_update, rj, "Accepted application has related_journal that does not exist"])
+            writer.writerow([application.id, application.created_date, application.last_manual_update, rj, "Accepted application has related_journal that does not exist"])
+            continue


### PR DESCRIPTION
* Issue: https://github.com/DOAJ/doajPM/issues/4267

---

# Script to check application -> journal connection integrity

After an application was accepted but the journal did not appear, this script checks to see if that's happened previously.

This PR...
- [x] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring



## Testing

None

## Deployment

### Scripts

```
python portality/scripts/application_journal_integrity_report.py
```

This will produce a file in `portality/scripts/application_journal_integrity_report.csv` which should be reviewed.
