### PR TITLE
Hotfix/4394 6 login bugfixess

### DIFF
--- a/dev.template.cfg
+++ b/dev.template.cfg
@@ -54,6 +54,8 @@ HUEY_REDIS_PORT = 6379
 ###########################################
 
 MAIL_SERVER = "smtp.mailtrap.io"
+MAIL_PORT = 587
+MAIL_USE_TLS = True
 MAIL_USERNAME = "[your mailtrap username]"
 MAIL_PASSWORD = "[your mailtrap password]"
 CONTACT_FORM_EMAIL = "doaj@cottaglabs.com"
@@ -61,6 +63,11 @@ CONTACT_FORM_EMAIL = "doaj@cottaglabs.com"
 ENABLE_PUBLISHER_EMAIL=True
 ENABLE_EMAIL=True
 CC_ALL_EMAILS_TO=None
+
+# Required for passwordless login emails (see PASSWORDLESS_ENCRYPTION_KEY
+# in settings.py for details). Generate with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+PASSWORDLESS_ENCRYPTION_KEY = "[generate a key - see settings.py]"
 
 ###########################################
 ## Background tasks

--- a/doajtest/selenium_helpers.py
+++ b/doajtest/selenium_helpers.py
@@ -1,12 +1,14 @@
 import datetime
 import logging
 import multiprocessing
+import time
 from multiprocessing import Process, freeze_support
 from typing import TYPE_CHECKING
 
 import selenium
 from selenium import webdriver
-from selenium.common.exceptions import StaleElementReferenceException, ElementClickInterceptedException
+from selenium.common.exceptions import StaleElementReferenceException, ElementClickInterceptedException, \
+    NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -183,12 +185,30 @@ class SeleniumTestCase(DoajTestCase):
         self.selenium.execute_script(script)
 
 
+def dismiss_cookie_consent(driver: 'WebDriver'):
+    """
+    Remove the cookie-consent banner if present. It's a fixed-position
+    element pinned to the viewport, so it can intercept clicks on
+    anything else it happens to overlap regardless of scroll position.
+    Removed directly via JS rather than clicking its own dismiss button -
+    that button is just as susceptible to being covered/mistimed as
+    anything else on the page, and this doesn't need to be a "real"
+    user dismissal (setting the consent cookie ahead of time isn't a
+    reliable alternative either: it's marked Secure and the test server
+    runs over plain HTTP, so the browser would just refuse to store it).
+    """
+    driver.execute_script(
+        "var el = document.getElementById('cookie-consent'); if (el) el.remove();"
+    )
+
+
 def goto(driver: 'WebDriver', url_path: str) -> str:
     if not url_path.startswith('/'):
         url_path = '/' + url_path
     url = SeleniumTestCase.get_doaj_url() + url_path
     log.info(f'goto: {url}')
     driver.get(url)
+    dismiss_cookie_consent(driver)
     return url
 
 
@@ -200,21 +220,52 @@ def cancel_alert(driver: 'WebDriver'):
         pass
 
 
+def scroll_and_click(driver: 'WebDriver', element: 'WebElement'):
+    # element_to_be_clickable only checks visibility/enabled state, not
+    # whether the element is scrolled into view or covered by something
+    # else at its actual screen coordinates - a plain .click() can still
+    # get intercepted, so scroll it into view first. Also re-check for
+    # the cookie-consent banner immediately before clicking: goto()'s
+    # one-time removal attempt isn't enough if the banner renders or
+    # reappears later in a longer-running test.
+    dismiss_cookie_consent(driver)
+    # main.css sets `html { scroll-behavior: smooth }` site-wide, so a
+    # plain scrollIntoView() animates over ~200-300ms and the immediately
+    # following click can fire mid-scroll, landing on whatever happens to
+    # be at that transient position. behavior: 'instant' overrides the
+    # CSS default for this call so the scroll completes synchronously.
+    driver.execute_script("arguments[0].scrollIntoView({block: 'center', behavior: 'instant'});", element)
+    element.click()
+
+
 def login(driver: 'WebDriver', username: str, password: str):
     # Preserve current URL to redirect back after login
     login_path = "/login?" + urlencode({'next': driver.current_url}) if driver.current_url else "/login"
     login_url = goto(driver, login_path)
