### PR TITLE
search journal by alternative title

### DIFF
--- a/doajtest/testbook/public_site/public_search.yml
+++ b/doajtest/testbook/public_site/public_search.yml
@@ -188,6 +188,25 @@ tests:
   - step: Click on 'Export RIS' of any article
     results:
       - A RIS file is downloaded
+- title: 'Test Public Search by Alternative Title: Journals'
+  context:
+    role: anonymous
+  steps:
+  - step: Make sure there is a Journal in DOAJ which has an alternative title.
+      For example, a journal with Arabic main title and English alternative title such as "Journal of Science and Knowledge Horizons"
+  - step: Go to the DOAJ journal search page at /search/journals
+  - step: Search for the journal using its alternative title (e.g. "Journal of Science and Knowledge Horizons")
+    results:
+    - The journal appears in the search results
+  - step: Search for the journal using a partial match of the alternative title (e.g. "Knowledge Horizons")
+    results:
+    - The journal appears in the search results
+  - step: Search for the journal using its main title (e.g. the Arabic title)
+    results:
+    - The journal appears in the search results
+  - step: Verify that "Alternative title" is not listed as a selectable field in the "search all" dropdown
+    results:
+    - The alternative title is only searchable via the general search bar, not as a separate field option
 - title: 'Test Public Search Ascii Folding: Articles/Journals'
   context:
     role: anonymous

--- a/doajtest/unit/test_query.py
+++ b/doajtest/unit/test_query.py
@@ -746,6 +746,38 @@ class TestQuery(DoajTestCase):
 
         assert res['hits']['total']["value"] == 1, res['hits']['total']["value"]
 
+    def test_public_journal_search_by_alternative_title(self):
+        """public journal search must find journals by alternative title"""
+        self.app_test.config['QUERY_ROUTE'] = SEARCH_ALL_QUERY_ROUTE
+        self.journal = models.Journal(**JournalFixtureFactory
+                                      .make_journal_with_data(title="مجلة آفاق العلم والمعرفة",
+                                                              alternative_title="Journal of Science and Knowledge Horizons"))
+        self.journal.save(blocking=True)
+        qsvc = QueryService()
+
+        # verify journal exists
+        res = qsvc.search('query', 'journal', MATCH_ALL_RAW_QUERY, account=None,
+                          additional_parameters={})
+        assert res['hits']['total']["value"] == 1, res['hits']['total']["value"]
+
+        # search by main title via all_meta (public search)
+        res = qsvc.search('query', 'journal', raw_query("آفاق العلم"),
+                          account=None, additional_parameters={})
+        assert res['hits']['total']["value"] == 1, \
+            "Public search by main title should return result, got: {}".format(res['hits']['total']["value"])
+
+        # search by alternative title via all_meta (public search) - this was the bug
+        res = qsvc.search('query', 'journal', raw_query("Science Knowledge Horizons"),
+                          account=None, additional_parameters={})
+        assert res['hits']['total']["value"] == 1, \
+            "Public search by alternative title should return result, got: {}".format(res['hits']['total']["value"])
+
+        # search by partial alternative title
+        res = qsvc.search('query', 'journal', raw_query("Knowledge Horizons"),
+                          account=None, additional_parameters={})
+        assert res['hits']['total']["value"] == 1, \
+            "Public search by partial alternative title should return result, got: {}".format(res['hits']['total']["value"])
+
     def test_application_query_ascii_folding_data(self):
         acc = models.Account(**AccountFixtureFactory.make_managing_editor_source())
         application = models.Application(**ApplicationFixtureFactory

--- a/portality/migrate/4288_search_journals_by_alternative_title/README.md
+++ b/portality/migrate/4288_search_journals_by_alternative_title/README.md
@@ -1,0 +1,9 @@
+# 19 08 2026; Issue 4288 - Search for journals by alternative title
+
+## Execution
+
+Update the right version in migrate.json file
+
+Run the migration with
+
+    python portality/scripts/es_reindex.py portality/migrate/4288_search_journals_by_alternative_title/migrate.json

--- a/portality/migrate/4288_search_journals_by_alternative_title/migrate.json
+++ b/portality/migrate/4288_search_journals_by_alternative_title/migrate.json
@@ -1,0 +1,16 @@
+{
+	"new_version": "-20260819",
+	"old_version": "-20260119",
+	"types": [
+		{
+			"type" : "article",
+			"migrate": true,
+			"set_alias": true
+		},
+		{
+			"type": "journal",
+			"migrate": true,
+			"set_alias": true
+		}
+	]
+}

--- a/portality/migrate/4288_search_journals_by_alternative_title/migrate.json
+++ b/portality/migrate/4288_search_journals_by_alternative_title/migrate.json
@@ -1,6 +1,6 @@
 {
-	"new_version": "-20260819",
-	"old_version": "-20260119",
+	"new_version": "-20260819_search_alternative_title",
+	"old_version": "-20250822_ascii_folding",
 	"types": [
 		{
 			"type" : "article",

--- a/portality/settings.py
+++ b/portality/settings.py
@@ -1067,21 +1067,22 @@ ADMIN_NOTES_SEARCH_MAPPING = {
 }
 
 ASCII_FOLDED = {"analyzer": "ascii_folded", "search_analyzer": "ascii_folded"}
+ASCII_FOLDED_ALL_META = {**ASCII_FOLDED, "copy_to": ["all_meta"]}
 
 JOURNAL_EXCEPTION_MAPPING = {
-    "bibjson.title" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED},
-    "bibjson.alternative_title" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED},
-    "bibjson.publisher.name" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED},
-    "index.country" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED},
-    "index.title": {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED}
+    "bibjson.title" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED_ALL_META},
+    "bibjson.alternative_title" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED_ALL_META},
+    "bibjson.publisher.name" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED_ALL_META},
+    "index.country" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED_ALL_META},
+    "index.title": {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED_ALL_META}
 }
 
 ARTICLE_EXCEPTION_MAPPING = {
-    "bibjson.abstract" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED},
-    "bibjson.author.name" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED},
-    "bibjson.journal.publisher": {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED},
-    "index.country": {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED},
-    "bibjson.title": {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED}
+    "bibjson.abstract" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED_ALL_META},
+    "bibjson.author.name" : {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED_ALL_META},
+    "bibjson.journal.publisher": {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED_ALL_META},
+    "index.country": {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED_ALL_META},
+    "bibjson.title": {**DATAOBJ_TO_MAPPING_DEFAULTS["unicode"], **ASCII_FOLDED_ALL_META}
 }
 
 ####################################################


