### PR TITLE
Handle exception for unknown errors

### DIFF
--- a/portality/bll/services/background_task_status.py
+++ b/portality/bll/services/background_task_status.py
@@ -48,8 +48,12 @@ class BackgroundTaskStatusService:
                     .order_by('created_date', 'desc')
                     .build_query_dict())
 
-        lr_results = BackgroundJob.q2obj(q=lr_query)
-        lr_job = lr_results[0] if len(lr_results) > 0 else None
+        try:
+            lr_results = BackgroundJob.q2obj(q=lr_query)
+            lr_job = lr_results[0] if len(lr_results) > 0 else None
+        except Exception as e:
+            app.logger.error(f'Error querying last successfully run status for action {action}: {e}')
+            lr_job = None
 
         status = constants.BG_STATUS_UNSTABLE
         lr = None
@@ -94,8 +98,13 @@ class BackgroundTaskStatusService:
                         .status_includes(constants.BGJOB_STATUS_QUEUED).size(1)
                         .order_by('created_date', 'asc')
                         .build_query_dict())
-        oldest_jobs = list(BackgroundJob.q2obj(q=oldest_query))
-        oldest_job = oldest_jobs and oldest_jobs[0]
+        try:
+            oldest_jobs = list(BackgroundJob.q2obj(q=oldest_query))
+            oldest_job = oldest_jobs and oldest_jobs[0]
+        except Exception as e:
+            app.logger.error(f'Error querying queued status for action {action}: {e}')
+            oldest_jobs = []
+            oldest_job = None
 
         err_msgs = []
         limited_oldest_date = dates.before_now(oldest)
@@ -118,11 +127,16 @@ class BackgroundTaskStatusService:
 
     def create_queues_status(self, queue_name) -> dict:
         # define last_completed_job
-        bgjob_list = BackgroundJob.q2obj(q=LastCompletedJobQuery(queue_name).query())
-        bgjob_list = list(bgjob_list)
-        if bgjob_list:
-            last_completed_date = bgjob_list[0].last_updated_timestamp
-        else:
+        try:
+            bgjob_list = BackgroundJob.q2obj(q=LastCompletedJobQuery(queue_name).query())
+            bgjob_list = list(bgjob_list)
+            if bgjob_list:
+                last_completed_date = bgjob_list[0].last_updated_timestamp
+            else:
+                last_completed_date = None
+        except Exception as e:
+            app.logger.error(f'Error querying last completed job for queue {queue_name}: {e}')
+            bgjob_list = []
             last_completed_date = None
 
         errors = {action: self.create_errors_status(action, **config) for action, config


### PR DESCRIPTION
* Issue: [enter link to issue here]

---

# Title <- provide a title for the PR

*We are seeing following error and to fix this quickly handled exception*

```
[2026-06-13 12:51:39 +0000] [411606] [ERROR] Error handling request /_status/
Traceback (most recent call last):
  File "/home/cloo/doaj/venv/lib/python3.10/site-packages/gunicorn/workers/sync.py", line 134, in handle
    self.handle_request(listener, req, client, addr)
  File "/home/cloo/doaj/venv/lib/python3.10/site-packages/gunicorn/workers/sync.py", line 177, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/home/cloo/doaj/venv/lib/python3.10/site-packages/flask/app.py", line 2213, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/cloo/doaj/venv/lib/python3.10/site-packages/werkzeug/middleware/proxy_fix.py", line 182, in __call__
    return self.app(environ, start_response)
  File "/home/cloo/doaj/venv/lib/python3.10/site-packages/flask/app.py", line 2190, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/cloo/doaj/venv/lib/python3.10/site-packages/flask/app.py", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/cloo/doaj/venv/lib/python3.10/site-packages/flask/app.py", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/cloo/doaj/portality/util.py", line 29, in decorated_function
    return f(*args, **kwargs)
  File "/home/cloo/doaj/portality/view/status.py", line 157, in status
    res['background'] = bgtask_status_service.create_background_status()
  File "/home/cloo/doaj/portality/bll/services/background_task_status.py", line 173, in create_background_status
    queues = {
  File "/home/cloo/doaj/portality/bll/services/background_task_status.py", line 174, in <dictcomp>
    queue_name: self.create_queues_status(queue_name)
  File "/home/cloo/doaj/portality/bll/services/background_task_status.py", line 134, in create_queues_status
    last_run = {action: self.create_last_successfully_run_status(action, **config) for action, config
  File "/home/cloo/doaj/portality/bll/services/background_task_status.py", line 134, in <dictcomp>
    last_run = {action: self.create_last_successfully_run_status(action, **config) for action, config
  File "/home/cloo/doaj/portality/bll/services/background_task_status.py", line 51, in create_last_successfully_run_status
    lr_results = BackgroundJob.q2obj(q=lr_query)
  File "/home/cloo/doaj/portality/dao.py", line 1253, in q2obj
    results = [cls(**r) for r in rs]
  File "/home/cloo/doaj/portality/dao.py", line 1253, in <listcomp>
    results = [cls(**r) for r in rs]
  File "/home/cloo/doaj/portality/models/background.py", line 29, in __init__
    super(BackgroundJob, self).__init__(raw=kwargs)
  File "/home/cloo/doaj/portality/lib/dataobj.py", line 339, in __init__
    self.data = construct(self.data, self._struct, self._coerce_map, silent_prune=construct_silent_prune, maintain_reference=construct_maintain_reference)
  File "/home/cloo/doaj/portality/lib/dataobj.py", line 1202, in construct
    beneath = construct(val, subinst, coerce=coerce, context=context + field_name + "[" + str(i) + "].", silent_prune=silent_prune)
  File "/home/cloo/doaj/portality/lib/dataobj.py", line 1130, in construct
    constructed._set_single(field_name, val, coerce=coerce_fn, **kwargs)
  File "/home/cloo/doaj/portality/lib/dataobj.py", line 778, in _set_single
    val = self._coerce(val, coerce, accept_failure=allow_coerce_failure)
  File "/home/cloo/doaj/portality/lib/dataobj.py", line 720, in _coerce
    return cast(val)
  File "/home/cloo/doaj/portality/lib/dataobj.py", line 124, in datify
    return dates.reformat(val, in_format=in_format, out_format=out_format)
  File "/home/cloo/doaj/portality/lib/dates.py", line 84, in reformat
    return format(parse(s, format=in_format), format=out_format)
  File "/home/cloo/doaj/portality/lib/dates.py", line 72, in parse
    return datetime.strptime(s, f)
  File "/usr/lib/python3.10/_strptime.py", line 565, in _strptime_datetime
    def _strptime_datetime(cls, data_string, format="%a %b %d %H:%M:%S %Y"):
  File "/home/cloo/doaj/venv/lib/python3.10/site-packages/gunicorn/workers/base.py", line 204, in handle_abort
    sys.exit(1)
SystemExit: 1
```

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [ ] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [ ] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [ ] Migation has been created and tested
* [ ] There is a recent merge from `develop`

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section should be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [ ] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [ ] Migation has been created and tested
* [ ] There is a recent merge from `develop`

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run by reviewers*

## Deployment

What deployment considerations are there? (delete any sections you don't need)

### Configuration changes

What configuration changes are included in this PR, and do we need to set specific values for production

### Scripts

What scripts need to be run from the PR (e.g. if this is a report generating feature), and when (once, regularly, etc).

### Migrations

What migrations need to be run to deploy this

### Monitoring

What additional monitoring is required of the application as a result of this feature

### New Infrastructure

What new infrastructure does this PR require (e.g. new services that need to run on the back-end).

### Continuous Integration

What CI changes are required for this