+    wait = WebDriverWait(driver, 10)
 
     driver.find_element(By.ID, 'user').send_keys(username)
     assert driver.find_element(By.ID, 'user').get_attribute('value') == username
-    driver.find_element(By.ID, 'password').send_keys(password)
+
+    # the password field starts hidden behind a "prefer to use a
+    # password?" toggle; reveal it before interacting with it. The reveal
+    # is an animated slideDown (fixed 400ms) - display flips to block
+    # immediately, but the container's height is still animating, so
+    # give it a moment to settle before touching anything inside it,
+    # otherwise scrolling/clicking hits stale mid-animation geometry.
+    password_section = driver.find_element(By.ID, 'password-section')
+    scroll_and_click(driver, driver.find_element(By.ID, 'show-password'))
+    wait.until(EC.visibility_of(password_section))
+    time.sleep(0.5)
+    password_field = driver.find_element(By.ID, 'password')
+
+    password_field.send_keys(password)
     assert driver.find_element(By.ID, 'password').get_attribute('value') == password
     driver.save_screenshot(f'doaj_seleniumtest_{username}.png')
-    driver.find_element(By.CSS_SELECTOR, 'input[type="submit"]').click()
+    scroll_and_click(driver, driver.find_element(By.ID, 'password-btn'))
 
     # Wait for login to complete - URL should change away from login page
     try:
-        wait = WebDriverWait(driver, 10)
         wait.until(EC.url_changes(login_url))
     except Exception as e:
         log.error(f"Login failed to complete, current_url: {driver.current_url}\n Error: {e}")

--- a/doajtest/seleniumtest/test_login.py
+++ b/doajtest/seleniumtest/test_login.py
@@ -1,11 +1,20 @@
+import time
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
+# jQuery's slideDown()/slideUp() run on a fixed 400ms duration. display
+# flips and element_to_be_clickable can both report "ready" mid-animation,
+# so wait out the animation itself before touching anything inside the
+# container - scrolling/clicking mid-flight hits stale geometry and gets
+# intercepted.
+ANIMATION_SETTLE_SECONDS = 0.5
+
 from doajtest import selenium_helpers
 from doajtest.fixtures import AccountFixtureFactory
-from doajtest.selenium_helpers import SeleniumTestCase
+from doajtest.selenium_helpers import SeleniumTestCase, scroll_and_click
 from portality import models
 
 
@@ -46,15 +55,18 @@ class LoginSTC(SeleniumTestCase):
         assert login_link_btn.get_attribute('disabled') is None
         assert password_btn.get_attribute('disabled') is not None
 
-        self.selenium.find_element(By.ID, 'show-password').click()
+        scroll_and_click(self.selenium, self.selenium.find_element(By.ID, 'show-password'))
         wait.until(EC.visibility_of(password_section))
+        time.sleep(ANIMATION_SETTLE_SECONDS)
 
         assert password_section.is_displayed()
         assert login_link_btn.get_attribute('disabled') is not None
         assert password_btn.get_attribute('disabled') is None
 
-        self.selenium.find_element(By.ID, 'show-login-link').click()
+        show_login_link = self.selenium.find_element(By.ID, 'show-login-link')
+        scroll_and_click(self.selenium, show_login_link)
         wait.until(lambda d: not password_section.is_displayed())
+        time.sleep(ANIMATION_SETTLE_SECONDS)
 
         assert login_link_btn.get_attribute('disabled') is None
         assert password_btn.get_attribute('disabled') is not None
@@ -87,8 +99,9 @@ class LoginSTC(SeleniumTestCase):
         user_field.send_keys(publisher.email)
 
         password_section = self.selenium.find_element(By.ID, 'password-section')
-        self.selenium.find_element(By.ID, 'show-password').click()
+        scroll_and_click(self.selenium, self.selenium.find_element(By.ID, 'show-password'))
         wait.until(EC.visibility_of(password_section))