### PR DESCRIPTION
* Issue: https://github.com/DOAJ/doajPM/issues/4288

---

# Search by alternative title should work

*Public search by alternative title for Journals is not working.
When we added ASCII_FOLDED feature, we missed to add the String to `all_meta`. General search usually search in all_meta. This has been added now.
I have tested on my local and it seems to be working.

There is a migration script that need be executed. Please check the versions   
*

This PR...
- [ ] has scripts to run
- [x] has migrations to run
- [ ] adds new infrastructure
- [ ] changes the CI pipeline
- [x] affects the public site
- [ ] affects the editorial area
- [ ] affects the publisher area
- [ ] affects the monitoring

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [x] Code meets acceptance criteria from issue
* [x] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [x] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [x] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [x] Migation has been created and tested
* [x] There is a recent merge from `develop`

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section should be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Project's coding standards are met
    - No deprecated methods are used
    - No magic strings/numbers - all strings are in `constants` or `messages` files
    - ES queries are wrapped in a Query object rather than inlined in the code
    - Where possible our common library functions have been used (e.g. dates manipulated via `dates`)
    - Cleaned up commented out code, etc
    - Urls are constructed with `url_for` not hard-coded
* [ ] Code documentation and related non-code documentation has all been updated
    - Core model documentation has been added to if needed: https://docs.google.com/spreadsheets/d/1lun2S9vwGbyfy3WjIjgXBm05D-3wWDZ4bp8xiIYfImM/edit
    - Events and consumers documentation has been added if needed: https://docs.google.com/spreadsheets/d/1oIeG5vg-blm2MZCE-7YhwulUlSz6TOUeY8jAftdP9JE/edit
* [ ] Migation has been created and tested
* [ ] There is a recent merge from `develop`

## Testing

*https://doaj.github.io/doaj-docs/feature/4288_search_journals_by_alternative_title/testbook/index.html#public_site/public_search/test_public_search_by_alternative_title_journals*

## Deployment

Migration script need to be run.

### Migrations

Update the right version in portality/migrate/4288_search_journals_by_alternative_title/migrate.json file

Run the migration:

    `python portality/scripts/es_reindex.py portality/migrate/4288_search_journals_by_alternative_title/migrate.json`