+        time.sleep(ANIMATION_SETTLE_SECONDS)
 
         password_field = self.selenium.find_element(By.ID, 'password')
         password_field.send_keys(password)

--- a/doajtest/seleniumtest/test_login.py
+++ b/doajtest/seleniumtest/test_login.py
@@ -1,3 +1,8 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
 from doajtest import selenium_helpers
 from doajtest.fixtures import AccountFixtureFactory
 from doajtest.selenium_helpers import SeleniumTestCase
@@ -18,4 +23,77 @@ class LoginSTC(SeleniumTestCase):
         target_path = "/publisher/uploadfile"
         selenium_helpers.goto(self.selenium, target_path)
         assert target_path in self.selenium.current_url
+
+    def test_password_toggle_reveals_field(self):
+        """
+        Regression test: clicking "prefer to use a password?" should
+        reveal the password field. It previously did nothing on the
+        /apply login page, because that page shared the form markup but
+        not the JS that binds the toggle handlers.
+
+        Also checks that the currently-hidden submit button is disabled
+        (and the visible one isn't) after each toggle, so a hidden button
+        can't be reached via Tab/keyboard while it's out of view.
+        """
+        selenium_helpers.goto(self.selenium, "/account/login")
+        wait = WebDriverWait(self.selenium, 10)
+
+        password_section = wait.until(EC.presence_of_element_located((By.ID, 'password-section')))
+        login_link_btn = self.selenium.find_element(By.ID, 'login-link-btn')
+        password_btn = self.selenium.find_element(By.ID, 'password-btn')
+
+        assert not password_section.is_displayed()
+        assert login_link_btn.get_attribute('disabled') is None
+        assert password_btn.get_attribute('disabled') is not None
+
+        self.selenium.find_element(By.ID, 'show-password').click()
+        wait.until(EC.visibility_of(password_section))
+
+        assert password_section.is_displayed()
+        assert login_link_btn.get_attribute('disabled') is not None
+        assert password_btn.get_attribute('disabled') is None
+
+        self.selenium.find_element(By.ID, 'show-login-link').click()
+        wait.until(lambda d: not password_section.is_displayed())
+
+        assert login_link_btn.get_attribute('disabled') is None
+        assert password_btn.get_attribute('disabled') is not None
+
+    def test_enter_key_logs_in_with_password(self):
+        """
+        Regression test: after switching to password mode and typing a
+        password, pressing Enter must log in with that password - not
+        submit a passwordless "send me a login link" request.
+
+        The form always has two submit buttons in the DOM (link and
+        password). A browser's native implicit (Enter-key) submission
+        targets the *first* submit button in DOM order regardless of
+        which is currently visible - disabling the other button doesn't
+        change that; a keypress just does nothing once the first button
+        in DOM order is disabled. So Enter is handled explicitly by a
+        keydown listener on the form (see _login_form_js.html) that
+        clicks whichever button is currently visible, instead of relying
+        on the browser to resolve the correct default button itself.
+        """
+        publisher = models.Account(**AccountFixtureFactory.make_publisher_source())
+        password = 'password'
+        publisher.set_password(password)
+        publisher.save(blocking=True)
+
+        selenium_helpers.goto(self.selenium, "/account/login")
+        wait = WebDriverWait(self.selenium, 10)
+
+        user_field = wait.until(EC.presence_of_element_located((By.ID, 'user')))
+        user_field.send_keys(publisher.email)
+
+        password_section = self.selenium.find_element(By.ID, 'password-section')
+        self.selenium.find_element(By.ID, 'show-password').click()
+        wait.until(EC.visibility_of(password_section))
+
+        password_field = self.selenium.find_element(By.ID, 'password')
+        password_field.send_keys(password)
+        password_field.send_keys(Keys.RETURN)
+
+        wait.until(lambda d: "/login" not in d.current_url)
+        assert "/login" not in self.selenium.current_url
 

--- a/doajtest/unit/test_account_login.py
+++ b/doajtest/unit/test_account_login.py
@@ -9,7 +9,7 @@ from doajtest.helpers import DoajTestCase
 # The account blueprint is registered twice - once at /account, and once
 # locale-prefixed at /<lang>/account (name "locale_account"). Both must
 # behave the same way.
-LOGIN_ROUTES = ('/account/login', '/en/account/login','/fr/account/login')
+LOGIN_ROUTES = ('/account/login', '/en/account/login', '/fr/account/login')
 
 
 class TestAccountLogin(DoajTestCase):
@@ -91,3 +91,25 @@ class TestAccountLogin(DoajTestCase):
                 ), follow_redirects=True)
                 self.assertEqual(resp.status_code, 200)
                 mock_send_email.assert_called_once()
+
+    def test_05_apply_redirect_login_includes_password_toggle_script(self):
+        """
+        Regression test: /account/login?redirected=apply renders the
+        login_to_apply template, which shares the login form markup
+        (including the "Prefer to use a password?" link) with the plain
+        login page via _login_form.html, but didn't carry over the JS
+        that binds the toggle click handler - so on the apply flow the
+        link was inert and never revealed the password field, even
+        though it worked fine on the plain /login page.
+        """
+        for route in LOGIN_ROUTES:
+            with self.subTest(route=route):
+                plain_resp = self.app_client.get(route, follow_redirects=True)
+                apply_resp = self.app_client.get(f'{route}?redirected=apply', follow_redirects=True)
+
+                for resp in (plain_resp, apply_resp):
+                    self.assertEqual(resp.status_code, 200)
+                    # the toggle link/markup should be present on both...
+                    self.assertIn(b'id="show-password"', resp.data)
+                    # ...and so should the script that makes it work
+                    self.assertIn(b"$('#show-password').on('click'", resp.data)

--- a/doajtest/unit/test_account_login.py
+++ b/doajtest/unit/test_account_login.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import patch
 
 from portality.app import app
@@ -69,16 +70,23 @@ class TestAccountLogin(DoajTestCase):
     @patch('portality.bll.services.account.AccountService.send_login_code_email')
     def test_04_passwordless_request_link(self, mock_send_email):
         """
-        Each login route needs its own account/email: the passwordless resend
-        backoff (PWLESS_RESEND_MIN_INTERVAL) would otherwise block the
-        2nd and 3rd requests for the same email fired straight after
+        Each login route needs its own account/email: the passwordless
+        resend backoff (PWLESS_RESEND_MIN_INTERVAL) would otherwise block
+        the 2nd and 3rd requests for the same email fired straight after
         the first, which has nothing to do with what's under test here.
+
+        The email also needs to be unique per test *run*, not just per
+        route: the backoff state lives in Redis, keyed by email, and
+        isn't reset by DoajTestCase's per-test ES index isolation - a
+        fixed email would accumulate resend counts across repeated runs
+        and eventually trip the backoff for reasons unrelated to the
+        test itself.
         """
-        #
+        run_id = uuid.uuid4().hex[:8]
         for i, route in enumerate(LOGIN_ROUTES):
             with self.subTest(route=route):
                 mock_send_email.reset_mock()
-                email = f'pwless{i}@example.com'
+                email = f'pwless-{run_id}-{i}@example.com'
                 account = Account.make_account(
                     username=f'pwlessuser{i}', name='Passwordless User', email=email, roles=['user']
                 )

--- a/doajtest/unit/test_account_login.py
+++ b/doajtest/unit/test_account_login.py
@@ -57,6 +57,34 @@ class TestAccountLogin(DoajTestCase):
                 self.assertEqual(resp.status_code, 200)
                 self.assertIn(b'password you entered is incorrect', resp.data)
 
+    def test_02b_incorrect_password_reveals_password_section(self):
+        """
+        Regression test: the "incorrect password" error is attached to
+        form.password.errors, which renders inside #password-section -
+        but that div was unconditionally rendered with
+        style="display: none;", so the error was left invisible unless
+        the user happened to click "prefer to use a password?" again.
+        _login_form.html now starts in password mode (section visible,
+        buttons' disabled state flipped to match) whenever
+        form.password.errors is set, so the error is visible on the
+        very page it's rendered on.
+        """
+        for route in LOGIN_ROUTES:
+            with self.subTest(route=route):
+                # baseline: a plain GET has no error, so it should still
+                # start collapsed
+                fresh_resp = self.app_client.get(route, follow_redirects=True)
+                self.assertIn(b'id="password-section" style="display: none;"', fresh_resp.data)
+
+                resp = self.app_client.post(route, data=dict(
+                    user=self.test_account.email, password='wrong-password', action='password_login'
+                ), follow_redirects=True)
+                self.assertEqual(resp.status_code, 200)
+                # the section itself is no longer hidden...
+                self.assertNotIn(b'id="password-section" style="display: none;"', resp.data)
+                # ...and the buttons' disabled state has flipped to match
+                self.assertIn(b'style="display: none;" disabled', resp.data)
+
     def test_03_unrecognised_account(self):
         """ Check the message reaches the frontend when the account isn't found"""
         for route in LOGIN_ROUTES:

--- a/doajtest/unit/test_account_login.py
+++ b/doajtest/unit/test_account_login.py
@@ -1,0 +1,93 @@
+from unittest.mock import patch
+
+from portality.app import app
+from portality.models.account import Account
+from doajtest.fixtures.accounts import AccountFixtureFactory
+
+from doajtest.helpers import DoajTestCase
+
+# The account blueprint is registered twice - once at /account, and once
+# locale-prefixed at /<lang>/account (name "locale_account"). Both must
+# behave the same way.
+LOGIN_ROUTES = ('/account/login', '/en/account/login','/fr/account/login')
+
+
+class TestAccountLogin(DoajTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.app_client = app.test_client()
+        self.app_client.testing = True
+        self.test_account = Account(**AccountFixtureFactory.make_publisher_source())
+        self.test_account.set_password('correct-password')
+        self.test_account.save(blocking=True)
+
+    def tearDown(self):
+        self.app_client.get('/account/logout', follow_redirects=True)
+        super().tearDown()
+
+    def test_01_correct_password_logs_in(self):
+        """ Use test client to fill the login form with correct password for all login routes"""
+        for route in LOGIN_ROUTES:
+            with self.subTest(route=route):
+                resp = self.app_client.post(route, data=dict(
+                    user=self.test_account.email, password='correct-password', action='password_login'
+                ), follow_redirects=True)
+                self.assertEqual(resp.status_code, 200)
+                self.assertIn(b'Welcome back', resp.data)
+                self.app_client.get('/account/logout', follow_redirects=True)
+
+    def test_02_incorrect_password_shows_error_not_500(self):
+        """
+        Regression test: an incorrect password used to 500 when the
+        request went via the locale-prefixed route, because the handler
+        builds a "reset your password" link with a relative
+        url_for('.forgot'), and the blueprint's url_value_preprocessor
+        stripped 'lang' from request.view_args before that call runs - so
+        Flask has no value to fill in for the 'lang' that the
+        locale_account.forgot rule requires, and url_for raises a
+        werkzeug BuildError.
+        """
+        for route in LOGIN_ROUTES:
+            with self.subTest(route=route):
+                resp = self.app_client.post(route, data=dict(
+                    user=self.test_account.email, password='wrong-password', action='password_login'
+                ), follow_redirects=True)
+                self.assertEqual(resp.status_code, 200)
+                self.assertIn(b'password you entered is incorrect', resp.data)
+
+    def test_03_unrecognised_account(self):
+        """ Check the message reaches the frontend when the account isn't found"""
+        for route in LOGIN_ROUTES:
+            with self.subTest(route=route):
+                resp = self.app_client.post(route, data=dict(
+                    user='doesnotexist@example.com', password='whatever', action='password_login'
+                ), follow_redirects=True)
+                self.assertEqual(resp.status_code, 200)
+                self.assertIn(b'Account not recognised', resp.data)
+
+    @patch('portality.bll.services.account.AccountService.send_login_code_email')
+    def test_04_passwordless_request_link(self, mock_send_email):
+        """
+        Each login route needs its own account/email: the passwordless resend
+        backoff (PWLESS_RESEND_MIN_INTERVAL) would otherwise block the
+        2nd and 3rd requests for the same email fired straight after
+        the first, which has nothing to do with what's under test here.
+        """
+        #
+        for i, route in enumerate(LOGIN_ROUTES):
+            with self.subTest(route=route):
+                mock_send_email.reset_mock()
+                email = f'pwless{i}@example.com'
+                account = Account.make_account(
+                    username=f'pwlessuser{i}', name='Passwordless User', email=email, roles=['user']
+                )
+                account.set_password('correct-password')
+                account.save()
+                account.refresh()
+
+                resp = self.app_client.post(route, data=dict(
+                    user=email, action='get_link'
+                ), follow_redirects=True)
+                self.assertEqual(resp.status_code, 200)
+                mock_send_email.assert_called_once()

--- a/portality/bll/services/account.py
+++ b/portality/bll/services/account.py
@@ -34,7 +34,7 @@ class AccountService:
         user.save()
         return code
 
-    def send_login_code_email(self, user: Account, code: str, redirected: Optional[str] = "") -> None:
+    def send_login_code_email(self, user: Account, code: str, redirected: Optional[str] = "") -> Optional[str]:
         """Compose and send the passwordless login email with code and a direct link.
         """
         if user is None or not user.email:
@@ -64,6 +64,8 @@ class AccountService:
             login_url=login_url,
             expiry_minutes=10
         )
+
+        return login_url
 
     def verify_password_login(self, user: Account, password: Optional[str]) -> Account:
         """

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -298,7 +298,15 @@ PASSWORD_RESET_TIMEOUT = 86400
 PASSWORD_CREATE_TIMEOUT = PASSWORD_RESET_TIMEOUT * 14
 # amount of time a login through login-link is valid for
 LOGIN_LINK_TIMEOUT = 600
-# Encryption key for passwordless login
+# Encryption key for passwordless login. Must be 32 url-safe
+# base64-encoded bytes, e.g. generated with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# The placeholder below is not a valid key - set a real one as a secret
+# in your overriding app.cfg or dev.cfg, or requesting a passwordless
+# login link will fail with
+# "Fernet key must be 32 url-safe base64-encoded bytes."
+# (password-reset emails use a separate uuid-based reset token and are
+# unaffected by this setting)
 PASSWORDLESS_ENCRYPTION_KEY = "Passwordless login encryption key"
 
 # "api" top-level role is added to all accounts on creation; it can be revoked per account by removal of the role.

--- a/portality/templates-v2/_account/includes/_login_form.html
+++ b/portality/templates-v2/_account/includes/_login_form.html
@@ -19,7 +19,7 @@
             {{ render_field(form.password, placeholder="********") }}
         </div>
 
-        <button id="password-btn" type="submit" class="button button--primary"
+        <button id="password-btn" type="submit" class="button button--primary" disabled
                 onclick="document.getElementById('action').value='password_login'">
             Log in with password
         </button>

--- a/portality/templates-v2/_account/includes/_login_form.html
+++ b/portality/templates-v2/_account/includes/_login_form.html
@@ -1,25 +1,31 @@
 {% from "includes/_formhelpers.html" import render_field %}
 
+{# A failed password attempt re-renders this form with the error attached
+   to form.password.errors. If present, render in password mode. Otherwise toggle is in JS #}
+{% set pw_mode = form.password.errors %}
+
 <form method="post" action="" class="form-login">
     <div class="form__question form-login__question">
         {{ render_field(form.user, placeholder="email@example.com") }}
     </div>
 
     <button id="login-link-btn" type="submit" class="button button--primary"
+            {% if pw_mode %}style="display: none;" disabled{% endif %}
             onclick="document.getElementById('action').value='get_link'">
         Send me a login link
     </button>
 
-    <div id="toggle-to-password" class="form__question">
+    <div id="toggle-to-password" class="form__question" {% if pw_mode %}style="display: none;"{% endif %}>
         <a href="#" id="show-password">Prefer to use a password?</a>
     </div>
 
-    <div id="password-section" style="display: none;">
+    <div id="password-section" {% if not pw_mode %}style="display: none;"{% endif %}>
         <div class="form__question form-login__question">
             {{ render_field(form.password, placeholder="********") }}
         </div>
 
-        <button id="password-btn" type="submit" class="button button--primary" disabled
+        <button id="password-btn" type="submit" class="button button--primary"
+                {% if not pw_mode %}disabled{% endif %}
                 onclick="document.getElementById('action').value='password_login'">
             Log in with password
         </button>

--- a/portality/templates-v2/_account/includes/_login_form_js.html
+++ b/portality/templates-v2/_account/includes/_login_form_js.html
@@ -3,16 +3,39 @@
         $('#show-password').on('click', function (e) {
             e.preventDefault();
             $('#password-section').slideDown();
-            $('#login-link-btn').hide();
+            // disabled (not just hidden) so a hidden login-link-btn isn't
+            // reachable by keyboard/assistive tech while it's out of view
+            $('#login-link-btn').hide().prop('disabled', true);
             $('#toggle-to-password').hide();
+            $('#password-btn').prop('disabled', false);
         });
 
         $('#show-login-link').on('click', function (e) {
             e.preventDefault();
             $('#password-section').slideUp();
-            $('#login-link-btn').show();
+            $('#login-link-btn').show().prop('disabled', false);
             $('#toggle-to-password').show();
             $('#password-section input[type="password"]').val('');
+            $('#password-btn').prop('disabled', true);
+        });
+
+        // The form always has two submit buttons in the DOM. A browser's
+        // native implicit (Enter-key) submission targets the *first*
+        // submit button in DOM order regardless of which is currently
+        // visible/enabled - disabling the other one doesn't change that,
+        // it just means implicit submission silently does nothing once
+        // that first button is disabled. So Enter is handled explicitly
+        // here instead: click whichever button is currently visible.
+        $('.form-login').on('keydown', function (e) {
+            if (e.key !== 'Enter') {
+                return;
+            }
+            e.preventDefault();
+            if ($('#password-section').is(':visible')) {
+                document.getElementById('password-btn').click();
+            } else {
+                document.getElementById('login-link-btn').click();
+            }
         });
     });
 </script>

--- a/portality/templates-v2/_account/includes/_login_form_js.html
+++ b/portality/templates-v2/_account/includes/_login_form_js.html
@@ -1,0 +1,18 @@
+<script type="text/javascript">
+    $(document).ready(function() {
+        $('#show-password').on('click', function (e) {
+            e.preventDefault();
+            $('#password-section').slideDown();
+            $('#login-link-btn').hide();
+            $('#toggle-to-password').hide();
+        });
+
+        $('#show-login-link').on('click', function (e) {
+            e.preventDefault();
+            $('#password-section').slideUp();
+            $('#login-link-btn').show();
+            $('#toggle-to-password').show();
+            $('#password-section input[type="password"]').val('');
+        });
+    });
+</script>

--- a/portality/templates-v2/public/account/login.html
+++ b/portality/templates-v2/public/account/login.html
@@ -22,24 +22,5 @@
 {% endblock %}
 
 {% block public_js %}
-<script type="text/javascript">
-    $(document).ready(function() {
-        console.log("it's me")
-        $('#show-password').on('click', function (e) {
-            e.preventDefault();
-            console.log("click")
-            $('#password-section').slideDown();
-            $('#login-link-btn').hide();
-            $('#toggle-to-password').hide();
-        });
-
-        $('#show-login-link').on('click', function (e) {
-            e.preventDefault();
-            $('#password-section').slideUp();
-            $('#login-link-btn').show();
-            $('#toggle-to-password').show();
-            $('#password-section input[type="password"]').val('');
-        });
-    });
-</script>
+    {% include "_account/includes/_login_form_js.html" %}
 {% endblock %}

--- a/portality/templates-v2/public/account/login_to_apply.html
+++ b/portality/templates-v2/public/account/login_to_apply.html
@@ -58,3 +58,7 @@
       </div>
     </div>
 {% endblock %}
+
+{% block public_js %}
+    {% include "_account/includes/_login_form_js.html" %}
+{% endblock %}

--- a/portality/view/account.py
+++ b/portality/view/account.py
@@ -1,6 +1,6 @@
 import uuid, json
 
-from flask import Blueprint, request, url_for, flash, redirect, make_response
+from flask import Blueprint, request, url_for, flash, redirect, make_response, g, current_app
 from flask import render_template, abort
 from flask_login import login_user, logout_user, current_user, login_required
 from wtforms import StringField, HiddenField, PasswordField, DecimalField, validators, Form
@@ -21,9 +21,19 @@ blueprint = Blueprint('account', __name__)
 
 @blueprint.url_value_preprocessor
 def pull_lang(endpoint, values):
-    # Remove 'lang' so it is not passed to the view function
+    # Remove 'lang' so it is not passed to the view function, but keep it
+    # around so url_for can still fill it in when building urls for
+    # endpoints (eg .forgot) that require it, since it's otherwise lost
+    # from request.view_args once popped below.
     if values:
         lang = values.pop('lang', None)
+        if lang:
+            g.lang = lang
+
+@blueprint.url_defaults
+def add_lang(endpoint, values):
+    if 'lang' not in values and current_app.url_map.is_endpoint_expecting(endpoint, 'lang'):
+        values['lang'] = g.get('lang')
 
 @blueprint.route('/')
 @login_required

--- a/portality/view/account.py
+++ b/portality/view/account.py
@@ -248,8 +248,11 @@ def _handle_pwless_login(user, form, redirected: str = ""):
     try:
         svc = DOAJ.accountService()
         code = svc.initiate_login_code(user)
-        svc.send_login_code_email(user, code, redirected or "")
+        login_url = svc.send_login_code_email(user, code, redirected or "")
         Messages.flash(Messages.ACCOUNT__PWLESS__EMAIL_SENT)
+
+        if app.config.get('DEBUG', False):
+            util.flash_with_url('Debug mode - url for login link is <a href={0}>{0}</a>'.format(login_url))
     except bll_exc.ArgumentException:
         Messages.flash(Messages.ACCOUNT__PWLESS__EMAIL_ERROR)
 


### PR DESCRIPTION
Issues: 
* https://github.com/DOAJ/doajPM/issues/4394
* https://github.com/DOAJ/doajPM/issues/4395
* https://github.com/DOAJ/doajPM/issues/4396

---

# Login bugfixes

This fixes behaviour of the login form:

* refactor inline JS to hide / show password field as an include blob, and utilise it in the login_to_apply template as well as login, to fix https://github.com/DOAJ/doajPM/issues/4394
* disable the unused submit button when password / passwordless is toggled, to fix https://github.com/DOAJ/doajPM/issues/4395
* don't fully discard the `lang` parameter - preserve when expected by next route - to fix https://github.com/DOAJ/doajPM/issues/4396

I've added new selenium tests for this behaviour, but due to an error with other CI unit tests I haven't seen them passing in CI yet, only locally.

This PR...
- [ ] has scripts to run
- [ ] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [x] affects the public site
- [x] affects the editorial area
- [x] affects the publisher area
- [ ] affects the monitoring

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [x] Code meets acceptance criteria from issue
* [x] Unit tests are written and all pass
* [x] User Test Scripts (if required) are written and have been run through
* [x] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [x] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [ ] Migation has been created and tested
* [x] There is a recent merge from `develop`

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section should be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [ ] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [ ] Migation has been created and tested
* [ ] There is a recent merge from `develop`

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run by reviewers*

Login tests

### Configuration changes

Supplies documentation for settings passwordless login hash in `dev.cfg`, which otherwise doesn't work. I've pushed a secret for
`app.cfg` on test servers.

### Continuous Integration

Selenium tests run after unit on CI; the unit tests must pass for us to see the effect.
